### PR TITLE
Fix lengthy and duplicate names generated for infrastructure provisioning scripts

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/InfrastructureConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/InfrastructureConfig.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.wso2.testgrid.common.TestGridError;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -167,8 +168,23 @@ public class InfrastructureConfig implements Serializable, Cloneable {
      * The provisioner has the same behavior as the {@link DeploymentConfig.DeploymentPattern}.
      *
      */
-    public static class Provisioner extends DeploymentConfig.DeploymentPattern {
+    public static class Provisioner extends DeploymentConfig.DeploymentPattern implements Cloneable {
         private static final long serialVersionUID = -3937792864579403430L;
+
+        @Override
+        public Provisioner clone() {
+            try {
+                Provisioner provisioner =  (Provisioner) super.clone();
+                List<Script> scripts = new ArrayList<>();
+                for (Script script : provisioner.getScripts()) {
+                    scripts.add(script.clone());
+                }
+                provisioner.setScripts(scripts);
+                return provisioner;
+            } catch (CloneNotSupportedException e) {
+                throw new TestGridError("Error occurred while cloning Provisioner object.", e);
+            }
+        }
     }
 
     @Override

--- a/common/src/main/java/org/wso2/testgrid/common/config/Script.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/Script.java
@@ -146,7 +146,6 @@ public class Script implements Serializable, Cloneable {
 
     @Override
     public Script clone() {
-
         try {
             return (Script) super.clone();
         } catch (CloneNotSupportedException e) {

--- a/common/src/main/java/org/wso2/testgrid/common/config/Script.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/Script.java
@@ -19,13 +19,15 @@
 
 package org.wso2.testgrid.common.config;
 
+import org.wso2.testgrid.common.TestGridError;
+
 import java.io.Serializable;
 import java.util.Properties;
 
 /**
  * Defines a model object for a provided custom script.
  */
-public class Script implements Serializable {
+public class Script implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 6547552538295691010L;
 
@@ -139,6 +141,16 @@ public class Script implements Serializable {
 
         public String toString() {
             return this.name;
+        }
+    }
+
+    @Override
+    public Script clone() {
+
+        try {
+            return (Script) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new TestGridError("Error occurred while cloning Script object.", e);
         }
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -470,11 +470,12 @@ public class GenerateTestPlanCommand implements Command {
             Optional<DeploymentConfig.DeploymentPattern> deploymentPattern = getMatchingDeploymentPatternFor(
                     provisioner, testgridYaml);
             for (InfrastructureCombination combination : infrastructureCombinations) {
-                setUniqueNamesFor(provisioner.getScripts());
+                Provisioner provisioner1 = provisioner.clone();
+                setUniqueNamesFor(provisioner1.getScripts());
 
                 TestPlan testPlan = new TestPlan();
                 testPlan.setInfrastructureConfig(testgridYaml.getInfrastructureConfig().clone());
-                testPlan.getInfrastructureConfig().setProvisioners(Collections.singletonList(provisioner));
+                testPlan.getInfrastructureConfig().setProvisioners(Collections.singletonList(provisioner1));
                 deploymentPattern.ifPresent(dp -> {
                     setUniqueNamesFor(dp.getScripts());
                     testPlan.setDeploymentConfig(new DeploymentConfig(Collections.singletonList(dp)));


### PR DESCRIPTION
**Purpose**
Fixes the bug in generation of the unique name for infrastructure provisioning script.
Resolves #599 and #582 

**Goals**
Resolve the bug in unique name generation for infrastructure provisioning script

**Approach**
Introduce clone() to Provisioner and Script.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes