### PR TITLE
Fix for multiple test-plan yaml files containing same infrastructure combination

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/InfrastructureConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/InfrastructureConfig.java
@@ -20,6 +20,7 @@
 package org.wso2.testgrid.common.config;
 
 import org.apache.commons.collections4.ListUtils;
+import org.wso2.testgrid.common.TestGridError;
 
 import java.io.Serializable;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.Properties;
  *
  * @since 1.0.0
  */
-public class InfrastructureConfig implements Serializable {
+public class InfrastructureConfig implements Serializable, Cloneable {
 
     private static final long serialVersionUID = -1660815137752094462L;
 
@@ -168,5 +169,22 @@ public class InfrastructureConfig implements Serializable {
      */
     public static class Provisioner extends DeploymentConfig.DeploymentPattern {
         private static final long serialVersionUID = -3937792864579403430L;
+    }
+
+    @Override
+    public InfrastructureConfig clone() {
+        try {
+            InfrastructureConfig infrastructureConfig = (InfrastructureConfig) super.clone();
+            infrastructureConfig.setProvisioners(provisioners);
+            infrastructureConfig.setParameters(parameters);
+            infrastructureConfig.setContainerOrchestrationEngine(containerOrchestrationEngine);
+            infrastructureConfig.setIacProvider(iacProvider);
+            infrastructureConfig.setInfrastructureProvider(infrastructureProvider);
+
+            return infrastructureConfig;
+        } catch (CloneNotSupportedException e) {
+            throw new TestGridError("Since the super class of this object is java.lang.Object that supports " +
+                    "cloning this failure condition should never happen unless a serious system error occurred.", e);
+        }
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -419,7 +419,7 @@ public class GenerateTestPlanCommand implements Command {
                 setUniqueNamesFor(provisioner.getScripts());
 
                 TestPlan testPlan = new TestPlan();
-                testPlan.setInfrastructureConfig(testgridYaml.getInfrastructureConfig());
+                testPlan.setInfrastructureConfig(testgridYaml.getInfrastructureConfig().clone());
                 testPlan.getInfrastructureConfig().setProvisioners(Collections.singletonList(provisioner));
                 deploymentPattern.ifPresent(dp -> {
                     setUniqueNamesFor(dp.getScripts());
@@ -429,7 +429,6 @@ public class GenerateTestPlanCommand implements Command {
                         combination.getParameters());
                 testPlan.getInfrastructureConfig().setParameters(configAwareInfraCombination);
                 testPlan.setScenarioConfig(testgridYaml.getScenarioConfig());
-                testPlan.setInfrastructureConfig(testgridYaml.getInfrastructureConfig());
 
                 testPlan.setInfrastructureRepository(testgridYaml.getInfrastructureRepository());
                 testPlan.setDeploymentRepository(testgridYaml.getDeploymentRepository());

--- a/jenkins/pipelines/Jenkinsfile
+++ b/jenkins/pipelines/Jenkinsfile
@@ -1,5 +1,11 @@
 pipeline {
-    agent any
+    agent {
+        node {
+            label ""
+             customWorkspace '/testgrid/testgrid-home/wso2is-5.4.1-LTS'
+        }
+    }
+
     environment {
         TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
@@ -38,51 +44,55 @@ pipeline {
     stages {
         stage('Preparation') {
             steps {
+                sh "cd ${TESTGRID_HOME}"
+                sh "mkdir -p ${PRODUCT}"
+                sh "cd ${PRODUCT}"
+                //dir("${TESTGRID_HOME}/${PRODUCT}"){
+                    echo pwd()
+                    deleteDir()
 
-                echo pwd()
-                deleteDir()
+                    // Clone scenario repo
+                    sh "mkdir ${SCENARIOS_LOCATION}"
+                    dir("${SCENARIOS_LOCATION}"){
+                        git url: "${SCENARIOS_REPOSITORY}"
+                    }
 
-                // Clone scenario repo
-                sh "mkdir ${SCENARIOS_LOCATION}"
-                dir("${SCENARIOS_LOCATION}"){
-                    git url: "${SCENARIOS_REPOSITORY}"
-                }
+                    // Clone infra repo
+                    sh "mkdir ${INFRA_LOCATION}"
+                    dir("${INFRA_LOCATION}"){
+                        git url:"${INFRASTRUCTURE_REPOSITORY}"
+                    }
 
-                // Clone infra repo
-                sh "mkdir ${INFRA_LOCATION}"
-                dir("${INFRA_LOCATION}"){
-                    git url:"${INFRASTRUCTURE_REPOSITORY}"
-                }
+                    sh """
+                    echo ${TESTGRID_NAME}
 
-                sh """
-                echo ${TESTGRID_NAME}
+                    unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
+                    cd ${TESTGRID_NAME}
+                    curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
+                    curl -o ./lib/selenium-java.jar $SELENIUM_JAR
+                    curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
+                    """
 
-                unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                curl -o ./lib/selenium-java.jar $SELENIUM_JAR
-                curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
-                """
+                    sh """
+                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                    echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
+                    echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
+                    echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}
 
-                sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
-                echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
-                echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
-                echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}
+                    echo The job-config.yaml:
+                    cat ${JOB_CONFIG_YAML_PATH}
+                    """
 
-                echo The job-config.yaml:
-                cat ${JOB_CONFIG_YAML_PATH}
-                """
+                    stash name: "${JOB_CONFIG_YAML}", includes : "${JOB_CONFIG_YAML}"
 
-                stash name: "${JOB_CONFIG_YAML}", includes : "${JOB_CONFIG_YAML}"
-
-                sh """
-                cd ${TESTGRID_NAME}
-                ./testgrid generate-test-plan \
-                    --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
-                """
+                    sh """
+                    cd ${TESTGRID_NAME}
+                    ./testgrid generate-test-plan \
+                        --product ${PRODUCT} \
+                        --file ${JOB_CONFIG_YAML_PATH} \
+                        --workingDir ${PWD}
+                    """
+               // }
             }
         }
 
@@ -128,8 +138,15 @@ pipeline {
 
             // Delete logs and reports after upload
             dir("${TESTGRID_HOME}/${PRODUCT}") {
-                deleteDir()
+                sh """
+                find . -maxdepth 1 -type f \\( -name "*.log" -o -name "*.html" \\) -delete
+                """
             }
-       }
+
+             emailext body: '''$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+
+Check console output at $BUILD_URL to view the results.''', subject: '$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!', to: 'harshan@wso2.com,kasung@wso2.com,asmaj@wso2.com,viduran@wso2.com,sameeraw@wso2.com,pasinduj@wso2.com'
+
+    }
   }
 }

--- a/jenkins/pipelines/Jenkinsfile
+++ b/jenkins/pipelines/Jenkinsfile
@@ -1,11 +1,5 @@
 pipeline {
-    agent {
-        node {
-            label ""
-             customWorkspace '/testgrid/testgrid-home/wso2is-5.4.1-LTS'
-        }
-    }
-
+    agent any
     environment {
         TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
@@ -44,55 +38,51 @@ pipeline {
     stages {
         stage('Preparation') {
             steps {
-                sh "cd ${TESTGRID_HOME}"
-                sh "mkdir -p ${PRODUCT}"
-                sh "cd ${PRODUCT}"
-                //dir("${TESTGRID_HOME}/${PRODUCT}"){
-                    echo pwd()
-                    deleteDir()
 
-                    // Clone scenario repo
-                    sh "mkdir ${SCENARIOS_LOCATION}"
-                    dir("${SCENARIOS_LOCATION}"){
-                        git url: "${SCENARIOS_REPOSITORY}"
-                    }
+                echo pwd()
+                deleteDir()
 
-                    // Clone infra repo
-                    sh "mkdir ${INFRA_LOCATION}"
-                    dir("${INFRA_LOCATION}"){
-                        git url:"${INFRASTRUCTURE_REPOSITORY}"
-                    }
+                // Clone scenario repo
+                sh "mkdir ${SCENARIOS_LOCATION}"
+                dir("${SCENARIOS_LOCATION}"){
+                    git url: "${SCENARIOS_REPOSITORY}"
+                }
 
-                    sh """
-                    echo ${TESTGRID_NAME}
+                // Clone infra repo
+                sh "mkdir ${INFRA_LOCATION}"
+                dir("${INFRA_LOCATION}"){
+                    git url:"${INFRASTRUCTURE_REPOSITORY}"
+                }
 
-                    unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
-                    cd ${TESTGRID_NAME}
-                    curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                    curl -o ./lib/selenium-java.jar $SELENIUM_JAR
-                    curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
-                    """
+                sh """
+                echo ${TESTGRID_NAME}
 
-                    sh """
-                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
-                    echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
-                    echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
-                    echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}
+                unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
+                cd ${TESTGRID_NAME}
+                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
+                curl -o ./lib/selenium-java.jar $SELENIUM_JAR
+                curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
+                """
 
-                    echo The job-config.yaml:
-                    cat ${JOB_CONFIG_YAML_PATH}
-                    """
+                sh """
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}
 
-                    stash name: "${JOB_CONFIG_YAML}", includes : "${JOB_CONFIG_YAML}"
+                echo The job-config.yaml:
+                cat ${JOB_CONFIG_YAML_PATH}
+                """
 
-                    sh """
-                    cd ${TESTGRID_NAME}
-                    ./testgrid generate-test-plan \
-                        --product ${PRODUCT} \
-                        --file ${JOB_CONFIG_YAML_PATH} \
-                        --workingDir ${PWD}
-                    """
-               // }
+                stash name: "${JOB_CONFIG_YAML}", includes : "${JOB_CONFIG_YAML}"
+
+                sh """
+                cd ${TESTGRID_NAME}
+                ./testgrid generate-test-plan \
+                    --product ${PRODUCT} \
+                    --file ${JOB_CONFIG_YAML_PATH} \
+                    --workingDir ${PWD}
+                """
             }
         }
 
@@ -138,15 +128,8 @@ pipeline {
 
             // Delete logs and reports after upload
             dir("${TESTGRID_HOME}/${PRODUCT}") {
-                sh """
-                find . -maxdepth 1 -type f \\( -name "*.log" -o -name "*.html" \\) -delete
-                """
+                deleteDir()
             }
-
-             emailext body: '''$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
-
-Check console output at $BUILD_URL to view the results.''', subject: '$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!', to: 'harshan@wso2.com,kasung@wso2.com,asmaj@wso2.com,viduran@wso2.com,sameeraw@wso2.com,pasinduj@wso2.com'
-
-    }
+       }
   }
 }


### PR DESCRIPTION
**Purpose**
Fixes #558 

**Approach**
The same Infrastructure-config object was added to an array-list in a loop. Thus all configs were becoming identical. Fixed by doing clone before adding to the array-list.

<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

