### PR TITLE
Improve testgrid to honor the  return status of infra provisioning script

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
+++ b/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
@@ -91,7 +91,7 @@ public class ShellExecutor {
      * @throws CommandExecutionException if an {@link IOException} occurs while executing the command
      */
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
-    public boolean executeCommand(String command) throws CommandExecutionException {
+    public int executeCommand(String command) throws CommandExecutionException {
 
         if (logger.isDebugEnabled()) {
             logger.debug("Running shell command : " + command + ", from directory : " + workingDirectory.toString());
@@ -114,7 +114,7 @@ public class ShellExecutor {
             executor.submit(outputStreamGobbler);
             executor.submit(errorStreamGobbler);
 
-            return process.waitFor() == 0;
+            return process.waitFor();
 
         } catch (IOException e) {
             throw new CommandExecutionException(

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
@@ -82,11 +82,12 @@ public class ShellScriptProvider implements InfrastructureProvider {
             String parameterString = TestGridUtil.getParameterString(null, inputParameters);
             ShellExecutor executor = new ShellExecutor(null);
             InfrastructureProvisionResult result = new InfrastructureProvisionResult();
-            if (!executor.executeCommand("bash " + Paths
-                    .get(testPlanLocation, createScript.getFile()) + " " + parameterString)) {
-                throw new TestGridInfrastructureException(
-                        "Error occurred while executing the infra-provision script. " +
-                                "Script returned a non-zero status code.");
+            int exitCode = executor.executeCommand("bash " + Paths
+                    .get(testPlanLocation, createScript.getFile()) + " " + parameterString);
+            if (exitCode > 0) {
+                logger.error(StringUtil.concatStrings("Error occurred while executing the infra-provision script. ",
+                        "Script exited with a status code of ", exitCode));
+                result.setSuccess(false);
             }
             result.setResultLocation(workspace);
             return result;
@@ -115,7 +116,8 @@ public class ShellScriptProvider implements InfrastructureProvider {
         try {
 
             if (executor.executeCommand("bash " + Paths
-                    .get(testPlanLocation, getScriptToExecute(infrastructureConfig, Script.Phase.DESTROY).getFile()))) {
+                    .get(testPlanLocation, getScriptToExecute(infrastructureConfig, Script.Phase.DESTROY)
+                            .getFile())) == 0) {
                 return true;
             }
         } catch (CommandExecutionException e) {

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
@@ -81,9 +81,13 @@ public class ShellScriptProvider implements InfrastructureProvider {
             inputParameters.setProperty(OUTPUT_DIR, workspace);
             String parameterString = TestGridUtil.getParameterString(null, inputParameters);
             ShellExecutor executor = new ShellExecutor(null);
-            executor.executeCommand("bash " + Paths
-                    .get(testPlanLocation, createScript.getFile()) + " " + parameterString);
             InfrastructureProvisionResult result = new InfrastructureProvisionResult();
+            if (!executor.executeCommand("bash " + Paths
+                    .get(testPlanLocation, createScript.getFile()) + " " + parameterString)) {
+                throw new TestGridInfrastructureException(
+                        "Error occurred while executing the infra-provision script. " +
+                                "Script returned a non-zero status code.");
+            }
             result.setResultLocation(workspace);
             return result;
 


### PR DESCRIPTION
**Purpose**
Contains improvements related to honouring the return status of infra provisioning script.
Resolves #337 

**Goals**
TestGrid should handle the infra creation failure gracefully when shell scripts are used.

**Approach**
Improve ShellScriptProvider#provision to consider for the boolean value returned by the ShellExecutor#executeCommand when returning the InfraProvisionResult

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes