### PR TITLE
Archive test run logs and reports in AWS S3

### DIFF
--- a/jenkins-pipelines/Jenkinsfile
+++ b/jenkins-pipelines/Jenkinsfile
@@ -98,14 +98,20 @@ pipeline {
             --groupBy deployment \
             """
 
-           publishHTML([
-           allowMissing: false,
-           alwaysLinkToLastBuild: true,
-           keepAll: true,
-           reportDir: "${TESTGRID_HOME}",
-           reportFiles: '*.html',
-           reportName: 'HTML Report',
-           reportTitles: ''])
+            // Archive artifacts
+            withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+              // Upload artifacts to S3
+              s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.log, **/*.html", bucket:"jenkins-testrun-artifacts", path:"artifacts/")
+            }
+
+            publishHTML([
+            allowMissing: false,
+            alwaysLinkToLastBuild: true,
+            keepAll: true,
+            reportDir: "${TESTGRID_HOME}",
+            reportFiles: '*.html',
+            reportName: 'HTML Report',
+            reportTitles: ''])
        }
    }
 }


### PR DESCRIPTION
## Purpose
Archive test run reports and logs in AWS S3 for traceability.

Resolves #302

## Release note
* Archive test run logs and reports in AWS S3

## Marketing
Test run reports and logs need to be archived in the cloud. The archived reports and logs will be against for each deployment pattern and infrastruncture combination. This would help to trace test failures for any deployment pattern and infrastructure combination for any given time.

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes