### PR TITLE
Fix resolving absolute paths in job-config.yaml

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -221,7 +221,7 @@ public class GenerateTestPlanCommand implements Command {
      */
     private void resolvePaths(JobConfigFile jobConfigFile) {
         String parent = jobConfigFile.getWorkingDir();
-        if (jobConfigFile.isRelativePaths() || parent != null) {
+        if (jobConfigFile.isRelativePaths() && parent != null) {
             //infra
             Path repoPath = Paths.get(parent, jobConfigFile.getInfrastructureRepository());
             jobConfigFile.setInfrastructureRepository(resolvePath(repoPath, jobConfigFile));


### PR DESCRIPTION
## Purpose
> Contains the fix for resolving absolute paths provided in job-config.yaml
> Resolves #537

## Goals
> Enable providing absolute paths for paths specified in job-config.yaml

## Approach
> The default paths are the ones specified in job-config.yaml. Resolving the path only if the parent directory is present AND relativePaths boolean is set to false in job-config.yaml. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.