### PR TITLE
Modify AWS Client Builders usage to read config.properties for credentials

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 /**
@@ -42,7 +41,7 @@ public class ConfigurationContext {
     static {
         try {
             properties = new Properties();
-            Path configPath = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_CONFIG_FILE);
+            Path configPath = TestGridUtil.getConfigFilePath();
             try (InputStream inputStream = Files.newInputStream(configPath)) {
                 properties.load(inputStream);
             }

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -357,4 +357,14 @@ public final class TestGridUtil {
 
         return TestGridConstants.DEFAULT_DEPLOYMENT_PATTERN_NAME;
     }
+
+    /**
+     * Returns the path of config.properties.
+     *
+     * @return path of <TESTGRID_HOME>/config.properties
+     * @throws IOException for interrupted I/O operations
+     */
+    public static Path getConfigFilePath() throws IOException {
+        return Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_CONFIG_FILE);
+    }
 }

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
@@ -26,7 +26,6 @@ import com.amazonaws.services.ec2.model.Image;
 import com.amazonaws.services.ec2.model.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.exception.TestGridInfrastructureException;
@@ -34,9 +33,7 @@ import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -54,21 +51,14 @@ public class AMIMapper {
 
     public AMIMapper() throws TestGridInfrastructureException {
         try {
-            Path configFilePath = Paths.get(TestGridUtil.getTestGridHomePath(),
-                    TestGridConstants.TESTGRID_CONFIG_FILE);
-            if (!Files.exists(configFilePath)) {
-                throw new TestGridInfrastructureException(
-                        TestGridConstants.TESTGRID_CONFIG_FILE + " file not found." +
-                                " Unable to obtain AWS credentials. Check if the file exists in " +
-                                configFilePath.toFile().toString());
-            }
+            Path configFilePath = TestGridUtil.getConfigFilePath();
             amazonEC2 = AmazonEC2ClientBuilder.standard()
                     .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
                     .withRegion(ConfigurationContext.getProperty(ConfigurationProperties.AWS_REGION_NAME))
                     .build();
         } catch (IOException e) {
             throw new TestGridInfrastructureException(
-                    "Error occurred while getting TestGrid home-path.", e);
+                    "Error occurred while trying to read AWS credentials.", e);
         }
     }
 

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.testgrid.infrastructure;
 
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder;
@@ -161,7 +161,7 @@ public class AWSProviderTest extends PowerMockTestCase {
         PowerMockito.when(cloudFormationClientBuilderMock.withRegion(Mockito.anyString()))
                 .thenReturn(cloudFormationClientBuilderMock);
         PowerMockito.when(cloudFormationClientBuilderMock.withCredentials(Mockito.
-                any(EnvironmentVariableCredentialsProvider.class))).thenReturn(cloudFormationClientBuilderMock);
+                any(PropertiesFileCredentialsProvider.class))).thenReturn(cloudFormationClientBuilderMock);
         PowerMockito.when(cloudFormationClientBuilderMock.build()).thenReturn(cloudFormation);
         PowerMockito.mockStatic(AmazonCloudFormationClientBuilder.class);
         PowerMockito.when(AmazonCloudFormationClientBuilder.standard()).thenReturn(cloudFormationClientBuilderMock);
@@ -219,7 +219,7 @@ public class AWSProviderTest extends PowerMockTestCase {
         PowerMockito.when(cloudFormationClientBuilderMock.withRegion(Mockito.anyString()))
                 .thenReturn(cloudFormationClientBuilderMock);
         PowerMockito.when(cloudFormationClientBuilderMock
-                .withCredentials(Mockito.any(EnvironmentVariableCredentialsProvider.class)))
+                .withCredentials(Mockito.any(PropertiesFileCredentialsProvider.class)))
                 .thenReturn(cloudFormationClientBuilderMock);
         AMIMapper awsAMIMapper = Mockito.mock(AMIMapper.class);
         PowerMockito.whenNew(AMIMapper.class).withAnyArguments().thenReturn(awsAMIMapper);

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -196,7 +196,7 @@ public class TestPlanService {
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
                             .setDescription(e.getMessage()).build()).build();
         } catch (IOException e) {
-            String msg = "Error occurred when retrieving TESTGRID_HOME.";
+            String msg = "Error occurred while trying to read AWS credentials.";
             logger.error(msg, e);
             return Response.serverError()
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)

--- a/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
+++ b/web/src/main/java/org/wso2/testgrid/web/plugins/AWSArtifactReader.java
@@ -21,7 +21,6 @@ import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
-import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.web.bean.TruncatedInputStreamData;
@@ -29,7 +28,6 @@ import org.wso2.testgrid.web.bean.TruncatedInputStreamData;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * This class is responsible for downloading artifacts from AWS.
@@ -58,11 +56,7 @@ public class AWSArtifactReader implements ArtifactReadable {
         if (StringUtil.isStringNullOrEmpty(bucket)) {
             throw new ArtifactReaderException("AWS S3 bucket name is null or empty");
         }
-        Path configFilePath = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_CONFIG_FILE);
-        if (!configFilePath.toFile().exists()) {
-            throw new ArtifactReaderException(StringUtil.concatStrings(TestGridConstants.TESTGRID_CONFIG_FILE,
-                    " file not found in ", TestGridUtil.getTestGridHomePath()));
-        }
+        Path configFilePath = TestGridUtil.getConfigFilePath();
         amazonS3 = AmazonS3ClientBuilder.standard()
                 .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
                 .withRegion(region)


### PR DESCRIPTION
**Purpose**
Contains changes related to modifying AWS Client Builders to use PropertiesFileCredentialsProvider.
Resolves #491

**Goals**
Avoiding environment variables for credentials and using existing config.properties.

**Approach**
Modify AWS Client Builders usage to use  PropertiesFileCredentialsProvider.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Migrations (if applicable)**
- cloudformation
Define the following properties in config.properties
`accessKey`
`secretKey`

- kubernetes
Add `openrc.sh` file to `infrastructureRepository` specified in `job-config.yaml` during runtime