### PR TITLE
Set host details from deployment.json in the proper format

### DIFF
--- a/deployment/src/main/java/org/wso2/testgrid/deployment/DeploymentUtil.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/DeploymentUtil.java
@@ -55,6 +55,9 @@ public class DeploymentUtil {
         File file = new File(Paths.get(workspace, DeployerConstants.DEPLOYMENT_FILE).toString());
         try {
             List<Host> hostList = mapper.readValue(file, DeploymentCreationResult.class).getHosts();
+            /* JMeter test files has the values for the host and ports as two properties. In order to replace
+             * the values, the serverHost and serverPort has to be set as two different hosts.
+             */
             for (Host host : hostList) {
                 Host serverHost = new Host();
                 serverHost.setIp(host.getIp());

--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
@@ -66,13 +66,14 @@ public class ShellDeployer implements Deployer {
         DeploymentConfig.DeploymentPattern deploymentPatternConfig = testPlan.getDeploymentConfig()
                 .getDeploymentPatterns().get(0);
         logger.info("Performing the Deployment " + deploymentPatternConfig.getName());
+        final Properties inputParameters;
         try {
             Script deployment = getScriptToExecute(testPlan.getDeploymentConfig(), Script.Phase.CREATE);
             logger.info("Performing the Deployment " + deployment.getName());
             String infraArtifact = StringUtil
                     .concatStrings(infrastructureProvisionResult.getResultLocation(),
                             File.separator, "k8s.properties");
-            final Properties inputParameters = getInputParameters(testPlan, deployment);
+            inputParameters = getInputParameters(testPlan, deployment);
             String parameterString = TestGridUtil.getParameterString(infraArtifact, inputParameters);
             ShellExecutor shellExecutor = new ShellExecutor(Paths.get(TestGridUtil.getTestGridHomePath()));
 
@@ -91,8 +92,8 @@ public class ShellDeployer implements Deployer {
         } catch (CommandExecutionException e) {
             throw new TestGridDeployerException(e);
         }
-        DeploymentCreationResult result = DeploymentUtil.getDeploymentCreationResult(infrastructureProvisionResult
-                .getDeploymentScriptsDir());
+        DeploymentCreationResult result = DeploymentUtil
+                .getDeploymentCreationResult(inputParameters.getProperty(WORKSPACE));
         result.setName(deploymentPatternConfig.getName());
 
         List<Host> hosts = new ArrayList<>();


### PR DESCRIPTION
**Purpose**
Contains changes related to setting the host details as `serverHost` and `serverPort` from deployment.json.
Resolves #616 

**Goals**
Provide the correct hostnames and ports for JMeter test execution.

**Approach**
Rework creation of DeploymentCreationResult in `DeploymentUtil#getDeploymentCreationResult`.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes