### PR TITLE
Resolve error in getting AWS-region from infrastructure-configurations file.

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -152,7 +152,9 @@ public class AWSProvider implements InfrastructureProvider {
 
     private InfrastructureProvisionResult doProvision(InfrastructureConfig infrastructureConfig,
         String stackName, String infraRepoDir) throws TestGridInfrastructureException {
-        String region = infrastructureConfig.getParameters().getProperty(AWS_REGION_PARAMETER);
+        String region = infrastructureConfig.getProvisioners().get(0)
+                .getScripts().get(0).getInputParameters().getProperty(AWS_REGION_PARAMETER);
+
             Path configFilePath;
             try {
                 configFilePath = TestGridUtil.getConfigFilePath();
@@ -258,7 +260,8 @@ public class AWSProvider implements InfrastructureProvider {
         }
         AmazonCloudFormation stackdestroy = AmazonCloudFormationClientBuilder.standard()
                 .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
-                .withRegion(infrastructureConfig.getParameters().getProperty(AWS_REGION_PARAMETER))
+                .withRegion(infrastructureConfig.getProvisioners().get(0).getScripts().get(0)
+                        .getInputParameters().getProperty(AWS_REGION_PARAMETER))
                 .build();
         DeleteStackRequest deleteStackRequest = new DeleteStackRequest();
         deleteStackRequest.setStackName(stackName);


### PR DESCRIPTION
**Purpose**
AWS region is mentioned under the infrastructureConfig -> scripts. However it was not read properly. This fixes the issue and read the property properly.
Fixes #496 

<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
Earlier the method was searching the parameter `region` in infrastuctureConfig's parameters.
Changed it to read from;
` infrastructureConfig --> provisioner--> script--> parameters --> 'region' parameter`

<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes