### PR TITLE
Clean out the workspace of testgrid CD pipeline at first.

### DIFF
--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -1,5 +1,6 @@
 node {
     stage('Deploy to Dev'){
+        deleteDir()
         copyArtifacts(projectName: 'testgrid/testgrid');
         sshagent(['testgrid-dev-key']) {
             sh """


### PR DESCRIPTION

## Purpose
Clean out the workspace of testgrid CD pipeline at first.
Workspace may contain stale files otherwise.

## Goals
Proper function of Testgrid continuous delivery.

## Approach
deleteDir() pipeline step is added as the very first step.
