### PR TITLE
Implement method to handle dashboard redirection for backend APIs when session expires.

### DIFF
--- a/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
@@ -71,7 +71,12 @@ public class SSOSessionCheckFilter implements Filter {
                 HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
                 String ssoLoginUrl = ConfigurationContext.getProperty(ConfigurationProperties.SSO_LOGIN_URL);
                 if (ssoLoginUrl != null) {
-                    httpResponse.sendRedirect(ssoLoginUrl);
+                    //If the request is for a backend API, Status Code 401 is sent.
+                    if (path.startsWith(Constants.BACKEND_API_URI)) {
+                        httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                    } else {
+                        httpResponse.sendRedirect(ssoLoginUrl);
+                    }
                 } else {
                     throw new ServletException(
                     StringUtil.concatStrings(ConfigurationProperties.SSO_LOGIN_URL.toString(),

--- a/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
+++ b/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
@@ -49,6 +49,7 @@ public class Constants extends TestGridConstants {
     public static final String ACS_URI = WEBAPP_CONTEXT + "/api/acs";
     public static final String JKS_FILE_NAME = "wso2carbon.jks";
     public static final String SSO_DIRECTORY = "SSO";
+    public static final String BACKEND_API_URI = WEBAPP_CONTEXT + "/api/";
 
     public static final String PROPERTYNAME_KEYSTORE_PASSWORD = "KeyStorePassword";
     public static final String PROPERTYNAME_PRIVATE_KEY_ALIAS = "PrivateKeyAlias";

--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -28,11 +28,11 @@ import {
 } from 'material-ui/Table';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
-import { add_current_deployment, add_current_infra } from '../actions/testGridActions.js';
+import {add_current_deployment, add_current_infra} from '../actions/testGridActions.js';
 import Moment from 'moment'
 import ReactTooltip from 'react-tooltip'
 import FlatButton from 'material-ui/FlatButton';
-import {FAIL,SUCCESS,ERROR,PENDING,RUNNING } from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 class DeploymentPatternView extends Component {
 
@@ -45,10 +45,12 @@ class DeploymentPatternView extends Component {
   }
 
   handleError(response) {
-    if (!response.ok) {
-      throw Error(response.statusText)
-    }
-    return response;
+      if (response.status.toString() === HTTP_UNAUTHORIZED) {
+          window.location.replace(LOGIN_URI);
+      } else if(!response.ok){
+          throw Error(response.statusText)
+      }
+      return response;
   }
 
   componentDidMount() {

--- a/web/src/main/react-dashboard/src/components/InfraCombinationView.js
+++ b/web/src/main/react-dashboard/src/components/InfraCombinationView.js
@@ -28,11 +28,11 @@ import {
 } from 'material-ui/Table';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
-import { add_current_infra, add_current_deployment } from '../actions/testGridActions.js';
+import {add_current_infra, add_current_deployment} from '../actions/testGridActions.js';
 import FlatButton from 'material-ui/FlatButton';
 import Divider from 'material-ui/Divider';
 import Moment from 'moment';
-import {FAIL,SUCCESS,ERROR,PENDING,RUNNING } from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 class InfraCombinationView extends Component {
 
@@ -45,8 +45,10 @@ class InfraCombinationView extends Component {
     }
 
     handleError(response) {
-        if (!response.ok) {
-          throw Error(response.statusText)
+        if (response.status.toString() === HTTP_UNAUTHORIZED) {
+            window.location.replace(LOGIN_URI);
+        } else if(!response.ok){
+            throw Error(response.statusText)
         }
         return response;
     }

--- a/web/src/main/react-dashboard/src/components/ProductStatusView.js
+++ b/web/src/main/react-dashboard/src/components/ProductStatusView.js
@@ -27,10 +27,10 @@ import {
   TableRowColumn,
 } from 'material-ui/Table';
 import SingleRecord from './SingleRecord.js';
-import { add_current_product } from '../actions/testGridActions.js';
+import {add_current_product} from '../actions/testGridActions.js';
 import Moment from 'moment'
 import ReactTooltip from 'react-tooltip';
-import {FAIL,SUCCESS,ERROR,PENDING,RUNNING } from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 class ProductStatusView extends Component {
 
@@ -43,7 +43,9 @@ class ProductStatusView extends Component {
   }
 
   handleError(response){
-    if(!response.ok){
+    if (response.status.toString() === HTTP_UNAUTHORIZED) {
+          window.location.replace(LOGIN_URI);
+    } else if(!response.ok){
       throw Error(response.statusText)
     }
     return response;

--- a/web/src/main/react-dashboard/src/components/ScenarioView.js
+++ b/web/src/main/react-dashboard/src/components/ScenarioView.js
@@ -28,7 +28,8 @@ import {
 } from 'material-ui/Table';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
-import { add_current_scenario } from '../actions/testGridActions.js';
+import {add_current_scenario} from '../actions/testGridActions.js';
+import {HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 class ScenarioView extends Component {
 
@@ -46,6 +47,13 @@ class ScenarioView extends Component {
         this.props.history.push(route);
     }
 
+    handleError(response) {
+        if (response.status.toString() === HTTP_UNAUTHORIZED) {
+            window.location.replace(LOGIN_URI);
+            return response;
+        }
+    }
+
     componentDidMount() {
         var url = "/testgrid/v0.9/api/test-plans/"+this.props.active.reducer.currentInfra.infrastructureId+"?require-test-scenario-info=true";
 
@@ -55,12 +63,13 @@ class ScenarioView extends Component {
             headers: {
                 'Accept': 'application/json'
             }
-        }).then(response => {
+        })
+        .then(this.handleError)
+        .then(response => {
             return response.json()
         })
             .then(data => this.setState({ hits: data }));
     }
-
 
     render() {
         console.log(this.props);

--- a/web/src/main/react-dashboard/src/components/ScenarioView.js
+++ b/web/src/main/react-dashboard/src/components/ScenarioView.js
@@ -55,7 +55,7 @@ class ScenarioView extends Component {
     }
 
     componentDidMount() {
-        var url = "/testgrid/v0.9/api/test-plans/"+this.props.active.reducer.currentInfra.infrastructureId+"?require-test-scenario-info=true";
+        var url = "/testgrid/v0.9/api/test-plans/" + this.props.active.reducer.currentInfra.infrastructureId + "?require-test-scenario-info=true";
 
         fetch(url, {
             method: "GET",

--- a/web/src/main/react-dashboard/src/components/TestCaseView.js
+++ b/web/src/main/react-dashboard/src/components/TestCaseView.js
@@ -28,7 +28,7 @@ import {
 } from 'material-ui/Table';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
-
+import {HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 class TestCaseView extends Component {
 
@@ -44,6 +44,13 @@ class TestCaseView extends Component {
 
     }
 
+    handleError(response) {
+        if (response.status.toString() === HTTP_UNAUTHORIZED) {
+            window.location.replace(LOGIN_URI);
+            return response;
+        }
+    }
+
     componentDidMount() {
         var url = '/testgrid/v0.9/api/test-scenarios/'+this.props.active.reducer.currentScenario.scenarioId;
 
@@ -53,13 +60,14 @@ class TestCaseView extends Component {
             headers: {
                 'Accept': 'application/json'
             }
-        }).then(response => {
+        })
+        .then(this.handleError)
+        .then(response => {
             return response.json();
         })
             .then(data => this.setState({ hits: data }));
 
     }
-
 
     render() {
         return (

--- a/web/src/main/react-dashboard/src/components/TestCaseView.js
+++ b/web/src/main/react-dashboard/src/components/TestCaseView.js
@@ -52,7 +52,7 @@ class TestCaseView extends Component {
     }
 
     componentDidMount() {
-        var url = '/testgrid/v0.9/api/test-scenarios/'+this.props.active.reducer.currentScenario.scenarioId;
+        var url = '/testgrid/v0.9/api/test-scenarios/' + this.props.active.reducer.currentScenario.scenarioId;
 
         fetch(url, {
             method: "GET",

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -39,7 +39,7 @@ import {
 import Download from 'downloadjs'
 import Websocket from 'react-websocket';
 import Snackbar from 'material-ui/Snackbar';
-import {FAIL,SUCCESS,ERROR,PENDING,RUNNING } from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 
 
 /**
@@ -76,7 +76,9 @@ class TestRunView extends Component {
       headers: {
         'Accept': 'application/json'
       }
-    }).then(response => {
+    })
+    .then(this.handleError)
+    .then(response => {
       this.setState({
         testSummaryLoadStatus: response.ok ? SUCCESS : ERROR
       });
@@ -94,7 +96,9 @@ class TestRunView extends Component {
         headers: {
           'Accept': 'application/json'
         }
-      }).then(response => {
+      })
+      .then(this.handleError)
+      .then(response => {
         this.setState({
           logDownloadStatus: response.ok ? SUCCESS : ERROR
         });
@@ -116,6 +120,13 @@ class TestRunView extends Component {
 
   handleLiveLogData(data) {
     this.setState({ logContent: this.state.logContent + data });
+  }
+
+  handleError(response) {
+      if (response.status.toString() === HTTP_UNAUTHORIZED) {
+          window.location.replace(LOGIN_URI);
+          return response;
+      }
   }
 
   render() {
@@ -220,7 +231,9 @@ class TestRunView extends Component {
                     headers: {
                       'Accept': 'application/json'
                     }
-                  }).then(response => {
+                  })
+                  .then(this.handleError)
+                  .then(response => {
                     this.setState({
                       showLogDownloadErrorDialog: !response.ok
                     });
@@ -525,7 +538,8 @@ class TestRunView extends Component {
                                   headers: {
                                     'Accept': 'application/json'
                                   }
-                                }).then(response => {
+                                }).then(this.handleError)
+                                  .then(response => {
                                   this.setState({
                                     logDownloadStatus: response.ok ? SUCCESS : ERROR
                                   });

--- a/web/src/main/react-dashboard/src/constants.js
+++ b/web/src/main/react-dashboard/src/constants.js
@@ -3,3 +3,5 @@ export const ERROR = "ERROR";
 export const SUCCESS = "SUCCESS";
 export const RUNNING = "RUNNING";
 export const PENDING = "PENDING";
+export const HTTP_UNAUTHORIZED = "401";
+export const LOGIN_URI = "/testgrid/dashboard/login";

--- a/web/src/main/react-dashboard/src/registerServiceWorker.js
+++ b/web/src/main/react-dashboard/src/registerServiceWorker.js
@@ -75,7 +75,7 @@ function registerValidSW(swUrl) {
 function checkValidServiceWorker(swUrl) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl, { credentials: 'same-origin',})
-    .then(response => {
+      .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       if (
         response.status === 404 ||

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -72,11 +72,13 @@
     <listener>
         <listener-class>org.wso2.testgrid.web.sso.SSOContextEventListener</listener-class>
     </listener>
-
     <error-page>
         <error-code>404</error-code>
         <location>/index.html</location>
     </error-page>
 
-
+    <!-- Uncomment the following to customize session time-out-->
+    <!--<session-config>-->
+        <!--<session-timeout>60</session-timeout>-->
+    <!--</session-config>-->
 </web-app>


### PR DESCRIPTION
## Purpose
>When a session-invalidated-user tries to view dashboard, he should return to the login-page of the dashboard.
Fixes #521 
## Approach
>  Since the pages are cached, ATM the only requests that goes to back-end from a session-invalidate-user are the backend-API calls. Customized the session check in the backend as to return 401 for any backend-API call from invalid /null session request. From react, the dashboard is redirected to its login page when a 401 is received for a backend

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes