### PR TITLE
Remove DeletionPolicy element at CF-script pre-process step

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/CloudFormationScriptPreprocessor.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/CloudFormationScriptPreprocessor.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.testgrid.infrastructure;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.util.regex.Matcher;
@@ -27,9 +29,13 @@ import java.util.regex.Pattern;
  */
 public class CloudFormationScriptPreprocessor {
 
+    private static final Logger logger = LoggerFactory.getLogger(CloudFormationScriptPreprocessor.class);
+
     private static final int RANDOMIZED_STR_LENGTH = 6;
     private static final String NAME_ELEMENT_KEY = "Name";
     private static final String DB_INSTANCE_IDENTIFIER_KEY = "DBInstanceIdentifier";
+    private static final String DELETION_POLICY_KEY = "DeletionPolicy";
+    private static final String REGEX_LINE_SPLIT = "\\r?\\n";
 
     /**
      * This method includes each pre-processing steps the script has to go through.
@@ -39,6 +45,7 @@ public class CloudFormationScriptPreprocessor {
     public String process(String script) {
         script = appendRandomValue(NAME_ELEMENT_KEY, script);
         script = appendRandomValue(DB_INSTANCE_IDENTIFIER_KEY, script);
+        script = removeElement(DELETION_POLICY_KEY, script);
         return script;
     }
 
@@ -54,15 +61,39 @@ public class CloudFormationScriptPreprocessor {
         Pattern pattern = Pattern.compile("(\\s+)(" + key + ")\\s*:\\s*(.*)");
         Matcher matcher;
         //Take each line and check for the reg-ex pattern.
-        for (String line : script.split("\\r?\\n")) {
+        for (String line : script.split(REGEX_LINE_SPLIT)) {
             matcher = pattern.matcher(line);
             if (matcher.find()) {
+                logger.debug("Appending random string to CF-Script element \"" + line + "\".");
                 line = matcher.group(1) + matcher.group(2) + ": " + matcher.group(3) +
                         StringUtil.generateRandomString(RANDOMIZED_STR_LENGTH);
             }
             newScript.append(line).append(System.lineSeparator());
         }
         return newScript.toString();
+    }
+
+    /**
+     * This method removes the elements which contains the key passed.
+     * @param key Key of the element which should be removed.
+     * @param script CF script
+     * @return New CF script after removing elements for the requested key (This can be multiple places if the
+     * element exists in multiple places in the script.
+     */
+    private static String removeElement(String key, String script) {
+      StringBuilder newScript = new StringBuilder();
+      Pattern pattern = Pattern.compile("(\\s+)(" + key + ")\\s*:\\s*(.*)");
+      Matcher matcher;
+      //Take each line and check for the reg-ex pattern.
+      for (String line : script.split(REGEX_LINE_SPLIT)) {
+        matcher = pattern.matcher(line);
+        if (matcher.find()) {
+          logger.debug("Removing \"" + line + "\" element from CF-Script.");
+          continue;
+        }
+        newScript.append(line).append(System.lineSeparator());
+      }
+      return newScript.toString();
     }
 }
 

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/CloudFormationScriptPreprocessor.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/CloudFormationScriptPreprocessor.java
@@ -39,6 +39,7 @@ public class CloudFormationScriptPreprocessor {
 
     /**
      * This method includes each pre-processing steps the script has to go through.
+     *
      * @param script CloudFormation script
      * @return Pre-processed CloudFormation script
      */
@@ -51,6 +52,7 @@ public class CloudFormationScriptPreprocessor {
 
     /**
      * This method appends a random string to the value of the element.
+     *
      * @param key Key of the element where the random string should be appended to its value.
      * @param script CF script
      * @return New CF script with random values appended for the requested element (This can be multiple places if the
@@ -75,6 +77,7 @@ public class CloudFormationScriptPreprocessor {
 
     /**
      * This method removes the elements which contains the key passed.
+     *
      * @param key Key of the element which should be removed.
      * @param script CF script
      * @return New CF script after removing elements for the requested key (This can be multiple places if the


### PR DESCRIPTION
**Purpose**
If the deletion policy is set to snapshot, then, AWS makes a backup of the database before deletion. But, AWS has a limitation on how many manual snapshots we can create (100).
Since testgrid re-spawns CF stacks again and again, we need to remove this policy. 
Fixes #423 

**Approach**
Check for the DeletionPolicy element at the CF script pre-process stage and remove it.
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
