### PR TITLE
Support DBEngine, DBEngineVersion as infrastructure parameters.

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
@@ -200,8 +200,9 @@ public class InfrastructureParameter extends AbstractUUIDEntity implements
      */
     public enum Type {
         OPERATING_SYSTEM("operating_system"),
-        DATABASE("database"),
-        JDK("jdk");
+        DBEngine("DBEngine"),
+        DBEngineVersion("DBEngineVersion"),
+        JDK("JDK");
 
         private final String name;
 


### PR DESCRIPTION
## Purpose
Support DBEngine, DBEngineVersion as infrastructure parameters.

## Goals
Backward-compatibility.

## Approach
Support DBEngine, DBEngineVersion as infrastructure parameters.

## Related PRs
#343 