### PR TITLE
Generate infrastructure combinations via value-sets in a database.

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridError.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridError.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common;
+
+/**
+ * Represents an {@link Error} during testgrid execution.
+ */
+public class TestGridError extends Error {
+    private static final long serialVersionUID = 1241514073858897098L;
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public TestGridError() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public TestGridError(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public TestGridError(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public TestGridError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/IncompatibleInfrastructureParameterException.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/IncompatibleInfrastructureParameterException.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common.infrastructure;
+
+/**
+ * Thrown if the {@link InfrastructureValueSet}'s type does not match with the
+ * infrastructure parameter added to it.
+ */
+public class IncompatibleInfrastructureParameterException extends RuntimeException {
+
+    private static final long serialVersionUID = -6983147951783083632L;
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public IncompatibleInfrastructureParameterException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public IncompatibleInfrastructureParameterException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public IncompatibleInfrastructureParameterException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public IncompatibleInfrastructureParameterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureCombination.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureCombination.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common.infrastructure;
+
+import org.wso2.testgrid.common.TestGridError;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Reperesents an infrastructure combination against which a test-plan
+ * can be instantiated and run. This contains a set of infrastructure parameters
+ * one from each infrastructure types.
+ *
+ * @since 1.0.0
+ */
+public class InfrastructureCombination implements Cloneable {
+    private TreeSet<InfrastructureParameter> parameters = new TreeSet<>();
+
+    /**
+     * Initializes an @{@link InfrastructureCombination} object with the given
+     * set of infrastructure parameters.
+     *
+     * @param parameters a set of infrastructure parameters that have distinct types.
+     */
+    public InfrastructureCombination(Set<InfrastructureParameter> parameters) {
+        this.parameters.addAll(parameters);
+    }
+
+    /**
+     * Get the list of infrastructure parameters.
+     *
+     * @return set of infrastructure parameters.
+     */
+    public Set<InfrastructureParameter> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Add another infrastructure parameter.
+     *
+     * @param param the infrastructure parameter
+     */
+    public void addParameter(InfrastructureParameter param) {
+        parameters.add(param);
+    }
+
+    /**
+     * performs a shallow clone of this infrastructure combination.
+     *
+     * @return the cloned infrastructure combination
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public InfrastructureCombination clone() {
+        try {
+            InfrastructureCombination clone = (InfrastructureCombination) super.clone();
+            clone.parameters = (TreeSet<InfrastructureParameter>) parameters.clone();
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            throw new TestGridError("Since the super class of this object is java.lang.Object that supports cloning, "
+                    + "this failure condition should never happen unless a serious system error occurred.", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "InfrastructureCombination{\n" +
+                "parameters=" + parameters +
+                "\n}";
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common.infrastructure;
+
+import org.wso2.testgrid.common.AbstractUUIDEntity;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+/**
+ * This represents the InfrastructureParameter entity.
+ * An InfrastructureParameter provides details about a given
+ * infrastructure - name, type, and list of its properties.
+ * <p>
+ * Type is defined by the @{@link Type} enum.
+ *
+ * @since 1.0
+ */
+@Entity
+@Table(
+        name = InfrastructureParameter.INFRASTRUCTURE_PARAMETER_TABLE,
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = InfrastructureParameter.INFRASTRUCTURE_PARAMETER_NAME_COLUMN)
+        }
+)
+public class InfrastructureParameter extends AbstractUUIDEntity implements
+        Serializable, Comparable<InfrastructureParameter> {
+
+    public static final String INFRASTRUCTURE_PARAMETER_NAME_COLUMN = "name";
+
+    /**
+     * We need to replace these metamodel names by generating the JPA Metamodel for this entity.
+     * This needs to happen after merging common, dao, and core modules into one.
+     * TODO: testgrid#413
+     */
+    public static final String INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME = "type";
+    public static final String INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME = "readyForTestGrid";
+    static final String INFRASTRUCTURE_PARAMETER_TABLE = "infrastructure_parameter";
+
+    private static final long serialVersionUID = 4714791395656165784L;
+
+    @Column
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Type type;
+
+    @Column
+    private String properties;
+
+    @Column(name = "ready_for_testgrid")
+    private boolean readyForTestGrid;
+
+    public InfrastructureParameter(String name, Type type, String properties, boolean readyForTestGrid) {
+        this.name = name;
+        this.type = type;
+        this.properties = properties;
+        this.readyForTestGrid = readyForTestGrid;
+    }
+
+    public InfrastructureParameter() {
+    }
+
+    /**
+     * Name is a unique identifier for a given infrastructure.
+     *
+     * @return @{@link InfrastructureParameter} name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    /**
+     * The properties list make include information about this {@link InfrastructureParameter}.
+     * Typical properties may include the AMI_ID, RDS_ID etc.
+     *
+     * @return list of properties of this {@link InfrastructureParameter}
+     */
+    public String getProperties() {
+        return properties;
+    }
+
+    public void setProperties(String properties) {
+        this.properties = properties;
+    }
+
+    public boolean isReadyForTestGrid() {
+        return readyForTestGrid;
+    }
+
+    public void setReadyForTestGrid(boolean readyForTestGrid) {
+        this.readyForTestGrid = readyForTestGrid;
+    }
+
+    @Override
+    public String toString() {
+        return "InfrastructureParameter{" +
+                "name='" + name + '\'' +
+                ", type='" + type + '\'' +
+                ", properties='" + properties + '\'' +
+                ", readyForTestGrid=" + readyForTestGrid +
+                '}';
+    }
+
+    @Override
+    public int compareTo(InfrastructureParameter o) {
+        final int before = -1;
+        final int equal = 0;
+        final int after = 1;
+
+        int comparison = name.compareTo(o.name);
+        if (comparison != equal) {
+            return comparison;
+        }
+
+        comparison = type.compareTo(o.type);
+        if (comparison != equal) {
+            return comparison;
+        }
+
+        comparison = properties.compareTo(o.properties);
+        if (comparison != equal) {
+            return comparison;
+        }
+
+        if (!readyForTestGrid && o.readyForTestGrid) {
+            return before;
+        }
+
+        if (readyForTestGrid && !o.readyForTestGrid) {
+            return after;
+        }
+
+        return equal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        InfrastructureParameter that = (InfrastructureParameter) o;
+
+        return readyForTestGrid == that.readyForTestGrid
+                && name.equals(that.name)
+                && type == that.type
+                && (properties != null ? properties.equals(that.properties) : that.properties == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        result = 31 * result + (readyForTestGrid ? 1 : 0);
+        return result;
+    }
+
+    /**
+     * Enumeration of the possible infrastructure parameter values.
+     */
+    public enum Type {
+        OPERATING_SYSTEM("operating_system"),
+        DATABASE("database"),
+        JDK("jdk");
+
+        private final String name;
+
+        /**
+         * Sets the name of the type.
+         *
+         * @param name type name
+         */
+        Type(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+
+    }
+
+}

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureValueSet.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureValueSet.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common.infrastructure;
+
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter.Type;
+import org.wso2.testgrid.common.util.StringUtil;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Represents a set of values of a given infrastructure 'type'.
+ * A given {@link InfrastructureValueSet} belongs to a specific type.
+ *
+ * @since 1.0
+ */
+public class InfrastructureValueSet {
+    private Type type;
+    private Set<InfrastructureParameter> values = new TreeSet<>();
+
+    /**
+     * Creates an instance of {@link InfrastructureValueSet}.
+     *
+     * @param type                     the infrastructure type
+     * @param infrastructureParameters list of infrastructureParameters of the type.
+     * @throws IncompatibleInfrastructureParameterException if the parameter set contains a param with a different
+     * type.
+     */
+    public InfrastructureValueSet(Type type, Set<InfrastructureParameter> infrastructureParameters) throws
+            IncompatibleInfrastructureParameterException {
+        this.type = type;
+        Optional<InfrastructureParameter> incompatibleParam = infrastructureParameters.stream()
+                .filter(param -> !param.getType().equals(type)).findAny();
+        incompatibleParam.ifPresent(param -> {
+            throw new IncompatibleInfrastructureParameterException(
+                    StringUtil.concatStrings("The infrastructure parameter, ", param,
+                            ", is incompatible with this value-set's type: ", type.toString()));
+        });
+        this.values.addAll(infrastructureParameters);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Set<InfrastructureParameter> getValues() {
+        return values;
+    }
+
+    public void setValues(Set<InfrastructureParameter> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String toString() {
+        return "InfrastructureValueSet{" +
+                "name='" + type + '\'' +
+                ", values=\n" + values +
+                "\n}";
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/package-info.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/**
+ * This package handles the infrastructure value-sets, and
+ * takes care of generating infrastructure combinations needed
+ * for each test run.
+ *
+ * @since 1.0.0
+ */
+package org.wso2.testgrid.common.infrastructure;

--- a/core/src/main/java/org/wso2/testgrid/core/TestConfig.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestConfig.java
@@ -24,8 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This class is used to retrieve test configuration values given by the user.
- *
+ * This class is used to retrieve test plan for a given test run.
  * @since 1.0.0
  */
 public class TestConfig {

--- a/core/src/main/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProvider.java
+++ b/core/src/main/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.infrastructure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.infrastructure.InfrastructureCombination;
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.InfrastructureParameterUOW;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * This class provides list of infrastructure combinations. Scenario tests
+ * will be run against each of these infrastructure combinations.
+ * <p>
+ * The infrastructure combinations are generated from a set of @{@link InfrastructureValueSet}s
+ * read from the database.
+ * Here, each InfrastructureValueSet instance represents a collection of infrastructure parameters
+ * of a given infrastructure type.
+ */
+public class InfrastructureCombinationsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(InfrastructureCombinationsProvider.class);
+
+    public Set<InfrastructureCombination> getCombinations() throws TestGridDAOException {
+        Set<InfrastructureValueSet> valueSets = new InfrastructureParameterUOW().getValueSet();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieved value-set from database: " + valueSets);
+        }
+        Set<InfrastructureCombination> infrastructureCombinations = getCombinations(valueSets);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Generated set of infrastructure combinations: " + infrastructureCombinations);
+        }
+
+        return infrastructureCombinations;
+    }
+
+    public Set<InfrastructureCombination> getCombinations(Set<InfrastructureValueSet> valueSets)
+            throws TestGridDAOException {
+
+        if (valueSets.size() == 0) {
+            return Collections.emptySet();
+        }
+
+        if (valueSets.size() == 1) {
+            Set<InfrastructureCombination> infrastructureCombinations = new HashSet<>();
+            for (InfrastructureParameter value : valueSets.iterator().next().getValues()) {
+                infrastructureCombinations.add(new InfrastructureCombination(Collections.singleton(value)));
+            }
+            return infrastructureCombinations;
+        }
+
+        Iterator<InfrastructureValueSet> valueSetIterator = valueSets.iterator();
+        InfrastructureValueSet currentValueSet = valueSetIterator.next();
+        valueSetIterator.remove();
+        Set<InfrastructureCombination> combinationsSubSet = getCombinations(valueSets);
+        Set<InfrastructureCombination> finalInfrastructureCombinations = new HashSet<>(
+                combinationsSubSet.size() * currentValueSet.getValues().size());
+        //add the currentValueSet to the returning combinations and create a new combination set.
+        for (InfrastructureParameter value : currentValueSet.getValues()) {
+            for (InfrastructureCombination infrastructureCombination : combinationsSubSet) {
+                InfrastructureCombination clone = infrastructureCombination.clone();
+                clone.addParameter(value);
+                finalInfrastructureCombinations.add(clone);
+            }
+        }
+
+        return finalInfrastructureCombinations;
+    }
+
+}

--- a/core/src/test/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProviderTest.java
+++ b/core/src/test/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.infrastructure;
+
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.testgrid.common.infrastructure.InfrastructureCombination;
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
+import org.wso2.testgrid.common.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Unit tests for the {@link InfrastructureCombinationsProvider} class.
+ */
+public class InfrastructureCombinationsProviderTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(InfrastructureCombinationsProviderTest.class);
+
+    @BeforeTest
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    /**
+     * Tests the infrastructure combination generation algorithm.
+     * Here, we create a list of {@link InfrastructureValueSet}s,
+     * and pass that to {@link InfrastructureCombinationsProvider} to
+     * get the infrastructure combinations.
+     *
+     * @throws Exception if an unexpected exception occurred during test execution
+     */
+    @Test
+    public void testGetCombinations() throws Exception {
+        Set<InfrastructureValueSet> valueSets = new HashSet<>();
+        InfrastructureValueSet osValueSet = new InfrastructureValueSet(InfrastructureParameter.Type.OPERATING_SYSTEM,
+                createInfrastructureParameterSet(InfrastructureParameter.Type.OPERATING_SYSTEM, 2));
+        InfrastructureValueSet dbValueSet = new InfrastructureValueSet(InfrastructureParameter.Type.DATABASE,
+                createInfrastructureParameterSet(InfrastructureParameter.Type.DATABASE, 1));
+        InfrastructureValueSet jdkValueSet = new InfrastructureValueSet(InfrastructureParameter.Type.JDK,
+                createInfrastructureParameterSet(InfrastructureParameter.Type.JDK, 1));
+        valueSets.add(osValueSet);
+        valueSets.add(dbValueSet);
+        valueSets.add(jdkValueSet);
+
+        Set<InfrastructureCombination> combinations = new InfrastructureCombinationsProvider()
+                .getCombinations(valueSets);
+        logger.info("Generated infrastructure combinations: " + combinations);
+        Assert.assertEquals(combinations.size(), 2, "There must be two infrastructure combinations.");
+        for (InfrastructureCombination combination : combinations) {
+            Assert.assertEquals(combination.getParameters().size(), 3, "Combination contains more than three "
+                    + "infrastructure parameters: " + combination);
+        }
+
+        List<String> operatingSystems = new ArrayList<String>() {
+            {
+                add(InfrastructureParameter.Type.OPERATING_SYSTEM.toString() + 1);
+                add(InfrastructureParameter.Type.OPERATING_SYSTEM.toString() + 2);
+            }
+        };
+
+        for (InfrastructureCombination combination : combinations) {
+            //check os
+            boolean osExists = combination.getParameters().removeIf(param ->
+                    param.getName().equals(operatingSystems.get(0)) &&
+                            param.getType().equals(InfrastructureParameter.Type.OPERATING_SYSTEM));
+            if (!osExists && operatingSystems.size() == 2) {
+                osExists = combination.getParameters().removeIf(param ->
+                        param.getName().equals(operatingSystems.get(1)) &&
+                                param.getType().equals(InfrastructureParameter.Type.OPERATING_SYSTEM));
+                Assert.assertTrue(osExists, StringUtil.concatStrings(operatingSystems.get(0), " nor ",
+                        operatingSystems.get(1), " does not exist in the combination: ", combination));
+                operatingSystems.remove(1);
+            } else if (!osExists) {
+                Assert.fail(StringUtil
+                        .concatStrings(operatingSystems.get(0), " was not found in the combinations: ", combinations));
+            } else {
+                operatingSystems.remove(0);
+            }
+
+            //check db
+            boolean dbExists = combination.getParameters().removeIf(param ->
+                    param.getName().equals(dbValueSet.getValues().iterator().next().getName()) &&
+                            param.getType().equals(InfrastructureParameter.Type.DATABASE));
+            Assert.assertTrue(dbExists, "DB does not exist in the combination: " + combination);
+
+            //check jdk
+            boolean jdkExists = combination.getParameters().removeIf(param ->
+                    param.getName().equals(jdkValueSet.getValues().iterator().next().getName()) &&
+                            param.getType().equals(InfrastructureParameter.Type.JDK));
+            Assert.assertTrue(jdkExists, "JDK does not exist in the combination: " + combination);
+
+            Assert.assertEquals(combination.getParameters().size(), 0);
+        }
+
+    }
+
+    private Set<InfrastructureParameter> createInfrastructureParameterSet(InfrastructureParameter.Type type,
+            int count) {
+        Set<InfrastructureParameter> params = new TreeSet<>();
+        Properties properties = new Properties();
+        properties.setProperty("ami_id", "ami123");
+        properties.setProperty("elastic_ip_id", "eip123");
+        for (int i = 1; i <= count; i++) {
+            InfrastructureParameter param = new InfrastructureParameter(type.toString() + i, type, properties
+                    .toString(), true);
+            params.add(param);
+        }
+
+        return params;
+    }
+
+}

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+
+<suite name="TestGrid - Test Automation Module" object-factory="org.powermock.modules.testng.PowerMockObjectFactory">
+    <test name="dao-test" parallel="false">
+        <classes>
+            <class name="org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider"/>
+        </classes>
+    </test>
+</suite>

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -92,6 +92,11 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.wso2.testgrid</groupId>
+            <artifactId>org.wso2.testgrid.logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/InfrastructureParameterRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/InfrastructureParameterRepository.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.testgrid.dao.repository;
+
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.specification.Specification;
+
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * Repository class for {@link InfrastructureParameter} table.
+ *
+ * @since 1.0.0
+ */
+public class InfrastructureParameterRepository extends AbstractRepository<InfrastructureParameter> {
+
+    /**
+     * Constructs an instance of the repository class.
+     *
+     * @param entityManager {@link EntityManager} instance
+     */
+    public InfrastructureParameterRepository(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    /**
+     * Persists an {@link InfrastructureParameter} instance in the database.
+     *
+     * @param entity InfrastructureParameter to persist in the database
+     * @return added or updated {@link InfrastructureParameter} instance
+     * @throws TestGridDAOException thrown when error on persisting the InfrastructureParameter instance
+     */
+    public InfrastructureParameter persist(InfrastructureParameter entity) throws TestGridDAOException {
+        return super.persist(entity);
+    }
+
+    /**
+     * Removes an {@link InfrastructureParameter} instance from database.
+     *
+     * @param entity InfrastructureParameter instance to be removed from database.
+     * @throws TestGridDAOException thrown when error on removing entry from database
+     */
+    public void delete(InfrastructureParameter entity) throws TestGridDAOException {
+        super.delete(entity);
+    }
+
+    /**
+     * Query the database according to the {@link Specification} and return the result-set as the U type.
+     *
+     * @param spec specification that a given query need to adhere to.
+     * @return instance of an {@link U} matching the given primary key
+     * @throws TestGridDAOException thrown when an error occurred while querying.
+     */
+    public <U> List<U> find(Specification<InfrastructureParameter, U> spec, Class<U> clazz) throws
+            TestGridDAOException {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<U> query = criteriaBuilder.createQuery(clazz);
+        Root<InfrastructureParameter> root = query.from(InfrastructureParameter.class);
+        Predicate predicate = spec.toPredicate(root, query, criteriaBuilder);
+        query.where(predicate);
+        return entityManager.createQuery(query).getResultList();
+    }
+
+    /**
+     * Find a specific {@link InfrastructureParameter} instance from database for the given primary key.
+     *
+     * @param id primary key of the entity to be searched for
+     * @return instance of an {@link InfrastructureParameter} matching the given primary key
+     * @throws TestGridDAOException thrown when error on searching for entity
+     */
+    public InfrastructureParameter findByPrimaryKey(String id) throws TestGridDAOException {
+        return findByPrimaryKey(InfrastructureParameter.class, id);
+    }
+
+    /**
+     * Returns a list of {@link InfrastructureParameter} instances matching the given criteria.
+     *
+     * @param params parameters (map of field name and values) for obtaining the result list
+     * @return a list of values for the matched criteria
+     * @throws TestGridDAOException thrown when error on searching for entity
+     */
+    public List<InfrastructureParameter> findByFields(Map<String, Object> params) throws TestGridDAOException {
+        return super.findByFields(InfrastructureParameter.class, params);
+    }
+
+    /**
+     * Returns all the entries from the InfrastructureParameter table.
+     *
+     * @return List<InfrastructureParameter> all the entries from the table matching the given entity type
+     * @throws TestGridDAOException thrown when error on searching for entity
+     */
+    public List<InfrastructureParameter> findAll() throws TestGridDAOException {
+        return super.findAll(InfrastructureParameter.class);
+    }
+
+}

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/InfrastructureParameterRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/InfrastructureParameterRepository.java
@@ -70,8 +70,11 @@ public class InfrastructureParameterRepository extends AbstractRepository<Infras
     /**
      * Query the database according to the {@link Specification} and return the result-set as the U type.
      *
+     * Most of the time, U will be {@link InfrastructureParameter}. You may also have any field within
+     * {@link InfrastructureParameter} as U as well.
+     *
      * @param spec specification that a given query need to adhere to.
-     * @return instance of an {@link U} matching the given primary key
+     * @return List of {@link U}s.
      * @throws TestGridDAOException thrown when an error occurred while querying.
      */
     public <U> List<U> find(Specification<InfrastructureParameter, U> spec, Class<U> clazz) throws

--- a/dao/src/main/java/org/wso2/testgrid/dao/specification/Specification.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/specification/Specification.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.dao.specification;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * Provides the specification pattern for JPA repository pattern.
+ * The specification allows you to build a query using the
+ * JPA Criteria API.
+ *
+ * @param <T> type of the entity a given specification handles.
+ * @param <U> type of the result-set DTO.
+ */
+public interface Specification<T, U> {
+
+    Predicate toPredicate(Root<T> root, CriteriaQuery<U> query, CriteriaBuilder cb);
+
+}

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/InfrastructureParameterUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/InfrastructureParameterUOW.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.dao.uow;
+
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
+import org.wso2.testgrid.dao.EntityManagerHelper;
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.repository.InfrastructureParameterRepository;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.persistence.EntityManager;
+
+import static org.wso2.testgrid.common.infrastructure.InfrastructureParameter.INFRASTRUCTURE_PARAMETER_NAME_COLUMN;
+import static org.wso2.testgrid.common.infrastructure.InfrastructureParameter
+        .INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME;
+import static org.wso2.testgrid.common.infrastructure.InfrastructureParameter
+        .INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME;
+import static org.wso2.testgrid.common.infrastructure.InfrastructureParameter.Type;
+
+/**
+ * This class defines the Unit of work related to a {@link InfrastructureParameter}.
+ *
+ * @since 1.0
+ */
+public class InfrastructureParameterUOW {
+
+    private final InfrastructureParameterRepository infraParamRepository;
+
+    /**
+     * Constructs an instance of {@link InfrastructureParameterUOW} to manager use cases related to product test plan.
+     */
+    public InfrastructureParameterUOW() {
+        EntityManager entityManager = EntityManagerHelper.getEntityManager();
+        infraParamRepository = new InfrastructureParameterRepository(entityManager);
+    }
+
+    /**
+     * Returns an instance of {@link InfrastructureParameter} for the given name.
+     *
+     * @param name parameter name
+     * @return an instance of {@link InfrastructureParameter} for the given name.
+     */
+    public Optional<InfrastructureParameter> getInfrastructureParameter(String name)
+            throws TestGridDAOException {
+        // Search criteria parameters
+        Map<String, Object> params = new HashMap<>();
+        params.put(INFRASTRUCTURE_PARAMETER_NAME_COLUMN, name);
+
+        List<InfrastructureParameter> infraParams = infraParamRepository.findByFields(params);
+        if (infraParams.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(infraParams.get(0));
+    }
+
+    /**
+     * Returns a List of {@link InfrastructureParameter} instances.
+     *
+     * @return a List of {@link InfrastructureParameter} instances
+     */
+    public List<InfrastructureParameter> getInfrastructureParameters() throws TestGridDAOException {
+        return infraParamRepository.findAll();
+    }
+
+    /**
+     *
+     * @return a set of {@link InfrastructureValueSet} instances. Each set item contains a
+     * {@link InfrastructureValueSet} of a given {@link Type}.
+     */
+    public Set<InfrastructureValueSet> getValueSet() throws TestGridDAOException {
+        List<InfrastructureParameter.Type> types = infraParamRepository
+                .find(((root, query, cb) -> {
+                    query.select(root.get(INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME)).distinct(true);
+                    return cb.isTrue(root.get(INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME));
+                }), Type.class);
+
+        //create sets of ValueSets by infrastructure type
+        Set<InfrastructureValueSet> infrastructureParameterSets = new HashSet<>();
+        for (Type type : types) {
+            List<InfrastructureParameter> infrastructureParameters = infraParamRepository.find((root, query, cb) -> {
+                //                query.select(root.get("type")).distinct(true);
+                return cb.and(
+                        cb.equal(root.get(INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME), type),
+                        cb.isTrue(root.get(INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME)));
+            }, InfrastructureParameter.class);
+
+            InfrastructureValueSet valueSet = new InfrastructureValueSet(type, new TreeSet<>(infrastructureParameters));
+            infrastructureParameterSets.add(valueSet);
+        }
+        return infrastructureParameterSets;
+    }
+
+    /**
+     * This method persists a {@link InfrastructureParameter} instance to the database.
+     *
+     * @param infraParam {@link InfrastructureParameter} to persist.
+     * @return persisted {@link InfrastructureParameter} instance
+     * @throws TestGridDAOException thrown when error on persisting the object
+     */
+    public InfrastructureParameter persistInfrastructureParameter(InfrastructureParameter infraParam) throws
+            TestGridDAOException {
+        return infraParamRepository.persist(infraParam);
+    }
+
+}

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/InfrastructureParameterUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/InfrastructureParameterUOW.java
@@ -101,12 +101,11 @@ public class InfrastructureParameterUOW {
         //create sets of ValueSets by infrastructure type
         Set<InfrastructureValueSet> infrastructureParameterSets = new HashSet<>();
         for (Type type : types) {
-            List<InfrastructureParameter> infrastructureParameters = infraParamRepository.find((root, query, cb) -> {
-                //                query.select(root.get("type")).distinct(true);
-                return cb.and(
-                        cb.equal(root.get(INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME), type),
-                        cb.isTrue(root.get(INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME)));
-            }, InfrastructureParameter.class);
+            List<InfrastructureParameter> infrastructureParameters = infraParamRepository
+                    .find((root, query, cb) -> cb.and(
+                            cb.equal(root.get(INFRASTRUCTURE_PARAMETER_TYPE_METAMODEL_NAME), type),
+                            cb.isTrue(root.get(INFRASTRUCTURE_PARAMETER_READY_FOR_TESTGRID_METAMODEL_NAME))),
+                            InfrastructureParameter.class);
 
             InfrastructureValueSet valueSet = new InfrastructureValueSet(type, new TreeSet<>(infrastructureParameters));
             infrastructureParameterSets.add(valueSet);
@@ -117,7 +116,7 @@ public class InfrastructureParameterUOW {
     /**
      * This method persists a {@link InfrastructureParameter} instance to the database.
      *
-     * @param infraParam {@link InfrastructureParameter} to persist.
+     * @param infraParam {@link InfrastructureParameter} to persist
      * @return persisted {@link InfrastructureParameter} instance
      * @throws TestGridDAOException thrown when error on persisting the object
      */

--- a/dao/src/main/resources/META-INF/persistence.xml
+++ b/dao/src/main/resources/META-INF/persistence.xml
@@ -24,7 +24,7 @@
         <class>org.wso2.testgrid.common.Product</class>
         <class>org.wso2.testgrid.common.DeploymentPattern</class>
         <class>org.wso2.testgrid.common.TestPlan</class>
-        <class>org.wso2.testgrid.common.InfraParameter</class>
+        <class>org.wso2.testgrid.common.infrastructure.InfrastructureParameter</class>
         <class>org.wso2.testgrid.common.TestScenario</class>
         <class>org.wso2.testgrid.common.TestCase</class>
         <properties>

--- a/dao/src/test/resources/META-INF/persistence.xml
+++ b/dao/src/test/resources/META-INF/persistence.xml
@@ -24,7 +24,7 @@
         <class>org.wso2.testgrid.common.Product</class>
         <class>org.wso2.testgrid.common.DeploymentPattern</class>
         <class>org.wso2.testgrid.common.TestPlan</class>
-        <class>org.wso2.testgrid.common.InfraParameter</class>
+        <class>org.wso2.testgrid.common.infrastructure.InfrastructureParameter</class>
         <class>org.wso2.testgrid.common.TestScenario</class>
         <class>org.wso2.testgrid.common.TestCase</class>
         <properties>


### PR DESCRIPTION
## Purpose
The values of each infrastructure value-set is maintained platform-wide in a single spreadsheet. Product teams are not given the authority to select the infrastructure. If a given product cannot support a given infrastructure, then that needs to be escalated, and if valid, an exclusion-clause can be added to the spreadsheet.

Resolves #343 

## Goals
Single location to manage all infrastructure combinations.

## Approach
* Introduced a new table - InfrastructureParameter
* The InfrastructureParameterRepository then reads the data from the database and provide domain-level InfrastructureValueSet objects for each infrastructure type.
* Then, the InfrastructureCombinationsProvider generates the InfrastructureCombination set by reading the value-sets.

## User stories
N/A

## Release note
Generate infrastructure combinations via value-sets in a database.

**Documentation**
**Training**
**Certification**
**Marketing:**
N/A

## Automation tests
![image](https://user-images.githubusercontent.com/936037/35560200-b163f678-05d2-11e8-8b02-143cf0024346.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Samples**
**Related PRs**
**Migrations (if applicable)**
**Test environment**
**Learning:**
N/A