### PR TITLE
Move ConfigurationContext to org.wso2.testgrid.common.config package

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -16,11 +16,13 @@
  * under the License.
  */
 
-package org.wso2.testgrid.common.util;
+package org.wso2.testgrid.common.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/dao/src/main/java/org/wso2/testgrid/dao/EntityManagerHelper.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/EntityManagerHelper.java
@@ -20,8 +20,8 @@ package org.wso2.testgrid.dao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestGridConstants;
-import org.wso2.testgrid.common.util.ConfigurationContext;
-import org.wso2.testgrid.common.util.ConfigurationContext.ConfigurationProperties;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.util.HashMap;

--- a/web/src/main/java/org/wso2/testgrid/web/operation/JenkinsJobConfigurationProvider.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/JenkinsJobConfigurationProvider.java
@@ -20,9 +20,8 @@ package org.wso2.testgrid.web.operation;
 
 import org.apache.hc.client5.http.fluent.Content;
 import org.apache.hc.client5.http.fluent.Request;
+import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.exception.TestGridException;
-import org.wso2.testgrid.common.util.ConfigurationContext;
-import org.wso2.testgrid.common.util.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.web.bean.TestPlanRequest;
 import org.wso2.testgrid.web.utils.Constants;
 
@@ -69,10 +68,10 @@ public class JenkinsJobConfigurationProvider {
         try {
             Content content =  Request.
                     Get(ConfigurationContext.getProperty(
-                            ConfigurationProperties.JENKINS_HOST) + JENKINS_TEMPLATE_JOB_URI)
+                            ConfigurationContext.ConfigurationProperties.JENKINS_HOST) + JENKINS_TEMPLATE_JOB_URI)
                     .addHeader(HttpHeaders.USER_AGENT, USER_AGENT)
-                    .addHeader(HttpHeaders.AUTHORIZATION, "Basic " +
-                            ConfigurationContext.getProperty(ConfigurationProperties.JENKINS_USER_AUTH_KEY))
+                    .addHeader(HttpHeaders.AUTHORIZATION, "Basic " + ConfigurationContext.getProperty(
+                            ConfigurationContext.ConfigurationProperties.JENKINS_USER_AUTH_KEY))
                     .execute().returnContent();
             if (content != null) {
                 return content.asString().trim();

--- a/web/src/main/java/org/wso2/testgrid/web/operation/JenkinsPipelineManager.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/JenkinsPipelineManager.java
@@ -26,9 +26,8 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.exception.TestGridException;
-import org.wso2.testgrid.common.util.ConfigurationContext;
-import org.wso2.testgrid.common.util.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.web.utils.Constants;
 
@@ -52,10 +51,11 @@ public class JenkinsPipelineManager {
     public String createNewPipelineJob(String configXml, String jobName) throws TestGridException, IOException {
         Response response = Request
                 .Post(ConfigurationContext.getProperty(
-                        ConfigurationProperties.JENKINS_HOST) + "/createItem?name=" + jobName)
+                        ConfigurationContext.ConfigurationProperties.JENKINS_HOST) + "/createItem?name=" + jobName)
                 .addHeader(HttpHeaders.USER_AGENT, USER_AGENT)
                 .addHeader(HttpHeaders.AUTHORIZATION, "Basic " +
-                        ConfigurationContext.getProperty(ConfigurationProperties.JENKINS_USER_AUTH_KEY))
+                        ConfigurationContext.getProperty(
+                                ConfigurationContext.ConfigurationProperties.JENKINS_USER_AUTH_KEY))
                 .addHeader(Constants.JENKINS_CRUMB_HEADER_NAME, getCrumb())
                 .addHeader(HttpHeaders.CONTENT_TYPE, "application/xml")
                 .bodyString(configXml, ContentType.APPLICATION_XML)
@@ -80,10 +80,12 @@ public class JenkinsPipelineManager {
         try {
             String response = Request
                     .Get(ConfigurationContext.getProperty(
-                            ConfigurationProperties.JENKINS_HOST) + Constants.JENKINS_CRUMB_ISSUER_URI)
+                            ConfigurationContext.ConfigurationProperties.JENKINS_HOST)
+                            + Constants.JENKINS_CRUMB_ISSUER_URI)
                     .addHeader(HttpHeaders.USER_AGENT, USER_AGENT)
                     .addHeader(HttpHeaders.AUTHORIZATION, "Basic " +
-                            ConfigurationContext.getProperty(ConfigurationProperties.JENKINS_USER_AUTH_KEY))
+                            ConfigurationContext.getProperty(
+                                    ConfigurationContext.ConfigurationProperties.JENKINS_USER_AUTH_KEY))
                     .execute().returnContent().asString().trim();
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonNode = objectMapper.readValue(response, JsonNode.class);
@@ -104,7 +106,7 @@ public class JenkinsPipelineManager {
      */
     private String buildJobSpecificUrl(String jobName) throws TestGridException {
         return StringUtil.concatStrings(
-                ConfigurationContext.getProperty(ConfigurationProperties.JENKINS_HOST),
+                ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.JENKINS_HOST),
                 Constants.BLUE_OCEAN_URI, "/", jobName, "/activity");
     }
 }

--- a/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
+++ b/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
@@ -21,6 +21,7 @@ import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.web.bean.TruncatedInputStreamData;
@@ -57,9 +58,10 @@ public class AWSArtifactReader implements ArtifactReadable {
         if (StringUtil.isStringNullOrEmpty(bucket)) {
             throw new ArtifactReaderException("AWS S3 bucket name is null or empty");
         }
-        Path configFilePath = Paths.get(TestGridUtil.getTestGridHomePath(), "testgrid-web-config.properties");
+        Path configFilePath = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_CONFIG_FILE);
         if (!configFilePath.toFile().exists()) {
-            throw new ArtifactReaderException("testgrid-web-config.properties file not found");
+            throw new ArtifactReaderException(StringUtil.concatStrings(TestGridConstants.TESTGRID_CONFIG_FILE,
+                    " file not found in ", TestGridUtil.getTestGridHomePath()));
         }
         amazonS3 = AmazonS3ClientBuilder.standard()
                 .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))

--- a/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
@@ -21,8 +21,8 @@ package org.wso2.testgrid.web.sso;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestGridConstants;
-import org.wso2.testgrid.common.util.ConfigurationContext;
-import org.wso2.testgrid.common.util.ConfigurationContext.ConfigurationProperties;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.web.utils.Constants;
 


### PR DESCRIPTION
## Purpose
> Contains changes related to refactoring ConfigurationContext to move from org.wso2.testgrid.common.util to org.wso2.testgrid.common..config package.
> Resolves #525 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes