### PR TITLE
Fix RollingFileAppender missing date pattern error

### DIFF
--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -23,14 +23,14 @@
             <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
         </Console>
         <RollingFile name="AUDIT_LOGFILE" fileName="${env:TESTGRID_HOME}/audit.log"
-                     filePattern="${env:TESTGRID_HOME}/audit.log">
+                     filePattern="${env:TESTGRID_HOME}/audit-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
         <RollingFile name="ERROR_LOGFILE" fileName="${env:TESTGRID_HOME}/errors.log"
-                     filePattern="${env:TESTGRID_HOME}/errors.log">
+                     filePattern="${env:TESTGRID_HOME}/errors-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
@@ -41,7 +41,7 @@
             <Routes pattern="$${path:key2}">
                 <Route>
                     <RollingFile name="SCENARIO_LOGFILE" fileName="${env:TESTGRID_HOME}/${path:key2}"
-                                 filePattern="${env:TESTGRID_HOME}/${path:key2}">
+                                 filePattern="${env:TESTGRID_HOME}/${path:key2}-%d{MM-dd-yyyy}">
                         <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n" />
                         <Policies>
                             <SizeBasedTriggeringPolicy size="50 MB" />


### PR DESCRIPTION
## Purpose
Add date pattern to rolling files in log4j.xml
Resolves #380

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes