### PR TITLE
Fix database persistence failure due to length of failure_message

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterResultCollector.java
@@ -62,9 +62,7 @@ public class JMeterResultCollector extends ResultCollector {
                 message = StringUtil.concatStrings("{ \"Status code\": \"",
                         result.getResponseCode().replaceAll("\"", "\\\""),
                         "\", \"Response Message\": \"",
-                        result.getResponseMessage().replaceAll("\"", "\\\""),
-                        "\", \"Response Data\": \"",
-                        result.getResponseDataAsString().replaceAll("\"", "\\\""), "\"}");
+                        result.getResponseMessage().replaceAll("\"", "\\\""), "\"}");
 
                 logMessage = StringUtil.concatStrings("{ \"Status code\": \"",
                         result.getResponseCode().replaceAll("\"", "\\\""),


### PR DESCRIPTION
**Purpose**
Removes response data from testcase failure message.
Resolves #608 

**Goals**
Resolve database persistence failure.

**Approach**
Remove response data from testcase failure message.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes