### PR TITLE
Copy testgrid distribution to jenkins slaves

### DIFF
--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -1,4 +1,4 @@
-node {
+node('COMPONENT_ECS') {
     stage('Deploy to Dev'){
         deleteDir()
         copyArtifacts(projectName: 'testgrid/testgrid');
@@ -8,6 +8,18 @@ node {
                 scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
                 """
            }
+    }
+
+    stage('Deploy to OpenStack Slave'){
+        node('OSLK01'){
+            deleteDir()
+            copyArtifacts(projectName: 'testgrid/testgrid');
+            sshagent(['testgrid-openstack-dev-key']) {
+                sh """
+                    scp -o StrictHostKeyChecking=no distribution/target/*.zip ${OS_SLAVE_USER}@${OS_SLAVE_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
+                    """
+               }
+        }
     }
 
     stage('Deploy to Prod'){


### PR DESCRIPTION
## Purpose
> Contains additional steps required to copy the TestGrid distribution to the slave nodes to run tests. 
> Resolves #504

## Goals
> Adding the TestGrid distribution to the jenkins slave nodes

## Approach
> Adding another stage to deploy to the slave node in the Jenkins continuous-delivery pipeline

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes