### PR TITLE
Logging only the warn logs of org.eclipse.persistence into stdout

### DIFF
--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -61,8 +61,10 @@
         <Logger name="AUDIT_LOG" level="info" additivity="false">
             <AppenderRef ref="AUDIT_LOGFILE"/>
         </Logger>
-        <Logger name="org.eclipse.persistence" level="debug" additivity="false">
+        <Logger name="org.eclipse.persistence" level="warn" additivity="false">
             <AppenderRef ref="TESTGRID_CONSOLE"/>
+        </Logger>
+        <Logger name="org.eclipse.persistence" level="info" additivity="false">
             <AppenderRef ref="Routing"/>
         </Logger>
     </Loggers>


### PR DESCRIPTION
## Purpose
Logging only the warn logs of org.eclipse.persistence into stdout
since its logs are too verbose. The info logs are sent to the testgrid.log. Fixes #408

## Goals
better readability.

## Approach
via log4j2.xml

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
