### PR TITLE
Change dashboard base URL

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -190,7 +190,7 @@
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <warName>testgrid#v${version}</warName>
+                    <warName>testgrid#dashboard##v${version}</warName>
                 </configuration>
             </plugin>
         </plugins>

--- a/web/src/main/react-dashboard/package.json
+++ b/web/src/main/react-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "testgrid-dashboard",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/testgrid/v0.9/",
+  "homepage": "/testgrid/dashboard",
   "dependencies": {
     "downloadjs": "^1.4.7",
     "material-ui": "^0.20.0",

--- a/web/src/main/react-dashboard/src/App.js
+++ b/web/src/main/react-dashboard/src/App.js
@@ -62,6 +62,7 @@ class App extends Component {
 
   constructor(props) {
     super(props);
+    this.baseURL = "/testgrid/dashboard"
     this.state = {
       open: true,
       navWidth: 240
@@ -84,12 +85,12 @@ class App extends Component {
               </Drawer>
               <Paper style={paperStyle} zDepth={2}>
                 <Switch>
-                  <Route exact path='/testgrid/v0.9/' component={ProductContainer} />
-                  <Route exact path='/testgrid/v0.9/deployments/product/:productId/' component={DeploymentContainer} />
-                  <Route exact path='/testgrid/v0.9/infrastructures/deployment/:deploymentid/' component={InfrastructureContainer} />
-                  <Route exact path='/testgrid/v0.9/scenarios/infrastructure/:infraid' component={ScenarioContainer} />
-                  <Route exact path='/testgrid/v0.9/testcases/scenario/:scenarioid' component={TestCaseContainer} />
-                  <Route exact path='/testgrid/v0.9/testplans/:testplanid' component={testRunContainer}/>
+                  <Route exact path = {this.baseURL + '/'} component={ProductContainer} />
+                  <Route exact path = {this.baseURL + '/deployments/product/:productId/'} component={DeploymentContainer} />
+                  <Route exact path = {this.baseURL + '/infrastructures/deployment/:deploymentid/'} component={InfrastructureContainer} />
+                  <Route exact path = {this.baseURL + '/scenarios/infrastructure/:infraid'} component={ScenarioContainer} />
+                  <Route exact path = {this.baseURL + '/testcases/scenario/:scenarioid'} component={TestCaseContainer} />
+                  <Route exact path = {this.baseURL + '/testplans/:testplanid'} component={testRunContainer}/>
                 </Switch>
               </ Paper>
             </div>

--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -37,7 +37,7 @@ class DeploymentPatternView extends Component {
 
   constructor(props) {
     super(props)
-    this.baseURL = "/testgrid/v0.9";
+    this.baseURL = "/testgrid/dashboard";
     this.state = {
       hits: []
     };
@@ -97,7 +97,7 @@ class DeploymentPatternView extends Component {
                         <TableRowColumn style={{ whiteSpace: 'normal', wordWrap: 'break-word' }}>{value.lastBuild.infraParams}</TableRowColumn>
                         <TableRowColumn>
                           <FlatButton style={{ color: '#0E457C' }}
-                            onClick={() => this.navigateToRoute( this.baseUR + "/testplans/" + value.lastBuild.id, {
+                            onClick={() => this.navigateToRoute( this.baseURL + "/testplans/" + value.lastBuild.id, {
                               deploymentPatternName: key
                             }, {
                                 testPlanId: value.lastBuild.id,

--- a/web/src/main/react-dashboard/src/components/InfraCombinationView.js
+++ b/web/src/main/react-dashboard/src/components/InfraCombinationView.js
@@ -36,6 +36,7 @@ class InfraCombinationView extends Component {
 
     constructor(props) {
         super(props);
+        this.baseURL = "/testgrid/dashboard" ;
         this.state = {
             hits: []
         }
@@ -47,7 +48,7 @@ class InfraCombinationView extends Component {
     }
 
     componentDidMount() {
-        var url = "/testgrid/v0.9/api/test-plans?deployment-pattern-id=" + this.props.active.reducer.currentDeployment.deploymentId + "&date=" + this.props.active.reducer.currentProduct.productDate + "&require-test-scenario-info=false";
+        var url = this.baseURL + "/api/test-plans?deployment-pattern-id=" + this.props.active.reducer.currentDeployment.deploymentId + "&date=" + this.props.active.reducer.currentProduct.productDate + "&require-test-scenario-info=false";
 
         fetch(url, {
             method: "GET",

--- a/web/src/main/react-dashboard/src/components/ProductStatusView.js
+++ b/web/src/main/react-dashboard/src/components/ProductStatusView.js
@@ -35,13 +35,14 @@ class ProductStatusView extends Component {
 
   constructor(props) {
     super(props);
+    this.baseURL = "/testgrid/dashboard"
     this.state = {
       hits: []
     };
   }
 
   componentDidMount() {
-    var url = '/testgrid/v0.9/api/products/product-status'
+    var url = this.baseURL + '/api/products/product-status'
     fetch(url, {
       method: "GET",
       headers: {
@@ -64,7 +65,7 @@ class ProductStatusView extends Component {
       return (<TableRow key={index}>
 
         <TableRowColumn> <SingleRecord value={product.status} /> </TableRowColumn>
-        <TableRowColumn ><h2 style={{ cursor: 'pointer' }} onClick={() => this.nevigateToRoute("/testgrid/v0.9/deployments/product/" + product.id, {
+        <TableRowColumn ><h2 style={{ cursor: 'pointer' }} onClick={() => this.nevigateToRoute( this.baseURL + "/deployments/product/" + product.id, {
           productId: product.id,
           productName: product.name,
         })}><i>{product.name}</i></h2></TableRowColumn>
@@ -73,7 +74,7 @@ class ProductStatusView extends Component {
             if (product.lastBuild.modifiedTimestamp) {
               return (
                 <SingleRecord value={product.lastBuild.status}
-                  nevigate={() => this.nevigateToRoute("/testgrid/v0.9/deployments/product/" + product.id, {
+                  nevigate={() => this.nevigateToRoute(this.baseURL + "/deployments/product/" + product.id, {
                     productId: product.id,
                     productName: product.name,
                   })} time={product.lastBuild.modifiedTimestamp}
@@ -87,7 +88,7 @@ class ProductStatusView extends Component {
           {(() => {
             if (product.lastfailed.modifiedTimestamp) {
               return (
-                <h4 onClick={() => this.nevigateToRoute("/testgrid/v0.9/deployments/product/" + product.id, {
+                <h4 onClick={() => this.nevigateToRoute(this.baseURL + "/deployments/product/" + product.id, {
                   productId: product.id,
                   productName: product.name,
                 })} style={{ cursor: 'pointer', textDecoration: 'underline' }} >{Moment(product.lastBuild.modifiedTimestamp).fromNow()}</h4>

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -47,6 +47,7 @@ class TestRunView extends Component {
 
   constructor(props) {
     super(props);
+    this.baseURL = "/testgrid/dashboard";
     this.state = {
       testScenarioSummaries: [],
       scenarioTestCaseEntries: [],
@@ -60,11 +61,11 @@ class TestRunView extends Component {
   }
 
   componentDidMount() {
-    const testScenarioSummaryUrl = '/testgrid/v0.9/api/test-plans/test-summary/' +
+    const testScenarioSummaryUrl = this.baseURL + '/api/test-plans/test-summary/' +
       this.props.active.reducer.currentInfra.testPlanId;
-    const logTruncatedContentUrl = '/testgrid/v0.9/api/test-plans/log/' +
+    const logTruncatedContentUrl = this.baseURL + '/api/test-plans/log/' +
       this.props.active.reducer.currentInfra.testPlanId + "?truncate=" + true;
-    const logAllContentUrl = '/testgrid/v0.9/api/test-plans/log/' +
+    const logAllContentUrl = this.baseURL + '/api/test-plans/log/' +
       this.props.active.reducer.currentInfra.testPlanId + "?truncate=" + false;
 
     fetch(testScenarioSummaryUrl, {


### PR DESCRIPTION
## Purpose
Resolves #403 

## Goals
Removed version from dashboard URL

## Approach
Use `##` notation to hide the version of war file from dashboard URL and change the 
base URL as `/testgrid/dashboard/`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> #405 