### PR TITLE
Improve test-run log file name

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -30,8 +30,11 @@ public class TestGridConstants {
     public static final String TESTGRID_YAML = "testgrid.yaml";
     public static final String TEST_PLAN_YAML_PREFIX = "test-plan";
 
-    public static final String TEST_LOG_FILE_NAME = "test-run.log";
+    public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";
+    public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";
+    public static final String FILE_SEPARATOR = "/";
+    public static final String LOG_FILE_EXTENSION = ".log";
 
     public static final String WORKSPACE = "workspace";
     public static final String TESTGRID_JOB_DIR = "jobs";

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -387,4 +387,14 @@ public final class TestGridUtil {
     public static Path getConfigFilePath() throws IOException {
         return Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_CONFIG_FILE);
     }
+
+    /**
+     * Returns the path of the log file.
+     *
+     * @param productName product name
+     * @return log file path
+     */
+    public static String deriveLogFilePath(String productName, String logFileName) {
+        return Paths.get(productName, TestGridConstants.TESTGRID_LOGS_DIR, logFileName).toString();
+    }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -68,6 +68,7 @@ import static org.wso2.testgrid.common.TestGridConstants.TESTGRID_HOME_SYSTEM_PR
 public final class TestGridUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGridUtil.class);
+    private static final String UNDERSCORE = "_";
 
     /**
      * Executes a command.
@@ -396,5 +397,14 @@ public final class TestGridUtil {
      */
     public static String deriveLogFilePath(String productName, String logFileName) {
         return Paths.get(productName, TestGridConstants.TESTGRID_LOGS_DIR, logFileName).toString();
+    }
+
+    public static String deriveTestRunLogFileName(TestPlan testPlan) throws TestGridException {
+        DeploymentPattern deploymentPattern = testPlan.getDeploymentPattern();
+        int testRunNumber = testPlan.getTestRunNumber();
+        String deploymentDir = deploymentPattern.getName();
+        String infraDir = getInfraParamUUID(testPlan.getInfraParameters());
+
+        return StringUtil.concatStrings(deploymentDir, UNDERSCORE, infraDir, UNDERSCORE, String.valueOf(testRunNumber));
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
@@ -22,13 +22,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.ProductUOW;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
+import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 
 import java.util.List;
 
@@ -55,6 +58,9 @@ public class FinalizeRunTestplan implements Command {
 
     @Override
     public void execute() throws CommandExecutionException {
+
+        LogFilePathLookup.setLogFilePath(
+                TestGridUtil.deriveLogFilePath(productName, TestGridConstants.TESTGRID_LOG_FILE_NAME));
 
         logger.info("Finalizing testplans...");
         List<TestPlan> testPlans = testPlanUOW.getLatestTestPlans(getProduct(productName));

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateReportCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateReportCommand.java
@@ -26,13 +26,12 @@ import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.ProductUOW;
 import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 import org.wso2.testgrid.reporting.ReportingException;
 import org.wso2.testgrid.reporting.TestReportEngine;
-
-import java.nio.file.Paths;
 
 /**
  * This generates a cumulative test report that consists of all test plans for a given product.
@@ -66,7 +65,8 @@ public class GenerateReportCommand implements Command {
             logger.info("Generating test result report for " + productName);
 
             Product product = getProduct(productName);
-            LogFilePathLookup.setLogFilePath(deriveLogFilePath(productName));
+            LogFilePathLookup.setLogFilePath(
+                    TestGridUtil.deriveLogFilePath(productName, TestGridConstants.TESTGRID_LOG_FILE_NAME));
             TestReportEngine testReportEngine = new TestReportEngine();
             testReportEngine.generateReport(product, showSuccess, groupBy);
         } catch (ReportingException e) {
@@ -96,16 +96,5 @@ public class GenerateReportCommand implements Command {
                     .concatStrings("Error in retrieving Product {product name: ", productName,
                             "} from the Database. This exception should not occur in the test execution flow."), e);
         }
-    }
-
-    /**
-     * Returns the path of the log file.
-     *
-     * @param productName product name
-     * @return log file path
-     */
-    private String deriveLogFilePath(String productName) {
-        String productDir = StringUtil.concatStrings(productName);
-        return Paths.get(productDir, TestGridConstants.TEST_LOG_FILE_NAME).toString();
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -146,7 +146,8 @@ public class GenerateTestPlanCommand implements Command {
     public void execute() throws CommandExecutionException {
         try {
             //Set the log file path
-            LogFilePathLookup.setLogFilePath(deriveLogFilePath(productName));
+            LogFilePathLookup.setLogFilePath(
+                    TestGridUtil.deriveLogFilePath(productName, TestGridConstants.TESTGRID_LOG_FILE_NAME));
 
             if (!StringUtil.isStringNullOrEmpty(testgridYamlLocation)) {
                 logger.warn("--testConfig / -tc is deprecated. Use --file instead.");
@@ -612,17 +613,6 @@ public class GenerateTestPlanCommand implements Command {
             logger.info(StringUtil.concatStrings("Removing test directory : ", directory.toAbsolutePath().toString()));
             FileUtils.forceDelete(new File(directory.toString()));
         }
-    }
-
-    /**
-     * Returns the path of the log file.
-     *
-     * @param productName product name
-     * @return log file path
-     */
-    private String deriveLogFilePath(String productName) {
-        String productDir = StringUtil.concatStrings(productName);
-        return Paths.get(productDir, "testgrid").toString();
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -114,11 +114,9 @@ public class RunTestPlanCommand implements Command {
                 persistTestPlan(testPlan);
 
                 //Create logging directory
-                Path testRunDirectory = TestGridUtil.getTestRunWorkspace(testPlan);
-                String[] subStrings = testRunDirectory.toString().split(TestGridConstants.FILE_SEPARATOR, 2);
-                String logFileName = subStrings[1].replaceAll(TestGridConstants.FILE_SEPARATOR, "_")
-                        + TestGridConstants.LOG_FILE_EXTENSION;
-                LogFilePathLookup.setLogFilePath(TestGridUtil.deriveLogFilePath(subStrings[0], logFileName));
+                String productName = testPlan.getDeploymentPattern().getProduct().getName();
+                LogFilePathLookup.setLogFilePath(
+                        TestGridUtil.deriveLogFilePath(productName, TestGridUtil.deriveTestRunLogFileName(testPlan)));
 
                 executeTestPlan(testPlan, infrastructureConfig);
             } else {

--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -22,15 +22,15 @@
         <Console name="TESTGRID_CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%highlight{[%d{HH:mm:ss,SSS}] %m%ex%n}{ERROR=red, WARN=yellow}"/>
         </Console>
-        <RollingFile name="AUDIT_LOGFILE" fileName="${sys:testgrid.home}/audit.log"
-                     filePattern="${sys:testgrid.home}/audit-%d{MM-dd-yyyy}.log">
+        <RollingFile name="AUDIT_LOGFILE" fileName="${sys:testgrid.home}/logs/audit.log"
+                     filePattern="${sys:testgrid.home}/logs/audit-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
             </Policies>
         </RollingFile>
-        <RollingFile name="ERROR_LOGFILE" fileName="${sys:testgrid.home}/errors.log"
-                     filePattern="${sys:testgrid.home}/errors-%d{MM-dd-yyyy}.log">
+        <RollingFile name="ERROR_LOGFILE" fileName="${sys:testgrid.home}/logs/errors.log"
+                     filePattern="${sys:testgrid.home}/logs/errors-%d{MM-dd-yyyy}.log">
             <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/web/src/main/java/org/wso2/testgrid/web/api/LogEventSocketMediator.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/LogEventSocketMediator.java
@@ -26,11 +26,13 @@ import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
+import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 import org.wso2.testgrid.web.utils.FileWatcher;
 import org.wso2.testgrid.web.utils.FileWatcherException;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import javax.websocket.OnClose;
 import javax.websocket.OnMessage;
@@ -130,7 +132,13 @@ public class LogEventSocketMediator {
      * @throws TestGridException thrown when error on calculating the log file path
      */
     private Path getLogFilePath(TestPlan testPlan) throws TestGridException {
-        return TestGridUtil.getTestRunWorkspace(testPlan, false).resolve(TestGridConstants.TEST_LOG_FILE_NAME);
+        //Create logging directory
+        Path testRunDirectory = TestGridUtil.getTestRunWorkspace(testPlan);
+        String[] subStrings = testRunDirectory.toString().split(TestGridConstants.FILE_SEPARATOR, 2);
+        String logFileName = subStrings[1].replaceAll(TestGridConstants.FILE_SEPARATOR, "_")
+                + TestGridConstants.LOG_FILE_EXTENSION;
+        LogFilePathLookup.setLogFilePath(TestGridUtil.deriveLogFilePath(subStrings[0], logFileName));
+        return Paths.get(TestGridUtil.getTestGridHomePath(), subStrings[0], logFileName);
     }
 
     /**

--- a/web/src/main/java/org/wso2/testgrid/web/api/LogEventSocketMediator.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/LogEventSocketMediator.java
@@ -19,14 +19,12 @@ package org.wso2.testgrid.web.api;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
-import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 import org.wso2.testgrid.web.utils.FileWatcher;
 import org.wso2.testgrid.web.utils.FileWatcherException;
 
@@ -133,12 +131,9 @@ public class LogEventSocketMediator {
      */
     private Path getLogFilePath(TestPlan testPlan) throws TestGridException {
         //Create logging directory
-        Path testRunDirectory = TestGridUtil.getTestRunWorkspace(testPlan);
-        String[] subStrings = testRunDirectory.toString().split(TestGridConstants.FILE_SEPARATOR, 2);
-        String logFileName = subStrings[1].replaceAll(TestGridConstants.FILE_SEPARATOR, "_")
-                + TestGridConstants.LOG_FILE_EXTENSION;
-        LogFilePathLookup.setLogFilePath(TestGridUtil.deriveLogFilePath(subStrings[0], logFileName));
-        return Paths.get(TestGridUtil.getTestGridHomePath(), subStrings[0], logFileName);
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        return Paths.get(TestGridUtil.getTestGridHomePath(), productName,
+                TestGridUtil.deriveTestRunLogFileName(testPlan));
     }
 
     /**

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -22,6 +22,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestCase;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.config.ConfigurationContext;
@@ -43,7 +44,6 @@ import org.wso2.testgrid.web.operation.JenkinsPipelineManager;
 import org.wso2.testgrid.web.plugins.AWSArtifactReader;
 import org.wso2.testgrid.web.plugins.ArtifactReadable;
 import org.wso2.testgrid.web.plugins.ArtifactReaderException;
-import org.wso2.testgrid.web.utils.Constants;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -165,8 +165,12 @@ public class TestPlanService {
             TestPlan testPlan = optionalTestPlan.get();
 
             String testGridArtifactLocation = TestGridUtil.getTestRunWorkspace(testPlan).toString();
+            String[] subStrings = testGridArtifactLocation.split(TestGridConstants.FILE_SEPARATOR, 2);
+            String logFileName = subStrings[1].replaceAll(TestGridConstants.FILE_SEPARATOR, "_")
+                    + TestGridConstants.LOG_FILE_EXTENSION;
+            String logFileDir = Paths.get(subStrings[0], TestGridConstants.TESTGRID_LOGS_DIR).toString();
             String bucketKey = Paths
-                    .get(AWS_BUCKET_ARTIFACT_DIR, testGridArtifactLocation, Constants.TEST_LOG_FILE_NAME).toString();
+                    .get(AWS_BUCKET_ARTIFACT_DIR, logFileDir, logFileName).toString();
             // In future when TestGrid is deployed in multiple regions, builds may run in different regions.
             // Then AWS_REGION_NAME will to be moved to a per-testplan parameter.
             ArtifactReadable artifactDownloadable = new AWSArtifactReader(ConfigurationContext.


### PR DESCRIPTION
**Purpose**

Contains changes related to making the test-run log file name more context aware.

**Goals**

Improve logging implementation.

**Approach**

The new log file will be named as `<testgrid-home>/<product-name>/logs/<deployment_pattern>_<infrastructure-combination/uuid>_<build-number>.log`

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes