### PR TITLE
Change copy-location of TestGrid distrubution in CI/CD.

### DIFF
--- a/jenkins/pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins/pipelines/continuous-delivery/Jenkinsfile
@@ -5,7 +5,7 @@ node('COMPONENT_ECS') {
         sshagent(['testgrid-dev-key']) {
             sh """
                 scp -o StrictHostKeyChecking=no web/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/
-                scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
+                scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/testgrid-home/testgrid-dist/WSO2-TestGrid.zip
                 """
            }
     }
@@ -39,7 +39,7 @@ node('COMPONENT_ECS') {
             sshagent(['testgrid-prod-key']) {
                 sh """
                     scp -o StrictHostKeyChecking=no web/target/*.war ${PROD_USER}@${PROD_HOST}:/testgrid/deployment/apache-tomcat-8.5.24/webapps/
-                    scp -o StrictHostKeyChecking=no distribution/target/*.zip ${PROD_USER}@${PROD_HOST}:/testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
+                    scp -o StrictHostKeyChecking=no distribution/target/*.zip ${PROD_USER}@${PROD_HOST}:/testgrid/testgrid-home/testgrid-dist/WSO2-TestGrid.zip
                  """
             }
         } else {


### PR DESCRIPTION
**Purpose**
To change the copy-location of TestGrid distribution as following:
> Previously: /testgrid/jenkins-home/workspace/WSO2-TestGrid.zip
> New: <TESTGRID_HOME>/testgrid-dist/WSO2-TestGrid.zip

The reason is to consolidate working directories of Jenkins and TestGrid.
Partially fixes #526

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
