### PR TITLE
Fix failure in persistence of concurrent scenario samplers

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -80,7 +80,7 @@ public class JMeterResultCollector extends ResultCollector {
             testCase.setTestScenario(testScenario);
             testCase.setSuccess(result.isSuccessful());
             testCase.setFailureMessage(failureMessage);
-            testCases.add(testCase);
+            testScenario.addTestCase(testCase);
             jmeterResultLogger.info(StringUtil.concatStrings("Test case :", result.getSampleLabel(),
                     " failed for scenario: ", testScenario.getName(), "\n", failureMessage, "\", \"Sampler Data\": \"",
                     result.getSamplerData().replaceAll("\"", "\\\""), "\"}"));

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -23,10 +23,12 @@ import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.util.StringUtil;
-import org.wso2.testgrid.dao.TestGridDAOException;
-import org.wso2.testgrid.dao.uow.TestCaseUOW;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * This class is responsible for collecting JMeter test results.
@@ -41,6 +43,7 @@ public class JMeterResultCollector extends ResultCollector {
 
     private TestScenario testScenario;
     private static final int FAILURE_MESSAGE_LIMIT = 5000;
+    private List<TestCase> testCases = new CopyOnWriteArrayList<>();
 
     /**
      * Constructs an instance of {@link JMeterResultCollector}.
@@ -55,8 +58,6 @@ public class JMeterResultCollector extends ResultCollector {
 
     @Override
     public void sampleOccurred(SampleEvent sampleEvent) {
-        try {
-            TestCaseUOW testCaseUOW = new TestCaseUOW();
             super.sampleOccurred(sampleEvent);
             SampleResult result = sampleEvent.getResult();
             String samplerData = result.getSamplerData();
@@ -73,13 +74,20 @@ public class JMeterResultCollector extends ResultCollector {
                                             result.getResponseMessage().replaceAll("\"", "\\\""),
                                             "\", \"Sampler Data\": \"",
                                             samplerData.replaceAll("\"", "\\\""), "\"}");
-            // Persist result to the database
-            testCaseUOW.persistTestCase(result.getSampleLabel(), testScenario, result.isSuccessful(), failureMessage);
+            // Add result to concurrent list
+            TestCase testCase = new TestCase();
+            testCase.setName(result.getSampleLabel());
+            testCase.setTestScenario(testScenario);
+            testCase.setSuccess(result.isSuccessful());
+            testCase.setFailureMessage(failureMessage);
+            testCases.add(testCase);
             jmeterResultLogger.info(StringUtil.concatStrings("Test case :", result.getSampleLabel(),
                     " failed for scenario: ", testScenario.getName(), "\n", failureMessage, "\", \"Sampler Data\": \"",
                     result.getSamplerData().replaceAll("\"", "\\\""), "\"}"));
-        } catch (TestGridDAOException e) {
-            throw new RuntimeException(StringUtil.concatStrings("Error occurred when persisting test case."), e);
-        }
+
+    }
+
+    public List<TestCase> getTestCases() {
+        return testCases;
     }
 }

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -87,6 +87,13 @@ public class JMeterResultCollector extends ResultCollector {
 
     }
 
+    /**
+     * Gets the list of test cases pertaining to the scenario.
+     * The test cases are added to the into the list concurrently once it enters
+     * {@link #sampleOccurred(SampleEvent)} and the test execution is complete.
+     *
+     * @return the concurrent list of test cases
+     */
     public List<TestCase> getTestCases() {
         return testCases;
     }

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/TestCaseUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/TestCaseUOW.java
@@ -47,25 +47,10 @@ public class TestCaseUOW {
     /**
      * Persists the {@link TestCase} instance for the given params.
      *
-     * @param testName        name of the test case
-     * @param testScenario    {@link TestScenario} instance associated with test case
-     * @param isSuccess       status of the TestCase
-     * @param responseMessage response message of the test case
+     * @param testCase        test case to persist
      * @throws TestGridDAOException thrown when error on persisting
      */
-    public TestCase persistTestCase(String testName, TestScenario testScenario, boolean isSuccess,
-                                    String responseMessage) throws TestGridDAOException {
-        // Create test case instance
-        TestCase testCase = new TestCase();
-        testCase.setName(testName);
-        testCase.setSuccess(isSuccess);
-        testCase.setTestScenario(testScenario);
-        testCase.setFailureMessage(responseMessage);
-
-        // Set test scenario -> test case link
-        testScenario.addTestCase(testCase);
-
-        // Persist test case
+    public TestCase persistTestCase(TestCase testCase) throws TestGridDAOException {
         return testCaseRepository.persist(testCase);
     }
 


### PR DESCRIPTION
## Purpose
> Contains the fix for exception caused when attempted to concurrently persist test cases.
> Resolves #424 

## Goals
> Handling persistence of concurrent scenario samplers properly.

## Approach
> Test case persistence is done after all the test cases have completed for a particular scenario. 
> The ResultCollector writes the test results to a concurrent list and this list is used later in the JMeterExecutor to persist the test cases to the database.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes