### PR TITLE
Add a filter to copyArtifact plugin in continuous-delivery pipeline

### DIFF
--- a/jenkins/pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins/pipelines/continuous-delivery/Jenkinsfile
@@ -1,7 +1,7 @@
 node('COMPONENT_ECS') {
     stage('Deploy to Dev'){
         deleteDir()
-        copyArtifacts(projectName: 'testgrid/testgrid');
+        copyArtifacts(projectName: 'testgrid/testgrid', filter: 'distribution/target/*.zip, web/target/*.war');
         sshagent(['testgrid-dev-key']) {
             sh """
                 scp -o StrictHostKeyChecking=no web/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/


### PR DESCRIPTION
**Purpose**

Contains changes to avoid copying unnecessary artefacts from testgrid build job in testgrid-prod-deploy.
Resolves #303 

**Goals**

Avoid time and space taken to copy unnecessary files from testgrid job.

**Approach**

Added a filter when using copyArtifacts plugin in the pipeline

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes