### PR TITLE
Set COMPONENT_ECS as the node label for continuous-delivery pipeline

### DIFF
--- a/jenkins-pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins-pipelines/continuous-delivery/Jenkinsfile
@@ -1,4 +1,4 @@
-node {
+node('COMPONENT_ECS') {
     stage('Deploy to Dev'){
         deleteDir()
         copyArtifacts(projectName: 'testgrid/testgrid');


### PR DESCRIPTION
## Purpose
WSO2 Jenkins require all jobs to have a node label
Hence, using the COMPONENT_ECS label out of the available two.
