### PR TITLE
Rename Testgrid Framework to Testgrid Project in poms

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -20,14 +20,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.automation</artifactId>
-    <name>WSO2 TestGrid Framework - Automation POM</name>
+    <name>WSO2 TestGrid Project - Automation POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,14 +20,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.common</artifactId>
-    <name>WSO2 TestGrid Framework - Common POM</name>
+    <name>WSO2 TestGrid Project - Common POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,13 +20,13 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.core</artifactId>
-    <name>WSO2 TestGrid Framework - Core POM</name>
+    <name>WSO2 TestGrid Project - Core POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -18,14 +18,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.dao</artifactId>
-    <name>WSO2 TestGrid Framework - DAO POM</name>
+    <name>WSO2 TestGrid Project - DAO POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -20,14 +20,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.deployment</artifactId>
-    <name>WSO2 TestGrid Framework - Deployment POM</name>
+    <name>WSO2 TestGrid Project - Deployment POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,14 +19,14 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <groupId>org.wso2.testgrid</groupId>
         <version>0.9.0-m16-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.distribution</artifactId>
-    <name>WSO2 TestGrid Framework - Distribution POM</name>
+    <name>WSO2 TestGrid Project - Distribution POM</name>
     <url>http://wso2.org</url>
     <packaging>pom</packaging>
 

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -20,14 +20,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.testgrid.infrastruture</artifactId>
-    <name>WSO2 TestGrid Framework - Infrastructure POM</name>
+    <artifactId>org.wso2.testgrid.infrastructure</artifactId>
+    <name>WSO2 TestGrid Project - Infrastructure POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,10 +1,13 @@
 **Description:**
+
 <!-- Give a brief description of the issue -->
 
 **Suggested Labels:**
+
 <!-- Optional comma separated list of suggested labels. Non committers can’t assign labels to issues, so this will help issue creators who are not a committer to suggest possible labels-->
 
 **Suggested Assignees:**
+
 <!--Optional comma separated list of suggested team members who should attend the issue. Non committers can’t assign issues to assignees, so this will help issue creators who are not a committer to suggest possible assignees-->
 
 **Affected Product Version:**
@@ -15,4 +18,5 @@
 
 
 **Related Issues:**
+
 <!-- Any related issues such as sub tasks, issues reported in other repositories (e.g component repositories), similar problems, etc. -->

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -21,14 +21,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.logging</artifactId>
-    <name>WSO2 TestGrid Framework - Logging POM</name>
+    <name>WSO2 TestGrid Project - Logging POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.testgrid</groupId>
-    <artifactId>testgrid-framework</artifactId>
+    <artifactId>testgrid-parent</artifactId>
     <version>0.9.0-m16-SNAPSHOT</version>
-    <name>WSO2 TestGrid Framework - Aggregator POM</name>
+    <name>WSO2 TestGrid Project - Aggregator POM</name>
     <url>http://wso2.org</url>
     <packaging>pom</packaging>
 
@@ -288,7 +288,7 @@
                 <version>${apache.httpcomponents.fluent.version}</version>
             </dependency>
 
-            <!-- Automation Framework dependencies-->
+            <!-- Automation dependencies-->
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
@@ -547,7 +547,6 @@
         <!-- TestGrid infrastructure dependencies -->
         <com.aws.version>1.11.219</com.aws.version>
         <apache.http.version>4.5.3</apache.http.version>
-        <!-- Automation Framework version-->
         <apache.jmeter.version>3.3</apache.jmeter.version>
         <testng.version>6.11</testng.version>
         <!-- Apache commons dependencies-->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,52 +1,57 @@
-## Purpose
-> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
+**Purpose**
 
-## Goals
-> Describe the solutions that this feature/fix will introduce to resolve the problems described above
+<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
 
-## Approach
-> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.
+**Goals**
 
-## User stories
-> Summary of user stories addressed by this change>
+<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
 
-## Release note
-> Brief description of the new feature or bug fix as it will appear in the release notes
+**Approach**
 
-## Documentation
-> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact
+<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
 
-## Training
-> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable
+**User stories**
 
-## Certification
-> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.
+<!-- Summary of user stories addressed by this change> -->
 
-## Marketing
-> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable
+**Release note**
 
-## Automation tests
+<!-- Brief description of the new feature or bug fix as it will appear in the release notes -->
+
+**Documentation**
+<!-- Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact -->
+
+**Training**
+<!-- Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable -->
+
+**Certification**
+<!-- Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why. -->
+
+**Marketing**
+<!-- Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable -->
+
+**Automation tests**
  - Unit tests 
-   > Code coverage information
+   <!-- Code coverage information -->
  - Integration tests
-   > Details about the test cases and coverage
+   <!-- Details about the test cases and coverage -->
 
-## Security checks
+**Security checks**
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
  - Ran FindSecurityBugs plugin and verified report? yes/no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
 
-## Samples
-> Provide high-level details about the samples related to this feature
+**Samples**
+<!-- Provide high-level details about the samples related to this feature -->
 
-## Related PRs
-> List any other related PRs
+**Related PRs**
+<!-- List any other related PRs -->
 
-## Migrations (if applicable)
-> Describe migration steps and platforms on which migration has been tested
+**Migrations (if applicable)**
+<!-- Describe migration steps and platforms on which migration has been tested -->
 
-## Test environment
-> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
+**Test environment**
+<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->
  
-## Learning
-> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
+**Learning**
+<!-- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -18,14 +18,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.reporting</artifactId>
-    <name>WSO2 TestGrid Framework - Reporting POM</name>
+    <name>WSO2 TestGrid Project - Reporting POM</name>
     <url>http://wso2.org</url>
     <packaging>jar</packaging>
 

--- a/test/coverage/pom.xml
+++ b/test/coverage/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <groupId>org.wso2.testgrid</groupId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -27,7 +27,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.test.coverage</artifactId>
-    <name>WSO2 TestGrid Framework - Test Coverage POM</name>
+    <name>WSO2 TestGrid Project - Test Coverage POM</name>
     <url>http://wso2.org</url>
     <dependencies>
         <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,14 +21,14 @@
 
     <parent>
         <groupId>org.wso2.testgrid</groupId>
-        <artifactId>testgrid-framework</artifactId>
+        <artifactId>testgrid-parent</artifactId>
         <version>0.9.0-m16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.testgrid.web</artifactId>
-    <name>WSO2 TestGrid Framework - Webapp POM</name>
+    <name>WSO2 TestGrid Project - Webapp POM</name>
     <packaging>war</packaging>
     <version>0.9.0-m16-SNAPSHOT</version>
 


### PR DESCRIPTION
## Purpose
Rename Testgrid Framework to Testgrid Project in poms.

Testgrid is not a framework. It is a project in itself with ultimate plan
to provide a SaaS.

Fixed typo in the artifactId of infrastructure module.