### PR TITLE
Fix wrong testgrid distribution referred in the jenkins pipeline

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -7,6 +7,7 @@
     <formats>
         <format>zip</format>
     </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/bin</directory>

--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -7,7 +7,6 @@
     <formats>
         <format>zip</format>
     </formats>
-    <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/bin</directory>
@@ -33,6 +32,12 @@
         </file>
         <file>
             <source>../README.md</source>
+            <outputDirectory>.</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
+        <file>
+            <source>../version.md</source>
             <outputDirectory>.</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -50,7 +50,7 @@
                         </goals>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>WSO2-TestGrid-${test.grid.version}</finalName>
+                            <finalName>WSO2-TestGrid</finalName>
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>

--- a/jenkins-pipelines/Jenkinsfile
+++ b/jenkins-pipelines/Jenkinsfile
@@ -5,8 +5,9 @@ pipeline {
         TESTGRID_NAME = 'WSO2-TestGrid'
         TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
                 'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
+        TESTGRID_DIST_LOCATION = '/testgrid/jenkins-home/workspace/'
 
-        PRODUCT="wso2is-5.4.0-LTS"
+        PRODUCT="wso2is-5.4.1-LTS"
 
         INFRASTRUCTURE_REPOSITORY='https://github.com/azinneera/cloudformation-is'
         DEPLOYMENT_REPOSITORY='https://github.com/harshanL/cloudformation-is'
@@ -22,7 +23,7 @@ pipeline {
         WUM_USERNAME=credentials('WUM_USERNAME')
         WUM_PASSWORD=credentials('WUM_PASSWORD')
         PWD=pwd()
-        TESTGRID_HOME='/testgrid/jenkins-home/workspace/wso2is-5.4.0/testgrid-home'
+        TESTGRID_HOME='/testgrid/jenkins-home/workspace/wso2is-5.4.1/testgrid-home'
 
         MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
 
@@ -54,16 +55,16 @@ pipeline {
 
                 sh """
                 echo ${TESTGRID_NAME}
-                curl ${TESTGRID_DIST_URL} -o ${TESTGRID_NAME}-${TESTGRID_VERSION}.zip
-                unzip ${TESTGRID_NAME}-${TESTGRID_VERSION}.zip
-                cd ${TESTGRID_NAME}-${TESTGRID_VERSION}
+
+                unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
+                cd ${TESTGRID_NAME}
                 curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
                 curl -o ./lib/selenium-java.jar $SELENIUM_JAR
                 curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
                 """
 
                 sh """
-                cd ${TESTGRID_NAME}-${TESTGRID_VERSION}
+                cd ${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
                     -tc ${PWD}/${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml
@@ -79,7 +80,7 @@ pipeline {
                         sh "java -version"
 
                         sh """
-                        cd ${TESTGRID_NAME}-${TESTGRID_VERSION}
+                        cd ${TESTGRID_NAME}
                         ./testgrid run-testplan \
                             --product ${PRODUCT} \
                             -ir ${PWD}/${INFRA_LOCATION}/cloudformation-templates/pattern-1 \
@@ -91,6 +92,7 @@ pipeline {
                         currentBuild.result = 'FAILURE'
                     }
                 }
+                echo "RESULT: ${currentBuild.result}"
             }
         }
     }
@@ -98,7 +100,7 @@ pipeline {
     post {
         always {
            sh """
-            cd ${TESTGRID_NAME}-${TESTGRID_VERSION}
+            cd ${TESTGRID_NAME}
             ./testgrid generate-report \
             --product ${PRODUCT} \
             --groupBy scenario
@@ -110,10 +112,10 @@ pipeline {
               s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.log, **/*.html", bucket:"jenkins-testrun-artifacts", path:"artifacts/")
             }
 
-            // Delete logs and reports after upload          
+            // Delete logs and reports after upload
             dir("${TESTGRID_HOME}/${PRODUCT}") {
                 deleteDir()
             }
        }
-   }
+  }
 }

--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -4,7 +4,7 @@ node {
         sshagent(['testgrid-dev-key']) {
             sh """
                 scp -o StrictHostKeyChecking=no web/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/
-                scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/jenkins-home/workspace
+                scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
                 """
            }
     }
@@ -26,7 +26,7 @@ node {
             sshagent(['testgrid-prod-key']) {
                 sh """
                     scp -o StrictHostKeyChecking=no web/target/*.war ${PROD_USER}@${PROD_HOST}:/testgrid/deployment/apache-tomcat-8.5.24/webapps/
-                    scp -o StrictHostKeyChecking=no distribution/target/*.zip ${PROD_USER}@${PROD_HOST}:/testgrid/jenkins-home/workspace
+                    scp -o StrictHostKeyChecking=no distribution/target/*.zip ${PROD_USER}@${PROD_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
                  """
             }
         } else {

--- a/version.md
+++ b/version.md
@@ -1,0 +1,1 @@
+${project.version}


### PR DESCRIPTION
## Purpose
> The Jenkins build fails due to the changes pattern in name of testgrid distribution.
> Resolves #449

## Goals
> Use a standard name for the distribution so that modification of the distribution name in the Jenkins pipeline is avoided

## Approach
> Renamed the file when copying in CD pipeline script
> Avoided packing the directory with milestone and version into the distribution zip

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes