### PR TITLE
TESTGRID_HOME should default to ~/.testgrid if the env variable is not found

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.testgrid.common;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * Class to maintain constants across modules.
  *
@@ -26,4 +29,6 @@ public class TestGridConstants {
 
     // Logging constants
     public static final String TEST_LOG_FILE_NAME = "test-run.log";
+
+    public static final Path DEFAULT_TESTGRID_HOME = Paths.get(System.getProperty("user.home"), ".testgrid");
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -38,12 +38,15 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+
+import static org.wso2.testgrid.common.TestGridConstants.DEFAULT_TESTGRID_HOME;
 
 /**
  * This Util class holds the common utility methods.
@@ -156,10 +159,22 @@ public final class TestGridUtil {
      *
      * @return test grid home path
      */
-    public static String getTestGridHomePath() {
+    public static String getTestGridHomePath() throws IOException {
         String testGridHome = EnvironmentUtil.getSystemVariableValue(TESTGRID_HOME_ENV);
-        Path testGridHomePath = Paths.get(testGridHome);
-        return testGridHomePath.toAbsolutePath().toString();
+        Path testGridHomePath;
+        if (testGridHome == null) {
+            logger.warn("TESTGRID_HOME environment variable not set. Defaulting to ~/.testgrid.");
+            testGridHomePath = DEFAULT_TESTGRID_HOME;
+        } else {
+            testGridHomePath = Paths.get(testGridHome);
+        }
+
+        testGridHomePath = testGridHomePath.toAbsolutePath();
+        if (!Files.exists(testGridHomePath)) {
+            Files.createDirectories(testGridHomePath.toAbsolutePath());
+        }
+
+        return testGridHomePath.toString();
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/Main.java
+++ b/core/src/main/java/org/wso2/testgrid/core/Main.java
@@ -23,8 +23,6 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
-import org.wso2.testgrid.common.util.StringUtil;
-import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.core.command.CommandHandler;
 
 /**
@@ -43,15 +41,11 @@ public class Main {
             CmdLineParser parser = new CmdLineParser(commandHandler);
             parser.parseArgument(args);
 
-            // Validate test grid home
-            String testGridHome = TestGridUtil.getTestGridHomePath();
-            if (!StringUtil.isStringNullOrEmpty(testGridHome)) {
-                commandHandler.execute();
-            }
+            commandHandler.execute();
         } catch (CmdLineException e) {
-            logger.error("Error in parsing command line arguments.", e);
+            logger.error("Error while parsing command line arguments.", e);
         } catch (CommandExecutionException e) {
-            logger.error("Error in executing command.", e);
+            logger.error("Error while executing command.", e);
         }
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -200,7 +200,7 @@ public class RunTestPlanCommand implements Command {
      * @param product product to locate the file path of an generated test plan YAML file
      * @return file path of an generated test plan YAML file
      */
-    private Optional<String> getTestPlanGenFilePath(Product product) {
+    private Optional<String> getTestPlanGenFilePath(Product product) throws IOException {
         Path directory = getTestPlanGenLocation(product);
 
         // Get a infra file from directory
@@ -217,7 +217,7 @@ public class RunTestPlanCommand implements Command {
      * @param product product for location directory
      * @return path for the generated test plan YAML files directory
      */
-    private Path getTestPlanGenLocation(Product product) {
+    private Path getTestPlanGenLocation(Product product) throws IOException {
         String directoryName = product.getId();
         String testGridHome = TestGridUtil.getTestGridHomePath();
         return Paths.get(testGridHome, directoryName).toAbsolutePath();

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -35,6 +35,7 @@ import org.wso2.testgrid.reporting.renderer.Renderable;
 import org.wso2.testgrid.reporting.renderer.RenderableFactory;
 import org.wso2.testgrid.reporting.util.FileUtil;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -98,9 +99,13 @@ public class TestReportEngine {
         String fileName = StringUtil
                 .concatStrings(product.getName(), "-", product.getCreatedTimestamp(), "-", uniqueAxisColumn,
                         HTML_EXTENSION);
-        String testGridHome = TestGridUtil.getTestGridHomePath();
-        Path reportPath = Paths.get(testGridHome).resolve(product.getName()).resolve(fileName);
-        writeHTMLToFile(reportPath, htmlString);
+        try {
+            String testGridHome = TestGridUtil.getTestGridHomePath();
+            Path reportPath = Paths.get(testGridHome).resolve(product.getName()).resolve(fileName);
+            writeHTMLToFile(reportPath, htmlString);
+        } catch (IOException e) {
+            throw new ReportingException("Error while persisting HTML report at " + fileName, e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
We shouldn't just fail if the TESTGRID_HOME env var is not found. Instead, we should default to an appropriate location such as ~/.testgrid.

Resolves #393

## Goals
Better user experience

## Approach
Defaults to ~/.testgrid

## User stories
N/A

## Release note
N/A

## Documentation
Default testgrid_home is set to ~/.testgrid.

## Training
N/A

## Certification
N/A

## Marketing
N/A
## Automation tests
N/A
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
