### PR TITLE
Fix dashboard accessing issue when SSO is disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Apache commons validator-->
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons.validator.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -585,5 +591,6 @@
         <commons.lang.version>2.6</commons.lang.version>
         <wso2.carbon.identity.agent.sso.version>5.1.3</wso2.carbon.identity.agent.sso.version>
         <org.opensaml.version>2.6.4</org.opensaml.version>
+        <commons.validator.version>1.6</commons.validator.version>
     </properties>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.wso2.testgrid</groupId>
             <artifactId>org.wso2.testgrid.logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+
 
         <!-- Glass fish / jersey dependencies -->
         <dependency>

--- a/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/sso/SSOSessionCheckFilter.java
@@ -62,9 +62,8 @@ public class SSOSessionCheckFilter implements Filter {
             if (Boolean.valueOf(isSsoEnabled)) {
                 if (ssoLoginUrl == null || !urlValidator.isValid(ssoLoginUrl)) {
                     throw new ServletException(
-                            StringUtil.concatStrings(ConfigurationProperties.SSO_LOGIN_URL.toString(),
-                                                     " is not set in ", TestGridConstants
-                                                             .TESTGRID_CONFIG_FILE, " or invalid url is set"));
+                            StringUtil.concatStrings("SSO login url is not set in the ", TestGridConstants
+                                    .TESTGRID_CONFIG_FILE, " or invalid url is set"));
                 }
                 String path = ((HttpServletRequest) servletRequest).getRequestURI();
                 if (isSecuredAPI(path)) {


### PR DESCRIPTION

**Purpose**
The purpose of this PR is to fix TESTGRID dashboard accessing issue when SSO is disabled. 

This resolves wso2/testgrid#694, wso2/testgrid#693

**Goals**
All requests are passing through the SSOSessionCheckFilter.  SSOSessionCheckFilter doesn't allow to access the dashboard when SSO is disabled. Hence modified the doFilter method in the SSOSessionCheckFilter to access the dashboard when disabling the SSO.

**Approach**
N/A

**User stories**
N/A

**Release note**
N/A

**Documentation**
N/A

**Training**
N/A

**Certification**
N/A

**Marketing**
N/A

**Automation tests**
 - Unit tests 
   N/A
 - Integration tests
  N/A

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Samples**
N/A

**Related PRs**
N/A

**Migrations (if applicable)**
N/A

**Test environment**
> JDK - 1.8
> OS - UBUNTU
> DB - MySQL
 
**Learning**
N/A
