### PR TITLE
Add meaningful log message for waiting logic.

### DIFF
--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/AWSDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/AWSDeployer.java
@@ -56,12 +56,12 @@ public class AWSDeployer implements DeployerService {
         try {
             logger.info(StringUtil.concatStrings("Deploying the pattern.. : ", deployment.getName()));
             DeploymentValidator validator = new DeploymentValidator();
-            logger.info("Waiting for server startup..");
             for (Host host : deployment.getHosts()) {
                 try {
                     new URL(host.getIp());
+                    logger.info("Waiting for server startup on URL : " + host.getIp());
                 } catch (MalformedURLException e) {
-                    logger.error(StringUtil.concatStrings("Output Value : ", host.getIp(), " is Not a Valid URL, " +
+                    logger.debug(StringUtil.concatStrings("Output Value : ", host.getIp(), " is Not a Valid URL, " +
                             "hence skipping to next value.."));
                     continue;
                 }


### PR DESCRIPTION

## Purpose
Resolves #455 

## Approach
Add a log message to reflect that testgrid process is waiting on a URL to be ready.
And further adds debug logs to see what values are skipped from the cloudformation output values.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes