### PR TITLE
Modify AWSArtifactReader to get AWS credentials from properties file

### DIFF
--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -174,20 +174,29 @@ public class TestPlanService {
                                                                 artifactDownloadable.readArtifact(bucketKey);
             return Response.status(Response.Status.OK).entity(truncatedInputStreamData).build();
         } catch (TestGridDAOException e) {
-            String msg = "Error occurred while fetching the TestPlan by id : '" + id + "' " + e;
+            String msg = "Error occurred while fetching the TestPlan by id : '" + id + "' ";
             logger.error(msg, e);
             return Response.serverError()
-                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
+                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
+                            .setDescription(e.getMessage()).build()).build();
         } catch (TestGridException e) {
-            String msg = "Error occurred when calculating test run artifacts directory. " + e;
+            String msg = "Error occurred when calculating test run artifacts directory.";
             logger.error(msg, e);
             return Response.serverError()
-                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
+                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
+                            .setDescription(e.getMessage()).build()).build();
         } catch (ArtifactReaderException e) {
-            String msg = "Error occurred when reading the artifact. " + e;
+            String msg = "Error occurred when reading the artifact.";
             logger.error(msg, e);
             return Response.serverError()
-                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
+                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
+                            .setDescription(e.getMessage()).build()).build();
+        } catch (IOException e) {
+            String msg = "Error occurred when retrieving TESTGRID_HOME.";
+            logger.error(msg, e);
+            return Response.serverError()
+                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
+                            .setDescription(e.getMessage()).build()).build();
         }
     }
 

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -174,17 +174,17 @@ public class TestPlanService {
                                                                 artifactDownloadable.readArtifact(bucketKey);
             return Response.status(Response.Status.OK).entity(truncatedInputStreamData).build();
         } catch (TestGridDAOException e) {
-            String msg = "Error occurred while fetching the TestPlan by id : '" + id + "'";
+            String msg = "Error occurred while fetching the TestPlan by id : '" + id + "' " + e;
             logger.error(msg, e);
             return Response.serverError()
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         } catch (TestGridException e) {
-            String msg = "Error occurred when calculating test run artifacts directory.";
+            String msg = "Error occurred when calculating test run artifacts directory. " + e;
             logger.error(msg, e);
             return Response.serverError()
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         } catch (ArtifactReaderException e) {
-            String msg = "Error occurred when reading the artifact.";
+            String msg = "Error occurred when reading the artifact. " + e;
             logger.error(msg, e);
             return Response.serverError()
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();

--- a/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
+++ b/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
@@ -22,14 +22,13 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.web.bean.TruncatedInputStreamData;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static org.wso2.testgrid.web.utils.Constants.TESTGRID_HOME;
 
 /**
  * This class is responsible for downloading artifacts from AWS.
@@ -51,14 +50,14 @@ public class AWSArtifactReader implements ArtifactReadable {
      * @param bucket name of the bucket
      * @throws ArtifactReaderException thrown if the given parameters are null or empty
      */
-    public AWSArtifactReader(String region, String bucket) throws ArtifactReaderException {
+    public AWSArtifactReader(String region, String bucket) throws ArtifactReaderException, IOException {
         if (StringUtil.isStringNullOrEmpty(region)) {
             throw new ArtifactReaderException("AWS S3 bucket region is null or empty");
         }
         if (StringUtil.isStringNullOrEmpty(bucket)) {
             throw new ArtifactReaderException("AWS S3 bucket name is null or empty");
         }
-        Path configFilePath = Paths.get(TESTGRID_HOME, "testgrid-web-config.properties");
+        Path configFilePath = Paths.get(TestGridUtil.getTestGridHomePath(), "testgrid-web-config.properties");
         if (!configFilePath.toFile().exists()) {
             throw new ArtifactReaderException("testgrid-web-config.properties file not found");
         }


### PR DESCRIPTION
## Purpose
> Adds changes to provide missing AWS credentials causing inability to download the log file from the dashboard.
> Resolves #410 
> Partially resolves #409

## Goals
> Enable downloading the log file from the dashboard

## Approach
> AWS credentials were fetched from environment variables. This has been changed to read the credentials from a property file using the AWS PropertiesFileCredentialsProvider.


## Release note
> Fixed log file download link in dashboard

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes