### PR TITLE
Fix build failure caused by large test failure responses

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -61,7 +61,7 @@ public class JMeterResultCollector extends ResultCollector {
             SampleResult result = sampleEvent.getResult();
             String samplerData = result.getSamplerData();
 
-            if (samplerData.length() > 5000) {
+            if (samplerData.length() > FAILURE_MESSAGE_LIMIT) {
                 samplerData = result.getSamplerData().substring(0, FAILURE_MESSAGE_LIMIT)  + "\n log truncated...";
             }
             String failureMessage = result.isSuccessful() ? "" :

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -21,6 +21,8 @@ import org.apache.jmeter.reporters.ResultCollector;
 import org.apache.jmeter.reporters.Summariser;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
@@ -33,6 +35,7 @@ import org.wso2.testgrid.dao.uow.TestCaseUOW;
  */
 public class JMeterResultCollector extends ResultCollector {
 
+    private static final Logger logger = LoggerFactory.getLogger(JMeterResultCollector.class);
     private static final long serialVersionUID = -5244808712889913949L;
 
     private TestScenario testScenario;
@@ -60,11 +63,11 @@ public class JMeterResultCollector extends ResultCollector {
                                             "\", \"Status code\": \"",
                                             result.getResponseCode().replaceAll("\"", "\\\""),
                                             "\", \"Response Message\": \"",
-                                            result.getResponseMessage().replaceAll("\"", "\\\""),
-                                            "\", \"Sampler Data\": \"",
-                                            result.getSamplerData().replaceAll("\"", "\\\""), "\"}");
+                                            result.getResponseMessage().replaceAll("\"", "\\\""));
             // Persist result to the database
             testCaseUOW.persistTestCase(result.getSampleLabel(), testScenario, result.isSuccessful(), failureMessage);
+            logger.info(StringUtil.concatStrings(failureMessage, "\", \"Sampler Data\": \"",
+                    result.getSamplerData().replaceAll("\"", "\\\""), "\"}"));
         } catch (TestGridDAOException e) {
             throw new RuntimeException(StringUtil.concatStrings("Error occurred when persisting test case."), e);
         }

--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -67,9 +67,8 @@
         <Logger name="org.eclipse.persistence" level="info" additivity="false">
             <AppenderRef ref="Routing"/>
         </Logger>
-        <Logger name="org.wso2.testgrid.automation.executor.JMeterResultCollector" additivity="false">
+        <Logger name="org.wso2.testgrid.automation.executor.JMeterResultCollector.JMeterResultLogger" additivity="false">
             <AppenderRef ref="Routing" level="info"/>
-            <AppenderRef ref="TESTGRID_CONSOLE" level="error" />
         </Logger>
     </Loggers>
 </Configuration>

--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -67,5 +67,9 @@
         <Logger name="org.eclipse.persistence" level="info" additivity="false">
             <AppenderRef ref="Routing"/>
         </Logger>
+        <Logger name="org.wso2.testgrid.automation.executor.JMeterResultCollector" additivity="false">
+            <AppenderRef ref="Routing" level="info"/>
+            <AppenderRef ref="TESTGRID_CONSOLE" level="error" />
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Purpose
> Removes persistence of large error response sampler data returned by the tests.
> Resolves #451 

## Goals
> Remove test failure sampler data persistence

## Approach
> The failure messages are written in to the log file instead of the database.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes