### PR TITLE
Fix Dashboard Updating Issue

### DIFF
--- a/dao/src/main/java/org/wso2/testgrid/dao/EntityManagerHelper.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/EntityManagerHelper.java
@@ -25,6 +25,7 @@ import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationPropert
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -56,7 +57,7 @@ public class EntityManagerHelper {
      *
      * @return thread safe {@link EntityManager}
      */
-    public static EntityManager getEntityManager(String persistenceUnitName) {
+    private static EntityManager getEntityManager(String persistenceUnitName) {
         EntityManager entityManager = entityManagerMap.get(persistenceUnitName);
         if (entityManager == null || !entityManager.isOpen()) {
             EntityManagerFactory entityManagerFactory = getEntityManagerFactory(persistenceUnitName);
@@ -124,5 +125,33 @@ public class EntityManagerHelper {
             entityManagerFactoryMap.put(persistenceUnitName, entityManagerFactory);
         }
         return entityManagerFactory;
+    }
+
+    /**
+     * Returns the refreshed result list.
+     *
+     * @param entityManager Entity Manager object
+     * @param resultList    Result List of query execution
+     * @return List of refreshed results
+     */
+    public static <T> List<T> refreshResultList(EntityManager entityManager, List<T> resultList) {
+        if (!resultList.isEmpty()) {
+            for (T entity : resultList) {
+                entityManager.refresh(entity);
+            }
+        }
+        return resultList;
+    }
+
+    /**
+     * Returns the refreshed result.
+     *
+     * @param entityManager Entity Manager object
+     * @param result        Result of query execution
+     * @return Refreshed result
+     */
+    public static <T> T refreshResult(EntityManager entityManager, T result) {
+        entityManager.refresh(result);
+        return result;
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/AbstractRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/AbstractRepository.java
@@ -19,6 +19,7 @@ package org.wso2.testgrid.dao.repository;
 
 import com.google.common.collect.LinkedListMultimap;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.SortOrder;
 import org.wso2.testgrid.dao.TestGridDAOException;
 
@@ -133,7 +134,7 @@ abstract class AbstractRepository<T> {
             //Where criteria
             criteriaQuery.where(criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()])));
             TypedQuery<T> query = entityManager.createQuery(criteriaQuery);
-            return query.getResultList();
+            return EntityManagerHelper.refreshResultList(entityManager, query.getResultList());
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil
                     .concatStrings("Error when searching for entities with the params: ", params), e);
@@ -159,7 +160,7 @@ abstract class AbstractRepository<T> {
             Root<T> rootEntry = criteriaQuery.from(entityType);
             CriteriaQuery<T> criteriaQueryAll = criteriaQuery.select(rootEntry);
             TypedQuery<T> allQuery = entityManager.createQuery(criteriaQueryAll);
-            return allQuery.getResultList();
+            return EntityManagerHelper.refreshResultList(entityManager, allQuery.getResultList());
         } catch (Exception e) {
             throw new TestGridDAOException("Error occurred when searching for entity.", e);
         }
@@ -203,7 +204,7 @@ abstract class AbstractRepository<T> {
             query = entityManager.createQuery(criteriaQuery);
             query.setParameter(parameterExpression, entry.getValue());
         }
-        return query.getResultList();
+        return EntityManagerHelper.refreshResultList(entityManager, query.getResultList());
     }
 
     /**
@@ -216,7 +217,7 @@ abstract class AbstractRepository<T> {
     List<Object> executeTypedQuery(String nativeQuery) throws TestGridDAOException {
         try {
             Query query = entityManager.createNativeQuery(nativeQuery);
-            return query.getResultList();
+            return EntityManagerHelper.refreshResultList(entityManager, query.getResultList());
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil.concatStrings("Error on executing the native SQL query [",
                     nativeQuery, "]"), e);

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/DeploymentPatternRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/DeploymentPatternRepository.java
@@ -22,6 +22,7 @@ import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.DeploymentPatternTestFailureStat;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.SortOrder;
 import org.wso2.testgrid.dao.TestGridDAOException;
 
@@ -130,7 +131,9 @@ public class DeploymentPatternRepository extends AbstractRepository<DeploymentPa
                 "dp.PRODUCT_id = '" + productId + "' GROUP BY dp.id;";
         try {
             Query query = entityManager.createNativeQuery(queryStr, DeploymentPattern.class);
-            return query.getResultList();
+            @SuppressWarnings("unchecked")
+            List<DeploymentPattern> resultList = (List<DeploymentPattern>) query.getResultList();
+            return EntityManagerHelper.refreshResultList(entityManager, resultList);
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil.concatStrings("Error on executing the native SQL" +
                     " query [", queryStr, "]"), e);
@@ -153,7 +156,9 @@ public class DeploymentPatternRepository extends AbstractRepository<DeploymentPa
                 "tp.status = '" + Status.FAIL.name() + "' GROUP BY tp.DEPLOYMENTPATTERN_id;";
         try {
             Query query = entityManager.createNativeQuery(queryStr);
-            return this.getDeploymentPatternTestFailureStats(query.getResultList());
+            @SuppressWarnings("unchecked")
+            List resultList = EntityManagerHelper.refreshResultList(entityManager, query.getResultList());
+            return this.getDeploymentPatternTestFailureStats(resultList);
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil.concatStrings("Error on executing the native SQL " +
                     "query [", queryStr, "]"), e);

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
@@ -21,6 +21,7 @@ import com.google.common.collect.LinkedListMultimap;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.ProductTestStatus;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.SortOrder;
 import org.wso2.testgrid.dao.TestGridDAOException;
 
@@ -128,7 +129,9 @@ public class ProductRepository extends AbstractRepository<Product> {
                 "tp.created_timestamp DESC;";
         try {
             Query query = entityManager.createNativeQuery(queryStr);
-            return this.getProductTestStatuses(query.getResultList());
+            @SuppressWarnings("unchecked")
+            List resultList = EntityManagerHelper.refreshResultList(entityManager, query.getResultList());
+            return this.getProductTestStatuses(resultList);
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil.concatStrings("Error on executing the native SQL" +
                     " query [", queryStr, "]"), e);

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -21,6 +21,7 @@ import com.google.common.collect.LinkedListMultimap;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.SortOrder;
 import org.wso2.testgrid.dao.TestGridDAOException;
 
@@ -129,7 +130,9 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 "tp.created_timestamp = r.maxtime AND tp.DEPLOYMENTPATTERN_id = r.DEPLOYMENTPATTERN_id;";
         try {
             Query query = entityManager.createNativeQuery(queryStr, TestPlan.class);
-            return query.getResultList();
+            @SuppressWarnings("unchecked")
+            List<TestPlan> resultList = (List<TestPlan>) query.getResultList();
+            return EntityManagerHelper.refreshResultList(entityManager, resultList);
         } catch (Exception e) {
             throw new TestGridDAOException(StringUtil.concatStrings("Error on executing the native SQL" +
                     " query [", queryStr, "]"), e);
@@ -154,7 +157,7 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 .setParameter(1, product.getId())
                 .getResultList();
         if (!resultList.isEmpty()) {
-            return (TestPlan) resultList.get(0);
+            return (TestPlan) EntityManagerHelper.refreshResult(entityManager, resultList.get(0));
         } else {
             return null;
         }
@@ -178,7 +181,7 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 .setParameter(1, product.getId())
                 .getResultList();
         if (!resultList.isEmpty()) {
-            return (TestPlan) resultList.get(0);
+            return (TestPlan) EntityManagerHelper.refreshResult(entityManager, resultList.get(0));
         } else {
             return null;
         }
@@ -199,9 +202,11 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 "group by tp.infra_parameters,dp.name) as x on t.infra_parameters=x.infra_parameters " +
                 "AND t.modified_timestamp=x.time;";
 
-        return (List<TestPlan>) entityManager.createNativeQuery(sql, TestPlan.class)
+        @SuppressWarnings("unchecked")
+        List<TestPlan> resultList = (List<TestPlan>) entityManager.createNativeQuery(sql, TestPlan.class)
                 .setParameter(1, product.getId())
                 .getResultList();
+        return EntityManagerHelper.refreshResultList(entityManager, resultList);
     }
 
     /**
@@ -220,7 +225,7 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 .getResultList();
 
         if (!resultList.isEmpty()) {
-            return (TestPlan) resultList.get(0);
+            return (TestPlan) EntityManagerHelper.refreshResult(entityManager, resultList.get(0));
         } else {
             return null;
         }
@@ -237,10 +242,13 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
         String sql = " select t.* from test_plan t inner join deployment_pattern dp inner " +
                 "join product p on p.id=dp.PRODUCT_id and dp.id=t.DEPLOYMENTPATTERN_id " +
                 "where t.infra_parameters=? AND dp.id=? AND p.id=?";
-        return entityManager.createNativeQuery(sql, TestPlan.class)
+
+        @SuppressWarnings("unchecked")
+        List<TestPlan> resultList = (List<TestPlan>) entityManager.createNativeQuery(sql, TestPlan.class)
                 .setParameter(1, testPlan.getInfraParameters())
                 .setParameter(2, testPlan.getDeploymentPattern().getId())
                 .setParameter(3, testPlan.getDeploymentPattern().getProduct().getId())
                 .getResultList();
+        return EntityManagerHelper.refreshResultList(entityManager, resultList);
     }
 }


### PR DESCRIPTION
**Purpose**
The purpose of this PR is to fix dashboard updating issue when database entry change. Further resolving inconsistency of redeploying web app when database entry change. 

Resolves #661 

**Goals**
Since Entity Manager retrieves data from its associated cache and if we completely bypass the entity manager cache for updating the database, the state held by the cache won't be updated to the updated database state. Hence in order to avoid this inconsistency, it is required to clear the cache when we retrieve date.

**Approach**
In order to get data forcefully from the database instead of caching, called refresh() method of Entity Manager for a returned entity. Further, if List of objects returned by a query is not itself an Entity. Therefore in that kind of case, in order to refresh a bunch of things, iterate through them and refresh them individually.

**User stories**
N/A

**Release note**

N/A

**Documentation**
N/A

**Training**
N/A

**Certification**
N/A

**Marketing**
N/A

**Automation tests**
 - Unit tests 
   N/A
 - Integration tests
   N/A

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Samples**
N/A

**Related PRs**
N/A

**Migrations (if applicable)**
N/A

**Test environment**
>JDK - 1.8
> OS - UBUNTU
> DB - MySQL
> Browser Chrome
 
**Learning**
N/A
