### PR TITLE
Fixing log issues in testgrid classes

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateReportCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateReportCommand.java
@@ -23,12 +23,16 @@ import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.ProductUOW;
+import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 import org.wso2.testgrid.reporting.ReportingException;
 import org.wso2.testgrid.reporting.TestReportEngine;
+
+import java.nio.file.Paths;
 
 /**
  * This generates a cumulative test report that consists of all test plans for a given product.
@@ -59,12 +63,10 @@ public class GenerateReportCommand implements Command {
     @Override
     public void execute() throws CommandExecutionException {
         try {
-            logger.info("Generating test result report...");
-            logger.info(
-                    "Input Arguments: \n" +
-                    "\tProduct name: " + productName);
+            logger.info("Generating test result report for " + productName);
 
             Product product = getProduct(productName);
+            LogFilePathLookup.setLogFilePath(deriveLogFilePath(productName));
             TestReportEngine testReportEngine = new TestReportEngine();
             testReportEngine.generateReport(product, showSuccess, groupBy);
         } catch (ReportingException e) {
@@ -94,5 +96,16 @@ public class GenerateReportCommand implements Command {
                     .concatStrings("Error in retrieving Product {product name: ", productName,
                             "} from the Database. This exception should not occur in the test execution flow."), e);
         }
+    }
+
+    /**
+     * Returns the path of the log file.
+     *
+     * @param productName product name
+     * @return log file path
+     */
+    private String deriveLogFilePath(String productName) {
+        String productDir = StringUtil.concatStrings(productName);
+        return Paths.get(productDir, TestGridConstants.TEST_LOG_FILE_NAME).toString();
     }
 }

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/aws/AWSManager.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/aws/AWSManager.java
@@ -93,7 +93,9 @@ public class AWSManager {
         String awsIdentity = System.getenv(awsKeyVariableName);
         String awsSecret = System.getenv(awsSecretVariableName);
         if (StringUtil.isStringNullOrEmpty(awsIdentity) || StringUtil.isStringNullOrEmpty(awsSecret)) {
-            throw new TestGridInfrastructureException("AWS Credentials must be set as environment variables");
+            throw new TestGridInfrastructureException(StringUtil
+                    .concatStrings("AWS Credentials must be set as environment variables: ", awsIdentity, ", ",
+                            awsSecretVariableName));
         }
     }
 

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -642,8 +642,7 @@ public class TestReportEngine {
      * @throws ReportingException thrown when error on writing the HTML string to file
      */
     private void writeHTMLToFile(Path filePath, String htmlString) throws ReportingException {
-        logger.info("Started writing test results to file...");
+        logger.info("Writing test results to file: " + filePath.toString());
         FileUtil.writeToFile(filePath.toAbsolutePath().toString(), htmlString);
-        logger.info("Finished writing test results to file");
     }
 }


### PR DESCRIPTION
## Purpose
Fixing log issues in testgrid classes

## Goals
Better logs

## Approach
Fixing log issues in testgrid classes:
AWSManager: print the missing credential env var names.
TestReportEngine: print the report file path.
GenerateReportCommand: fix the log path.
