### PR TITLE
Fix build failure caused by wrong dependency used for infrastructure module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.testgrid</groupId>
-            <artifactId>org.wso2.testgrid.infrastruture</artifactId>
+            <artifactId>org.wso2.testgrid.infrastructure</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.testgrid</groupId>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.testgrid</groupId>
-            <artifactId>org.wso2.testgrid.infrastruture</artifactId>
+            <artifactId>org.wso2.testgrid.infrastructure</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.testgrid</groupId>
-            <artifactId>org.wso2.testgrid.infrastruture</artifactId>
+            <artifactId>org.wso2.testgrid.infrastructure</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.testgrid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.testgrid</groupId>
-                <artifactId>org.wso2.testgrid.infrastruture</artifactId>
+                <artifactId>org.wso2.testgrid.infrastructure</artifactId>
                 <version>${test.grid.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
**Purpose**
> Contains changes needed to fix the build failure caused by the wrong dependency used for infrastructure module.
> Resolves #547 

**Goals**
Fix build failure

**Approach**
Include the correct name of infrastructure module in other necessary modules and parent pom.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes