### PR TITLE
Fix coding standard violations

### DIFF
--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/JMeterExecutorTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/JMeterExecutorTest.java
@@ -65,9 +65,6 @@ public class JMeterExecutorTest {
         URL resource = classLoader.getResource("test-grid-is-resources");
         Assert.assertNotNull(resource);
 
-        String testScript = Paths.get(resource.getPath(), "SolutionPattern22", "Tests", "jmeter", "mock.jmx")
-                .toAbsolutePath().toString();
-
         String testLocation = Paths.get(resource.getPath(), "SolutionPattern22", "Tests")
                 .toAbsolutePath().toString();
         TestExecutor testExecutor = new JMeterExecutor();

--- a/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
@@ -38,9 +38,8 @@ public class FileUtil {
      * @throws IOException thrown when no file is found in the given location or when error on closing file input stream
      */
     public static <T> T readConfigurationFile(String location, Class<T> type) throws IOException {
-        FileInputStream fileInputStream = new FileInputStream(new File(location));
-        T configuration = new Yaml().loadAs(fileInputStream, type);
-        fileInputStream.close();
-        return configuration;
+        try (FileInputStream fileInputStream = new FileInputStream(new File(location))) {
+            return new Yaml().loadAs(fileInputStream, type);
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Resolves #427 

## Goals
Fix the code violations 

## Approach
Instead of manually closing the input stream, use 'try-with-resource' method.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

