### PR TITLE
Fix scenario failures on K8S due to missing host information

### DIFF
--- a/deployment/src/main/java/org/wso2/testgrid/deployment/DeploymentUtil.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/DeploymentUtil.java
@@ -46,8 +46,7 @@ public class DeploymentUtil {
             throws TestGridDeployerException {
 
         ObjectMapper mapper = new ObjectMapper();
-        File file = new File(Paths.get(testPlanLocation, DeployerConstants.PRODUCT_IS_DIR,
-                DeployerConstants.DEPLOYMENT_FILE).toString());
+        File file = new File(Paths.get(testPlanLocation, DeployerConstants.DEPLOYMENT_FILE).toString());
         try {
             return mapper.readValue(file, DeploymentCreationResult.class);
         } catch (IOException e) {

--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Deployer;
 import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.Host;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
 import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.TestPlan;
@@ -31,11 +32,14 @@ import org.wso2.testgrid.common.exception.TestGridDeployerException;
 import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.deployment.DeploymentUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -89,7 +93,21 @@ public class ShellDeployer implements Deployer {
         }
 
         result.setName(deploymentPatternConfig.getName());
-        result.setHosts(infrastructureProvisionResult.getHosts());
+
+        List<Host> hosts = new ArrayList<>();
+        Host tomcatHost = new Host();
+        tomcatHost.setLabel("tomcatHost");
+        tomcatHost.setIp("ec2-52-54-230-106.compute-1.amazonaws.com");
+        Host tomcatPort = new Host();
+        tomcatPort.setLabel("tomcatPort");
+        tomcatPort.setIp("8080");
+        hosts.add(tomcatHost);
+        hosts.add(tomcatPort);
+
+        DeploymentCreationResult result1 = DeploymentUtil.getDeploymentCreationResult(infrastructureProvisionResult
+                .getDeploymentScriptsDir());
+        hosts.addAll(result1.getHosts());
+        result.setHosts(hosts);
         return result;
     }
 

--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
@@ -66,7 +66,6 @@ public class ShellDeployer implements Deployer {
         DeploymentConfig.DeploymentPattern deploymentPatternConfig = testPlan.getDeploymentConfig()
                 .getDeploymentPatterns().get(0);
         logger.info("Performing the Deployment " + deploymentPatternConfig.getName());
-        DeploymentCreationResult result = new DeploymentCreationResult();
         try {
             Script deployment = getScriptToExecute(testPlan.getDeploymentConfig(), Script.Phase.CREATE);
             logger.info("Performing the Deployment " + deployment.getName());
@@ -84,14 +83,18 @@ public class ShellDeployer implements Deployer {
             if (exitCode > 0) {
                 logger.error(StringUtil.concatStrings("Error occurred while executing the deploy-provision script. ",
                         "Script exited with a status code of " , exitCode));
+                DeploymentCreationResult result = new DeploymentCreationResult();
+                result.setName(deploymentPatternConfig.getName());
                 result.setSuccess(false);
+                return result;
             }
         } catch (CommandExecutionException e) {
             throw new TestGridDeployerException(e);
         } catch (IOException e) {
             throw new TestGridDeployerException("Error occurred while retrieving the Testgrid_home ", e);
         }
-
+        DeploymentCreationResult result = DeploymentUtil.getDeploymentCreationResult(infrastructureProvisionResult
+                .getDeploymentScriptsDir());
         result.setName(deploymentPatternConfig.getName());
 
         List<Host> hosts = new ArrayList<>();
@@ -104,9 +107,7 @@ public class ShellDeployer implements Deployer {
         hosts.add(tomcatHost);
         hosts.add(tomcatPort);
 
-        DeploymentCreationResult result1 = DeploymentUtil.getDeploymentCreationResult(infrastructureProvisionResult
-                .getDeploymentScriptsDir());
-        hosts.addAll(result1.getHosts());
+        hosts.addAll(result.getHosts());
         result.setHosts(hosts);
         return result;
     }


### PR DESCRIPTION
**Purpose**
Contains changes related to adding the necessary host information in ShellDeployer.
Resolves  #561

**Goals**
Fixing the test failures occurring due to bugs in TestGrid

**Approach**
Hard-coded tomcat host information
Retrieved other host information of the deployment through deployment.json generated by deploy.sh

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes