### PR TITLE
Treat InfrastructureParameter properties as first-class Infrastructure Parameters

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
@@ -130,9 +130,8 @@ public class InfrastructureParameter extends AbstractUUIDEntity implements
         return "InfrastructureParameter{" +
                 "name='" + name + '\'' +
                 ", type='" + type + '\'' +
-                ", properties='" + properties + '\'' +
                 ", readyForTestGrid=" + readyForTestGrid +
-                '}';
+                "}\n";
     }
 
     @Override

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -100,7 +100,7 @@ public class GenerateTestPlanCommand implements Command {
      * This is @{@link Deprecated} in favor of '--file'
      */
     @Option(name = "--testConfig",
-            usage = "Test Configuration File",
+            usage = "Test Configuration File (Deprecated)",
             aliases = { "-tc" })
     private String testgridYamlLocation = "";
 


### PR DESCRIPTION
**Purpose**
Treat InfrastructureParameter properties as first-class Infrastructure Parameter instances at runtime

**Goals**
This is useful when two or more infrastructure parameter belong together.
Classic example is the database and database version. These two must be coupled together
and added as a single Infrastructure Parameter.

<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**

So, we will add a wrapper InfrastructureParameter called 'Database', and add the database engine
(DBEngine) and version (DBEngineVersion) as its properties.

The properties column in InfrastructureParameter table must conform the .properties file format.

<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Automation tests**
Yes.
**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes