### PR TITLE
Time-out and email option for CICD user-input step.

### DIFF
--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -13,13 +13,13 @@ node {
     stage('Deploy to Prod'){
         def userInput
         mail (
-            to: "${TEAM_MEMBERS}",
+            to: "${TEAM_MEMBERS},builder@wso2.org",
             subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
             body: "Hi team,\nLatest artifacts have been deployed to TestGrid-DEV." +
-                "\nPlease have a round of tests and visit ${env.BUILD_URL} to approve/decline deploying to TestGrid-PROD." +
-                "\nYou have ${TIMEOUT_HOURS} hours left!\n\nThanks!");
+                "\nPlease do a round of tests and visit ${env.BUILD_URL} to approve/decline deploying to TestGrid-PROD." +
+                "\nYou have 1 hour left!\n\nThanks!");
         try {
-            timeout(time: "${TIMEOUT_HOURS}" as Integer, unit: 'HOURS') {
+            timeout(time: 1, unit: 'HOURS') {
                 userInput = input (
                         id: 'Proceed1', message: 'Deploy to Prod environment?', parameters: [
                         [$class: 'BooleanParameterDefinition', defaultValue: true, description: '', name: 'Please confirm you agree with this.']

--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -12,17 +12,29 @@ node {
 
     stage('Deploy to Prod'){
         def userInput
+        mail (
+            to: "${TEAM_MEMBERS}",
+            subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
+            body: "Hi team,\nLatest artifacts have been deployed to TestGrid-DEV." +
+                "\nPlease have a round of tests and visit ${env.BUILD_URL} to approve/decline deploying to TestGrid-PROD." +
+                "\nYou have ${TIMEOUT_HOURS} hours left!\n\nThanks!");
         try {
-            userInput = input(
-                    id: 'Proceed1', message: 'Deploy to Prod environment?', parameters: [
-                    [$class: 'BooleanParameterDefinition', defaultValue: true, description: '', name: 'Please confirm you agree with this']
-            ])
+            timeout(time: "${TIMEOUT_HOURS}" as Integer, unit: 'HOURS') {
+                userInput = input (
+                        id: 'Proceed1', message: 'Deploy to Prod environment?', parameters: [
+                        [$class: 'BooleanParameterDefinition', defaultValue: true, description: '', name: 'Please confirm you agree with this.']
+                ])
+            }
         } catch(err) { // input false
-            def user = err.getCauses()[0].getUser()
             userInput = false
-            echo "Aborted by: [${user}]"
+            def user = err.getCauses()[0].getUser()
+            echo ${user.toString}
+            if('SYSTEM' == user.toString()) { // SYSTEM means timeout.
+                echo "Aborted due to time-out."
+            } else {
+                echo "Aborted by: [${user}]"
+            }
         }
-
         if (userInput == true) {
             sshagent(['testgrid-prod-key']) {
                 sh """

--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -21,7 +21,7 @@ node {
         try {
             timeout(time: 1, unit: 'HOURS') {
                 userInput = input (
-                        id: 'Proceed1', message: 'Deploy to Prod environment?', parameters: [
+                        message: 'Deploy to Prod environment?', parameters: [
                         [$class: 'BooleanParameterDefinition', defaultValue: true, description: '', name: 'Please confirm you agree with this.']
                 ])
             }


### PR DESCRIPTION
## Purpose
ATM Jenkins Job to deploy TestGrid to its environments waits in at one step excepting permission as a user input to continue. Due to this reason the job keeps hanging until the input is given. We needs to avoid that.

Fixes #471 
## Goals
Inform the team about this wait and also keep a time-out to automatically abort the job.

## Approach
The jenkins pipeline is modified as to execute user-input request inside a time-out. Also add email sending command at the time of user-input request.
![email](https://user-images.githubusercontent.com/8229975/36065826-38842ad2-0ec6-11e8-8806-b230536326c1.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes