### PR TITLE
Set the TESTGRID_HOME within shell script itself.

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -29,6 +29,8 @@ public class TestGridConstants {
 
     // Logging constants
     public static final String TEST_LOG_FILE_NAME = "test-run.log";
-
+    public static final String TESTGRID_HOME_ENV = "TESTGRID_HOME";
+    public static final String TESTGRID_HOME_SYSTEM_PROPERTY = "testgrid.home";
     public static final Path DEFAULT_TESTGRID_HOME = Paths.get(System.getProperty("user.home"), ".testgrid");
+
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -28,6 +28,7 @@ import org.wso2.testgrid.common.Deployment;
 import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Host;
 import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.common.exception.TestGridException;
@@ -47,6 +48,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 
 import static org.wso2.testgrid.common.TestGridConstants.DEFAULT_TESTGRID_HOME;
+import static org.wso2.testgrid.common.TestGridConstants.TESTGRID_HOME_SYSTEM_PROPERTY;
 
 /**
  * This Util class holds the common utility methods.
@@ -56,7 +58,6 @@ import static org.wso2.testgrid.common.TestGridConstants.DEFAULT_TESTGRID_HOME;
 public final class TestGridUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGridUtil.class);
-    private static final String TESTGRID_HOME_ENV = "TESTGRID_HOME";
 
     /**
      * Executes a command.
@@ -160,9 +161,12 @@ public final class TestGridUtil {
      * @return test grid home path
      */
     public static String getTestGridHomePath() throws IOException {
-        String testGridHome = EnvironmentUtil.getSystemVariableValue(TESTGRID_HOME_ENV);
+        String testGridHome = EnvironmentUtil.getSystemVariableValue(TestGridConstants.TESTGRID_HOME_ENV);
+        if (testGridHome == null || testGridHome.isEmpty()) {
+            testGridHome = EnvironmentUtil.getSystemVariableValue(TestGridConstants.TESTGRID_HOME_SYSTEM_PROPERTY);
+        }
         Path testGridHomePath;
-        if (testGridHome == null) {
+        if (testGridHome == null || testGridHome.isEmpty()) {
             logger.warn("TESTGRID_HOME environment variable not set. Defaulting to ~/.testgrid.");
             testGridHomePath = DEFAULT_TESTGRID_HOME;
         } else {
@@ -173,8 +177,20 @@ public final class TestGridUtil {
         if (!Files.exists(testGridHomePath)) {
             Files.createDirectories(testGridHomePath.toAbsolutePath());
         }
+        testGridHome = testGridHomePath.toString();
+        System.setProperty(TESTGRID_HOME_SYSTEM_PROPERTY, testGridHome);
 
-        return testGridHomePath.toString();
+        return testGridHome;
+    }
+
+    /**
+     * Returns the directory location where the test-plans are stored.
+     *
+     * @return path of the test plans directory
+     * @throws IOException thrown when error on calculating test plan artifacts directory
+     */
+    public static Path getTestPlanDirectory() throws IOException {
+        return Paths.get(getTestGridHomePath(), "test-plans");
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/Main.java
+++ b/core/src/main/java/org/wso2/testgrid/core/Main.java
@@ -23,7 +23,10 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.core.command.CommandHandler;
+
+import java.io.IOException;
 
 /**
  * This is the Main class of TestGrid which initiates the Test execution process for a particular project.
@@ -40,12 +43,16 @@ public class Main {
             CommandHandler commandHandler = new CommandHandler();
             CmdLineParser parser = new CmdLineParser(commandHandler);
             parser.parseArgument(args);
+            String testGridHome = TestGridUtil.getTestGridHomePath();
+            logger.info("TestGrid Home\t: " + testGridHome);
 
             commandHandler.execute();
         } catch (CmdLineException e) {
             logger.error("Error while parsing command line arguments.", e);
         } catch (CommandExecutionException e) {
             logger.error("Error while executing command.", e);
+        } catch (IOException e) {
+            logger.error("Error while creating $TESTGRID_HOME env variable.");
         }
     }
 }

--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -22,15 +22,15 @@
         <Console name="TESTGRID_CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
         </Console>
-        <RollingFile name="AUDIT_LOGFILE" fileName="${env:TESTGRID_HOME}/audit.log"
-                     filePattern="${env:TESTGRID_HOME}/audit-%d{MM-dd-yyyy}.log">
+        <RollingFile name="AUDIT_LOGFILE" fileName="${sys:testgrid.home}/audit.log"
+                     filePattern="${sys:testgrid.home}/audit-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
-        <RollingFile name="ERROR_LOGFILE" fileName="${env:TESTGRID_HOME}/errors.log"
-                     filePattern="${env:TESTGRID_HOME}/errors-%d{MM-dd-yyyy}.log">
+        <RollingFile name="ERROR_LOGFILE" fileName="${sys:testgrid.home}/errors.log"
+                     filePattern="${sys:testgrid.home}/errors-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
@@ -40,8 +40,8 @@
         <Routing name="Routing">
             <Routes pattern="$${path:key2}">
                 <Route>
-                    <RollingFile name="SCENARIO_LOGFILE" fileName="${env:TESTGRID_HOME}/${path:key2}"
-                                 filePattern="${env:TESTGRID_HOME}/${path:key2}-%d{MM-dd-yyyy}">
+                    <RollingFile name="SCENARIO_LOGFILE" fileName="${sys:testgrid.home}/${path:key2}"
+                                 filePattern="${sys:testgrid.home}/${path:key2}-%d{MM-dd-yyyy}">
                         <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n" />
                         <Policies>
                             <SizeBasedTriggeringPolicy size="50 MB" />

--- a/distribution/bin/testgrid
+++ b/distribution/bin/testgrid
@@ -133,7 +133,8 @@ fi
 
 # if TESTGRID_HOME is not set we're not happy
 if [ -z "$TESTGRID_HOME" ]; then
-  echo "TESTGRID_HOME is not set, system will setup a default location"
+  TESTGRID_HOME="$HOME/.testgrid/"
+  echo "TESTGRID_HOME is not set, using the default location : $TESTGRID_HOME"
 else
   echo "Testgrid Home is set to : " $TESTGRID_HOME
 fi
@@ -179,7 +180,6 @@ fi
 export CLASSPATH=$TESTGRID_DISTRIBUTION/lib/*
 
 # ----- Execute The Requested Command -----------------------------------------
-
 $JAVACMD \
 	-Xms256m -Xmx1024m \
 	-XX:+HeapDumpOnOutOfMemoryError \
@@ -187,5 +187,6 @@ $JAVACMD \
 	$JAVA_OPTS \
 	-Djava.security.egd=file:/dev/./urandom \
 	-Dfile.encoding=UTF8 \
+	-Dtestgrid.home=$TESTGRID_HOME \
 	-Dlog4j.configurationFile=$TESTGRID_DISTRIBUTION/log4j2.xml \
 	org.wso2.testgrid.core.Main $args

--- a/logging/src/main/java/org/wso2/testgrid/logging/plugins/LogFilePathLookup.java
+++ b/logging/src/main/java/org/wso2/testgrid/logging/plugins/LogFilePathLookup.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.core.lookup.StrLookup;
  */
 @Plugin(name = "path", category = StrLookup.CATEGORY)
 public class LogFilePathLookup implements StrLookup {
-    private static String logFilePath = "testgrid";
+    private static String logFilePath = "testgrid.log";
 
     @Override
     public String lookup(String key) {

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -286,8 +286,8 @@ public class TestPlanService {
      *                           2.If IOException occured while writing YAML file.
      *                           3.If the YAML file already exists.
      */
-    private void persistAsYamlFile(TestPlanRequest testPlanRequest) throws TestGridException {
-        java.nio.file.Path path = Paths.get(Constants.TESTPLANS_DIR, testPlanRequest.getTestPlanName());
+    private void persistAsYamlFile(TestPlanRequest testPlanRequest) throws TestGridException, IOException {
+        java.nio.file.Path path = TestGridUtil.getTestPlanDirectory().resolve(testPlanRequest.getTestPlanName());
 
         if (!Files.exists(path)) {
             try {

--- a/web/src/main/java/org/wso2/testgrid/web/utils/ConfigurationContext.java
+++ b/web/src/main/java/org/wso2/testgrid/web/utils/ConfigurationContext.java
@@ -19,6 +19,7 @@
 package org.wso2.testgrid.web.utils;
 
 import org.wso2.testgrid.common.exception.TestGridException;
+import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,19 +28,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-import static org.wso2.testgrid.web.utils.Constants.TESTGRID_HOME;
-
 /**
  * Implementation of configuration context which will contain functions relates with property file.
  * Example: Retrieve property value by property key.
  */
 public class ConfigurationContext {
-    private static Path path = Paths.get(TESTGRID_HOME, "testgrid-web-config.properties");
     private static InputStream inputStream;
     private static boolean isFileAccessed;
     static {
         try {
-            inputStream = Files.newInputStream(path);
+            Path configPath = Paths.get(TestGridUtil.getTestGridHomePath(), "testgrid-web-config.properties");
+            inputStream = Files.newInputStream(configPath);
             isFileAccessed = true;
         } catch (IOException e) {
             isFileAccessed = false;

--- a/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
+++ b/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
@@ -44,6 +44,4 @@ public class Constants extends TestGridConstants {
     public static final String DEPLOYMENT_LOCATION = "$deploymentLocation";
     public static final String SCENARIOS_LOCATION = "$scenariosLocation";
 
-    public static final String TESTGRID_HOME = System.getenv("TESTGRID_HOME");
-    public static final String TESTPLANS_DIR = TESTGRID_HOME + "/test-plans/";
 }


### PR DESCRIPTION
## Purpose
Set the TESTGRID_HOME within shell script itself. Enforcing the default testgrid.home as the logging directory for log4j.

Resolves #435 
Resolves #414 

## Approach
Set testgrid.home system property within the shell script itself. The log4j2.xml will read this system property to know the log file path.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
N/A