### PR TITLE
Improve reading of testgrid.yaml to skip missing properties and ignore if incomplete

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -47,6 +47,7 @@ import org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider;
 import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -378,7 +379,12 @@ public class GenerateTestPlanCommand implements Command {
                     + "could not be resolved via the job-config.yaml at: " + this.jobConfigFile);
         }
 
-        TestgridYaml testgridYaml = new Yaml().loadAs(testgridYamlContent, TestgridYaml.class);
+        Representer representer = new Representer();
+
+        // Skip missing properties in testgrid.yaml
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+        TestgridYaml testgridYaml = new Yaml(new Constructor(TestgridYaml.class), representer)
+                .loadAs(testgridYamlContent, TestgridYaml.class);
         testgridYaml.setInfrastructureRepository(jobConfigFile.getInfrastructureRepository());
         testgridYaml.setDeploymentRepository(jobConfigFile.getDeploymentRepository());
         testgridYaml.setScenarioTestsRepository(jobConfigFile.getScenarioTestsRepository());

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -366,7 +366,7 @@ public class GenerateTestPlanCommand implements Command {
                     TestGridConstants.TESTGRID_YAML, " is missing in ", deployRepositoryLocation));
         }
         testgridYamlContent = testgridYamlBuilder.toString().trim();
-        if (testgridYamlContent.isEmpty()) {
+        if (testgridYamlContent.isEmpty() || !testgridYamlContent.contains("scenarioConfig")) {
             testgridYamlContent = getTestgridYamlFor(Paths.get(testgridYamlLocation)).trim();
         }
 


### PR DESCRIPTION
**Purpose**

Contains changes related to modifying GenerateTestPlanCommand to:
  - skip missing properties in testgrid.yaml
  - ignore incomplete testgrid.yaml
Resolves #647 

**Goals**

Improve TestGrid code when reading testgrid.yaml

**Approach**

Modify `GenerateTestPlanCommand#buildTestgridYamlContent`

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes