### PR TITLE
Fix incorrect redirection to the login page when downloading a Test-log file

### DIFF
--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -227,6 +227,7 @@ class TestRunView extends Component {
                 <FlatButton label="Download Test Run Log"
                   onClick={() => (fetch(logAllContentUrl, {
                     method: "GET",
+                    credentials: 'same-origin',
                     headers: {
                       'Accept': 'application/json'
                     }
@@ -534,6 +535,7 @@ class TestRunView extends Component {
                               <FlatButton
                                 onClick={() => (fetch(logAllContentUrl, {
                                   method: "GET",
+                                  credentials: 'same-origin',
                                   headers: {
                                     'Accept': 'application/json'
                                   }


### PR DESCRIPTION
**Purpose**
Fixes #544 

**Approach**
The session-id was not included when trying to fetch test-log file from the backend.  Then the backend interpret it as a request from invalid user and a 401 is sent. Then the dashboard was redirected to Login page. The changes are to attach the session cookie with the fetch request so that the backend identifies its from a user with valid/ invalid session.

**Related PRs**
#373 