### PR TITLE
Modify scenario testLocation path to refer to directory using scenario#getDir

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
@@ -77,12 +77,13 @@ public class ScenarioExecutor {
         try {
             // Run test scenario.
             String homeDir = testPlan.getScenarioTestsRepository();
+            String scenarioDir = testScenario.getDir();
             testScenario.setTestPlan(testPlan);
             testScenario.setStatus(Status.RUNNING);
             testScenario = persistTestScenario(testScenario);
 
             logger.info("Executing Tests for Solution Pattern : " + testScenario.getName());
-            String testLocation = Paths.get(homeDir, testScenario.getName()).toAbsolutePath().toString();
+            String testLocation = Paths.get(homeDir, scenarioDir).toAbsolutePath().toString();
             List<Test> tests = getTests(testScenario, testLocation);
 
             if (tests.isEmpty()) {

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -115,7 +115,7 @@ public class TestPlanExecutor {
      * @param deploymentCreationResult the result of the previous build step
      */
     private void runScenarioTests(TestPlan testPlan, DeploymentCreationResult deploymentCreationResult) {
-        for (TestScenario testScenario : testPlan.getTestScenarios()) {
+        for (TestScenario testScenario : testPlan.getScenarioConfig().getScenarios()) {
             try {
                 scenarioExecutor.execute(testScenario, deploymentCreationResult, testPlan);
             } catch (Exception e) {


### PR DESCRIPTION
**Purpose**

Contains changes related to setting the `testLocation` based on the value of the property `dir` from test-plan yaml. 
Resolves #651

**Goals**

Refer to the scenario directory by the correct value specified in the test-plan-*.yaml

**Approach**

- Rework ScenarioExecutor#execute
- Rework TestPlanExecutor#runScenarioTests

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes