### PR TITLE
Add OSVersion as a infrastructure parameter for AMI lookup

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
@@ -49,6 +49,10 @@ import static org.wso2.testgrid.common.util.StringUtil.getPropertiesAsString;
 public class AMIMapper {
     private static final Logger logger = LoggerFactory.getLogger(AMIMapper.class);
 
+    //AMI lookup parameters
+    private static final String AMI_TAG_OS = "OS";
+    private static final String AMI_TAG_OS_VERSION = "OSVersion";
+
     private final AmazonEC2 amazonEC2;
 
     public AMIMapper() throws TestGridInfrastructureException {
@@ -128,7 +132,8 @@ public class AMIMapper {
 
         //Currently supports OS & JDK only.
         //Make this to read params from a external file once there are multiple parameters.
-        amiLookupSupportParameters.add("OS");
+        amiLookupSupportParameters.add(AMI_TAG_OS);
+        amiLookupSupportParameters.add(AMI_TAG_OS_VERSION);
 
         for (String supportParam : amiLookupSupportParameters) {
             for (String infraParamType : infraParamList.stringPropertyNames()) {


### PR DESCRIPTION
**Purpose**

To resolve #628 

**Goals**

To introduce OSVersion as a AMI lookup parameter.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes