### PR TITLE
Obtain wum credentials from the config file and pass it to CF script

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -39,4 +39,7 @@ public class TestGridConstants {
     public static final String DEFAULT_DEPLOYMENT_PATTERN_NAME = "default";
     public static final String TESTGRID_CONFIG_FILE = "config.properties";
 
+    public static final String WUM_USERNAME_PROPERTY = "WUMUsername";
+    public static final String WUM_PASSWORD_PROPERTY = "WUMPassword";
+
 }

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -103,7 +103,17 @@ public class ConfigurationContext {
         /**
          * AWS Region of TestGrid deployment
          */
-        AWS_REGION_NAME("AWS_REGION_NAME");
+        AWS_REGION_NAME("AWS_REGION_NAME"),
+
+        /**
+         * WUM Username of TestGrid deployment
+         */
+        WUM_USERNAME("WUM_USERNAME"),
+
+        /**
+         * WUM user password of TestGrid deployment
+         */
+        WUM_PASSWORD("WUM_PASSWORD");
 
         private String propertyName;
 

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -184,8 +184,7 @@ public class TestPlanExecutor {
             InfrastructureProvider infrastructureProvider = InfrastructureProviderFactory
                     .getInfrastructureProvider(infrastructureConfig);
             infrastructureProvider.init();
-            InfrastructureProvisionResult provisionResult = infrastructureProvider
-                    .provision(testPlan);
+            InfrastructureProvisionResult provisionResult = infrastructureProvider.provision(testPlan);
 
             provisionResult.setName(infrastructureConfig.getProvisioners().get(0).getName());
             //TODO: remove. deploymentScriptsDir is deprecated now in favor of DeploymentConfig.

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -43,6 +43,7 @@ import org.wso2.testgrid.common.InfrastructureProvider;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TimeOutBuilder;
+import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.exception.TestGridInfrastructureException;
@@ -304,6 +305,21 @@ public class AWSProvider implements InfrastructureProvider {
                         withParameterValue((String) theScriptParameter.getValue());
                 cfCompatibleParameters.add(awsParameter);
             });
+
+            //Set WUM credentials
+            if (expected.getParameterKey().equals("WUMUsername")) {
+                Parameter awsParameter = new Parameter().withParameterKey(expected.getParameterKey()).
+                        withParameterValue(ConfigurationContext.getProperty(ConfigurationContext.
+                                ConfigurationProperties.WUM_USERNAME));
+                cfCompatibleParameters.add(awsParameter);
+            }
+
+            if (expected.getParameterKey().equals("WUMPassword")) {
+                Parameter awsParameter = new Parameter().withParameterKey(expected.getParameterKey()).
+                        withParameterValue(ConfigurationContext.getProperty(ConfigurationContext.
+                                ConfigurationProperties.WUM_PASSWORD));
+                cfCompatibleParameters.add(awsParameter);
+            }
         }));
 
         return cfCompatibleParameters;

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Host;
 import org.wso2.testgrid.common.InfrastructureProvider;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TimeOutBuilder;
 import org.wso2.testgrid.common.config.ConfigurationContext;
@@ -307,14 +308,14 @@ public class AWSProvider implements InfrastructureProvider {
             });
 
             //Set WUM credentials
-            if (expected.getParameterKey().equals("WUMUsername")) {
+            if (TestGridConstants.WUM_USERNAME_PROPERTY.equals(expected.getParameterKey())) {
                 Parameter awsParameter = new Parameter().withParameterKey(expected.getParameterKey()).
                         withParameterValue(ConfigurationContext.getProperty(ConfigurationContext.
                                 ConfigurationProperties.WUM_USERNAME));
                 cfCompatibleParameters.add(awsParameter);
             }
 
-            if (expected.getParameterKey().equals("WUMPassword")) {
+            if (TestGridConstants.WUM_PASSWORD_PROPERTY.equals(expected.getParameterKey())) {
                 Parameter awsParameter = new Parameter().withParameterKey(expected.getParameterKey()).
                         withParameterValue(ConfigurationContext.getProperty(ConfigurationContext.
                                 ConfigurationProperties.WUM_PASSWORD));


### PR DESCRIPTION
**Purpose**

Resolve #576.

**Goals**

With this PR, it would be possible to pass wum credentials as input parameters to the infra/deployment script.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

