### PR TITLE
Remove test run logs and reports from Jenkins after archiving 

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -45,8 +45,6 @@ import org.wso2.testgrid.dao.uow.DeploymentPatternUOW;
 import org.wso2.testgrid.dao.uow.ProductUOW;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
-import org.wso2.testgrid.reporting.ReportingException;
-import org.wso2.testgrid.reporting.TestReportEngine;
 
 import java.io.File;
 import java.io.IOException;
@@ -134,14 +132,8 @@ public class RunTestPlanCommand implements Command {
 
             // Execute test plan
             executeTestPlan(testPlan, infrastructure);
-
-            // Generate report for the test plan
-            TestReportEngine testReportEngine = new TestReportEngine();
-            testReportEngine.generateReport(testPlan);
         } catch (IOException e) {
             throw new CommandExecutionException("Error in reading file generated config file", e);
-        } catch (ReportingException e) {
-            throw new CommandExecutionException("Error in generating report for the test plan.", e);
         } catch (TestGridLoggingException e) {
             throw new CommandExecutionException("Error in deriving log file path.", e);
         }

--- a/jenkins-pipelines/Jenkinsfile
+++ b/jenkins-pipelines/Jenkinsfile
@@ -102,14 +102,10 @@ pipeline {
               s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.log, **/*.html", bucket:"jenkins-testrun-artifacts", path:"artifacts/")
             }
 
-            publishHTML([
-            allowMissing: false,
-            alwaysLinkToLastBuild: true,
-            keepAll: true,
-            reportDir: "${TESTGRID_HOME}",
-            reportFiles: '*.html',
-            reportName: 'HTML Report',
-            reportTitles: ''])
+            // Delete logs and reports after upload
+            dir("${TESTGRID_HOME}/${PRODUCT}") {
+                deleteDir()
+            }
        }
    }
 }

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -24,7 +24,6 @@ import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
-import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.reporting.model.GroupBy;
@@ -68,50 +67,6 @@ public class TestReportEngine {
     private static final String HTML_EXTENSION = ".html";
 
     /**
-     * Generates a test report for the given test plan.
-     * <p>
-     * This report will be grouped by the test scenario since the report is generated to a single deployment and
-     * infrastructure
-     *
-     * @param testPlan test plan to generate the report for
-     * @throws ReportingException thrown when error on generating test report
-     */
-    public void generateReport(TestPlan testPlan) throws ReportingException {
-        try {
-            AxisColumn uniqueAxisColumn = AxisColumn.SCENARIO;
-            DeploymentPattern deploymentPattern = testPlan.getDeploymentPattern();
-            Product product = deploymentPattern.getProduct();
-
-            // Construct report elements
-            List<ReportElement> reportElements = Collections
-                    .unmodifiableList(createReportElementsForTestPlan(testPlan, deploymentPattern, uniqueAxisColumn));
-
-            // Break elements by group by (sorting also handled)
-            List<GroupBy> groupByList = groupReportElementsBy(uniqueAxisColumn, reportElements, false);
-
-            // Create per axis summaries
-            List<PerAxisHeader> perAxisHeaders = createPerAxisHeaders(uniqueAxisColumn, reportElements, false);
-
-            // Generate HTML string
-            Report report = new Report(false, product, groupByList, perAxisHeaders);
-            Map<String, Object> parsedResultMap = new HashMap<>();
-            parsedResultMap.put(REPORT_TEMPLATE_KEY, report);
-            Renderable renderable = RenderableFactory.getRenderable(REPORT_MUSTACHE);
-            String htmlString = renderable.render(REPORT_MUSTACHE, parsedResultMap);
-
-            // Write to HTML file
-            String testRunArtifactsDir = TestGridUtil.getTestRunArtifactsDirectory(testPlan).toString();
-            String fileName = StringUtil.concatStrings("Report", HTML_EXTENSION);
-            String testGridHome = TestGridUtil.getTestGridHomePath();
-            Path reportPath = Paths.get(testGridHome).resolve(testRunArtifactsDir).resolve(fileName);
-            writeHTMLToFile(reportPath, htmlString);
-        } catch (TestGridException e) {
-            throw new ReportingException("Logs related to test report generation will not be created since an error " +
-                                         "occurred in deriving log file path.", e);
-        }
-    }
-
-    /**
      * Generates a test report based on the given product name and product version.
      *
      * @param product     product to generate the report
@@ -144,7 +99,7 @@ public class TestReportEngine {
                 .concatStrings(product.getName(), "-", product.getCreatedTimestamp(), "-", uniqueAxisColumn,
                         HTML_EXTENSION);
         String testGridHome = TestGridUtil.getTestGridHomePath();
-        Path reportPath = Paths.get(testGridHome).resolve(fileName);
+        Path reportPath = Paths.get(testGridHome).resolve(product.getName()).resolve(fileName);
         writeHTMLToFile(reportPath, htmlString);
     }
 


### PR DESCRIPTION
## Purpose
* Delete log and report files via the Jenkins pipeline script
* Test report generation for each test plan removed 
* Test report for the product will be stored in the directory for the relevant product
Resolves #377 

## Release note
* Remove test run logs and reports from Jenkins after archiving 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes