### PR TITLE
Generate final report using the latest test run for each infra combination

### DIFF
--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -26,6 +26,7 @@ import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.reporting.model.GroupBy;
 import org.wso2.testgrid.reporting.model.PerAxisHeader;
 import org.wso2.testgrid.reporting.model.PerAxisSummary;
@@ -556,18 +557,12 @@ public class TestReportEngine {
      */
     private List<ReportElement> constructReportElements(Product product, AxisColumn groupByAxisColumn) {
         List<ReportElement> reportElements = new ArrayList<>();
-
-        // Deployment patterns
-        List<DeploymentPattern> deploymentPatterns = product.getDeploymentPatterns();
-        for (DeploymentPattern deploymentPattern : deploymentPatterns) {
-
-            // Test plans
-            List<TestPlan> testPlans = deploymentPattern.getTestPlans();
-            for (TestPlan testPlan : testPlans) {
-                List<ReportElement> reportElementsForTestPlan = createReportElementsForTestPlan(testPlan,
-                        deploymentPattern, groupByAxisColumn);
-                reportElements.addAll(reportElementsForTestPlan);
-            }
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        List<TestPlan> testPlans = testPlanUOW.getLatestTestPlans(product);
+        for (TestPlan testPlan : testPlans) {
+            List<ReportElement> reportElementsForTestPlan = createReportElementsForTestPlan(testPlan,
+                    testPlan.getDeploymentPattern(), groupByAxisColumn);
+            reportElements.addAll(reportElementsForTestPlan);
         }
         return reportElements;
     }


### PR DESCRIPTION
## Purpose
> Removes unwanted history from the final report and generates the final report based on the latest test run for each infra combination.
> Resolves #362 

## Goals
> The final report should only contain the details related to the latest test run for each infra combination

## Approach
> Rework report element construction logic in TestReportEngine#constructReportElements

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes