### PR TITLE
Rework reading testgrid.yaml and improve report and dashboard view

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestScenario.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestScenario.java
@@ -33,7 +33,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
-
+import javax.persistence.Transient;
 
 /**
  * Defines a model object of TestScenario with required attributes.
@@ -53,6 +53,7 @@ public class TestScenario extends AbstractUUIDEntity implements Serializable {
      * Column names of the table.
      */
     public static final String NAME_COLUMN = "name";
+    public static final String DESCRIPTION_COLUMN = "description";
     public static final String STATUS_COLUMN = "status";
     public static final String PRE_SCRIPT_STATUS_COLUMN = "isPreScriptSuccessful";
     public static final String POST_SCRIPT_STATUS_COLUMN = "isPostScriptSuccessful";
@@ -62,6 +63,9 @@ public class TestScenario extends AbstractUUIDEntity implements Serializable {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -80,6 +84,9 @@ public class TestScenario extends AbstractUUIDEntity implements Serializable {
     @OneToMany(mappedBy = "testScenario", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TestCase> testCases = new ArrayList<>();
 
+    @Transient
+    private String dir;
+
     /**
      * Returns the name of the test scenario.
      *
@@ -96,6 +103,46 @@ public class TestScenario extends AbstractUUIDEntity implements Serializable {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Returns the description of the test scenario.
+     *
+     * @return test scenario description
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    /**
+     * Sets the test scenario description.
+     *
+     * @param description test scenario description
+     */
+    public void setDescription(String description) {
+
+        this.description = description;
+    }
+
+    /**
+     * Returns the directory of the test scenario.
+     *
+     * @return test scenario directory
+     */
+    public String getDir() {
+
+        return dir;
+    }
+
+    /**
+     * Sets the test scenario directory.
+     *
+     * @param dir test scenario directory
+     */
+    public void setDir(String dir) {
+
+        this.dir = dir;
     }
 
     /**

--- a/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
@@ -19,6 +19,8 @@
 
 package org.wso2.testgrid.common.config;
 
+import org.wso2.testgrid.common.TestScenario;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -30,18 +32,18 @@ import java.util.List;
 public class ScenarioConfig implements Serializable {
     private static final long serialVersionUID = 6295205041044769906L;
 
-    private List<String> scenarios;
+    private List<TestScenario> scenarios;
 
     /**
      * This method returns the list of scenarios.
      *
      * @return List of test scenarios that need to be run in testgrid.
      */
-    public List<String> getScenarios() {
+    public List<TestScenario> getScenarios() {
         return scenarios;
     }
 
-    public void setScenarios(List<String> scenarios) {
+    public void setScenarios(List<TestScenario> scenarios) {
         this.scenarios = scenarios;
     }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -321,13 +321,9 @@ public final class TestGridUtil {
             testPlanEntity.setTestRunNumber(latestTestRunNumber + 1);
 
             // Set test scenarios
-            List<TestScenario> testScenarios = new ArrayList<>();
-            for (String name : testPlan.getScenarioConfig().getScenarios()) {
-                TestScenario testScenario = new TestScenario();
-                testScenario.setName(name);
-                testScenario.setTestPlan(testPlanEntity);
+            List<TestScenario> testScenarios = testPlan.getScenarioConfig().getScenarios();
+            for (TestScenario testScenario : testScenarios) {
                 testScenario.setStatus(Status.PENDING);
-                testScenarios.add(testScenario);
             }
             testPlanEntity.setTestScenarios(testScenarios);
             return testPlanEntity;

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -38,7 +38,12 @@ infrastructureConfig:
 infrastructureRepository: ./src/test/resources/workspace/infrastructure
 scenarioConfig:
   scenarios:
-  - solution01
+  - description: Test Scenario
+    dir: scenario01
+    name: scenario01
+    status: PENDING
+    testCases: [
+      ]
 scenarioTestsRepository: ./src/test/resources/workspace/scenarioTests
 testRunNumber: 1
 testScenarios: [

--- a/core/src/test/resources/workspace/testgrid.yaml
+++ b/core/src/test/resources/workspace/testgrid.yaml
@@ -22,8 +22,11 @@ infrastructureConfig:
           type: SHELL
           phase: DESTROY
 scenarioConfig:
-  scenarios:
-    -  "solution01"
+    scenarios:
+      -
+        name: scenario01
+        description: 'Test Scenario'
+        dir: scenario01
 deploymentConfig:
   deploymentPatterns:
     - name: 01-dummy-deployment

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -226,7 +226,7 @@ public class TestReportEngine {
      */
     private List<ReportElement> processOverallResultForDeploymentAxis(List<ReportElement> reportElements) {
         List<ReportElement> distinctElements = distinctList(reportElements, ReportElement::getInfraParams,
-                ReportElement::getScenarioName, ReportElement::isTestSuccess);
+                ReportElement::getScenarioDescription, ReportElement::isTestSuccess);
 
         // Fail list
         List<ReportElement> failList = distinctElements.stream()
@@ -245,7 +245,8 @@ public class TestReportEngine {
             for (ReportElement failListReportElement : failList) {
                 if (successListReportElement.getInfraParams()
                             .equals(failListReportElement.getInfraParams()) &&
-                    successListReportElement.getScenarioName().equals(failListReportElement.getScenarioName())) {
+                    successListReportElement.getScenarioDescription()
+                            .equals(failListReportElement.getScenarioDescription())) {
 
                     // If same combination os found, omit this next time
                     failList.remove(failListReportElement);
@@ -269,7 +270,7 @@ public class TestReportEngine {
      */
     private List<ReportElement> processOverallResultForInfrastructureAxis(List<ReportElement> reportElements) {
         List<ReportElement> distinctElements = distinctList(reportElements, ReportElement::getDeployment,
-                ReportElement::getScenarioName, ReportElement::isTestSuccess);
+                ReportElement::getScenarioDescription, ReportElement::isTestSuccess);
 
         // Fail list
         List<ReportElement> failList = distinctElements.stream()
@@ -287,7 +288,8 @@ public class TestReportEngine {
             boolean isBreakLoop = false;
             for (ReportElement failListReportElement : failList) {
                 if (successListReportElement.getDeployment().equals(failListReportElement.getDeployment()) &&
-                    successListReportElement.getScenarioName().equals(failListReportElement.getScenarioName())) {
+                    successListReportElement.getScenarioDescription()
+                            .equals(failListReportElement.getScenarioDescription())) {
 
                     // If same combination os found, omit this next time
                     failList.remove(failListReportElement);
@@ -377,7 +379,7 @@ public class TestReportEngine {
      */
     private PerAxisSummary createPerAxisSummary(AxisColumn uniqueAxisColumn, ReportElement reportElement) {
         boolean isTestSuccess = reportElement.isTestSuccess();
-        String scenarioName = reportElement.getScenarioName();
+        String scenarioName = reportElement.getScenarioDescription();
         String deployment = reportElement.getDeployment();
         String infrastructure = reportElement.getInfraParams();
 
@@ -437,7 +439,7 @@ public class TestReportEngine {
                 return reportElements.stream().collect(Collectors.groupingBy(ReportElement::getDeployment));
             case SCENARIO:
             default:
-                return reportElements.stream().collect(Collectors.groupingBy(ReportElement::getScenarioName));
+                return reportElements.stream().collect(Collectors.groupingBy(ReportElement::getScenarioDescription));
         }
     }
 
@@ -513,7 +515,7 @@ public class TestReportEngine {
                 return result;
             }
             // Then by scenario
-            result = re1.getScenarioName().compareToIgnoreCase(re2.getScenarioName());
+            result = re1.getScenarioDescription().compareToIgnoreCase(re2.getScenarioDescription());
             if (result != 0) {
                 return result;
             }
@@ -607,7 +609,7 @@ public class TestReportEngine {
         reportElement.setInfraParams(testPlan.getInfraParameters());
 
         // Test scenario information
-        reportElement.setScenarioName(testScenario.getName());
+        reportElement.setScenarioDescription(testScenario.getDescription());
 
         // Test case can be null if the infra fails.
         if (testCase != null) {

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/model/ReportElement.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/model/ReportElement.java
@@ -31,7 +31,7 @@ public class ReportElement {
     private final boolean isGroupByScenario;
     private String deployment;
     private String infraParams;
-    private String scenarioName;
+    private String scenarioDescription;
     private String testCase;
     private String testCaseFailureMessage;
     private boolean isTestSuccess;
@@ -84,21 +84,21 @@ public class ReportElement {
     }
 
     /**
-     * Returns the test scenario name.
+     * Returns the test scenario description.
      *
-     * @return test scenario name
+     * @return test scenario description
      */
-    public String getScenarioName() {
-        return scenarioName;
+    public String getScenarioDescription() {
+        return scenarioDescription;
     }
 
     /**
-     * Sets the test scenario name.
+     * Sets the test scenario description.
      *
-     * @param scenarioName test scenario name
+     * @param scenarioDescription test scenario description
      */
-    public void setScenarioName(String scenarioName) {
-        this.scenarioName = scenarioName;
+    public void setScenarioDescription(String scenarioDescription) {
+        this.scenarioDescription = scenarioDescription;
     }
 
     /**

--- a/reporting/src/main/resources/templates/report_element.mustache
+++ b/reporting/src/main/resources/templates/report_element.mustache
@@ -27,10 +27,10 @@
         <!-- Scenario -->
         {{^isGroupByScenario}}
             {{#isTestSuccess}}
-                <td class="successText">{{scenarioName}}</td>
+                <td class="successText">{{scenarioDescription}}</td>
             {{/isTestSuccess}}
             {{^isTestSuccess}}
-                <td class="errorText">{{scenarioName}}</td>
+                <td class="errorText">{{scenarioDescription}}</td>
             {{/isTestSuccess}}
         {{/isGroupByScenario}}
 

--- a/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
@@ -173,6 +173,7 @@ class APIUtil {
         if (testScenario != null) {
             testScenarioBean.setId(testScenario.getId());
             testScenarioBean.setName(testScenario.getName());
+            testScenarioBean.setDescription(testScenario.getDescription());
             testScenarioBean.setStatus(testScenario.getStatus().toString());
             if (requireTestCases) {
                 testScenarioBean.setTestCases(getTestCaseBeans(testScenario.getTestCases()));

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -379,8 +379,8 @@ public class TestPlanService {
             // Create scenario summary
             long totalSuccess = testCases.stream().filter(TestCase::isSuccess).count();
             long totalFailed = testCases.stream().filter(testCase -> !testCase.isSuccess()).count();
-            ScenarioSummary scenarioSummary = new ScenarioSummary(testScenario.getName(), totalSuccess, totalFailed,
-                    testScenario.getStatus());
+            ScenarioSummary scenarioSummary = new ScenarioSummary(
+                    testScenario.getDescription(), totalSuccess, totalFailed, testScenario.getStatus());
             scenarioSummaries.add(scenarioSummary);
 
             // Create test case entries for failed tests
@@ -390,7 +390,8 @@ public class TestPlanService {
                             testCase.isSuccess())
                     )
                     .collect(Collectors.toList());
-            scenarioTestCaseEntries.add(new ScenarioTestCaseEntry(testScenario.getName(), failedTestCaseEntries));
+            scenarioTestCaseEntries.add(new ScenarioTestCaseEntry(
+                    testScenario.getDescription(), failedTestCaseEntries));
         }
         return new TestExecutionSummary(scenarioSummaries, scenarioTestCaseEntries);
     }

--- a/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioSummary.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioSummary.java
@@ -26,7 +26,7 @@ import org.wso2.testgrid.common.Status;
  */
 public class ScenarioSummary {
 
-    private final String scenarioName;
+    private final String scenarioDescription;
     private final long totalSuccess;
     private final long totalFail;
     private final double successPercentage;
@@ -35,13 +35,13 @@ public class ScenarioSummary {
     /**
      * Constructs an instance of a {@link ScenarioSummary}.
      *
-     * @param scenarioName   scenario name
+     * @param scenarioDescription   scenario description
      * @param totalSuccess   total number of success test cases
      * @param totalFail      total number of failed test cases
      * @param scenarioStatus test scenario overall result
      */
-    public ScenarioSummary(String scenarioName, long totalSuccess, long totalFail, Status scenarioStatus) {
-        this.scenarioName = scenarioName;
+    public ScenarioSummary(String scenarioDescription, long totalSuccess, long totalFail, Status scenarioStatus) {
+        this.scenarioDescription = scenarioDescription;
         this.totalSuccess = totalSuccess;
         this.totalFail = totalFail;
         this.successPercentage = (double) totalSuccess / ((double) totalSuccess + (double) totalFail) * 100d;
@@ -49,12 +49,12 @@ public class ScenarioSummary {
     }
 
     /**
-     * Returns the scenario name.
+     * Returns the scenario description.
      *
-     * @return scenario name
+     * @return scenario description
      */
-    public String getScenarioName() {
-        return scenarioName;
+    public String getScenarioDescription() {
+        return scenarioDescription;
     }
 
     /**
@@ -96,7 +96,7 @@ public class ScenarioSummary {
     @Override
     public String toString() {
         return "ScenarioSummary{" +
-               "scenarioName='" + scenarioName + '\'' +
+               "scenarioDescription='" + scenarioDescription + '\'' +
                ", totalSuccess='" + totalSuccess + '\'' +
                ", totalFail='" + totalFail + '\'' +
                ", successPercentage='" + successPercentage + "%\'" +

--- a/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioTestCaseEntry.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioTestCaseEntry.java
@@ -26,27 +26,27 @@ import java.util.List;
  */
 public class ScenarioTestCaseEntry {
 
-    private final String scenarioName;
+    private final String scenarioDescription;
     private final List<TestCaseEntry> testCaseEntries;
 
     /**
      * Constructs an instance of {@link ScenarioTestCaseEntry}
      *
-     * @param scenarioName    scenario name
+     * @param scenarioDescription    scenario description
      * @param testCaseEntries list of test case entries
      */
-    public ScenarioTestCaseEntry(String scenarioName, List<TestCaseEntry> testCaseEntries) {
-        this.scenarioName = scenarioName;
+    public ScenarioTestCaseEntry(String scenarioDescription, List<TestCaseEntry> testCaseEntries) {
+        this.scenarioDescription = scenarioDescription;
         this.testCaseEntries = testCaseEntries;
     }
 
     /**
-     * Returns the scenario name.
+     * Returns the scenario description.
      *
-     * @return scenario name
+     * @return scenario description
      */
-    public String getScenarioName() {
-        return scenarioName;
+    public String getScenarioDescription() {
+        return scenarioDescription;
     }
 
     /**

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -355,7 +355,7 @@ class TestRunView extends Component {
                               wordWrap: "break-word",
                               whiteSpace: "wrap",
                               textDecoration: "none"
-                            }}> <a href={"#" + data.scenarioName}> {data.scenarioName} </a></TableRowColumn>
+                            }}> <a href={"#" + data.scenarioDescription}> {data.scenarioDescription} </a></TableRowColumn>
                             <TableRowColumn
                               style={{
                                 width: "15%",
@@ -406,7 +406,7 @@ class TestRunView extends Component {
                             {failedTestTitleContent}
                             <h2 style={{
                               color: "#e46226"
-                            }}><a id={data.scenarioName} >{data.scenarioName}</a></h2>
+                            }}><a id={data.scenarioDescription} >{data.scenarioDescription}</a></h2>
                             <Table>
                               <TableHeader displaySelectAll={false}
                                 adjustForCheckbox={false}>


### PR DESCRIPTION
**Purpose**

Contains changes related to displaying scenario names in the dashboard and final report using testgrid.yaml. 
Resolves #603

**Goals**

To display meaningful names for scenarios in the dashboard and the final report.

**Approach**

- Map the names in testgrid.yaml in scenario repository and parse the description of each scenario.
- Persist to database and retrieve to dashboard and report

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes