### PR TITLE
Support persisting Jenkins build number

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -154,18 +154,18 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     }
 
     /**
-     * Returns the test run number.
+     * Returns the build number.
      *
-     * @return test run number
+     * @return Jenkins build number
      */
     public int getBuildNumber() {
         return buildNumber;
     }
 
     /**
-     * Sets the test run number.
+     * Sets the build number.
      *
-     * @param buildNumber test run number
+     * @param buildNumber Jenkins build number
      */
     public void setBuildNumber(int buildNumber) {
         this.buildNumber = buildNumber;

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -56,7 +56,7 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
      */
     public static final String STATUS_COLUMN = "status";
     public static final String DEPLOYMENT_PATTERN_COLUMN = "deploymentPattern";
-    public static final String TESTRUN_NUMBER_COLUMN = "testRunNumber";
+    public static final String BUILD_NUMBER = "buildNumber";
 
     private static final long serialVersionUID = 9208083074380972876L;
 
@@ -67,8 +67,8 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     @Column(name = "infra_parameters")
     private String infraParameters;
 
-    @Column(name = "test_run_number")
-    private int testRunNumber;
+    @Column(name = "build_number")
+    private int buildNumber;
 
     @ManyToOne(optional = false, cascade = CascadeType.ALL, targetEntity = DeploymentPattern.class,
                fetch = FetchType.LAZY)
@@ -158,17 +158,17 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
      *
      * @return test run number
      */
-    public int getTestRunNumber() {
-        return testRunNumber;
+    public int getBuildNumber() {
+        return buildNumber;
     }
 
     /**
      * Sets the test run number.
      *
-     * @param testRunNumber test run number
+     * @param buildNumber test run number
      */
-    public void setTestRunNumber(int testRunNumber) {
-        this.testRunNumber = testRunNumber;
+    public void setBuildNumber(int buildNumber) {
+        this.buildNumber = buildNumber;
     }
 
     /**
@@ -303,7 +303,7 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
         return StringUtil.concatStrings("TestPlan{",
                 "id='", id, "\'",
                 ", status='", status, "\'",
-                ", testRunNumber='", testRunNumber, "\'",
+                ", buildNumber='", buildNumber, "\'",
                 ", createdTimestamp='", createdTimestamp, "\'",
                 ", modifiedTimestamp='", modifiedTimestamp, "\'",
                 ", deploymentPattern='", deploymentPattern, "\'",
@@ -327,7 +327,7 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
             testPlan.setScenarioConfig(scenarioConfig);
             testPlan.setStatus(status);
             testPlan.setScenarioTestsRepository(scenarioTestsRepository);
-            testPlan.setTestRunNumber(testRunNumber);
+            testPlan.setBuildNumber(buildNumber);
             testPlan.setTestScenarios(testScenarios);
 
             return testPlan;

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -374,7 +374,7 @@ public final class TestGridUtil {
 
     public static String deriveTestRunLogFileName(TestPlan testPlan) throws TestGridException {
         DeploymentPattern deploymentPattern = testPlan.getDeploymentPattern();
-        int testRunNumber = testPlan.getTestRunNumber();
+        int testRunNumber = testPlan.getBuildNumber();
         String deploymentDir = deploymentPattern.getName();
         String infraDir = getInfraParamUUID(testPlan.getInfraParameters());
 

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -47,9 +47,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -232,7 +229,7 @@ public final class TestGridUtil {
     public static Path getTestRunWorkspace(TestPlan testPlan, boolean relative) throws TestGridException {
         DeploymentPattern deploymentPattern = testPlan.getDeploymentPattern();
         Product product = deploymentPattern.getProduct();
-        int testRunNumber = testPlan.getTestRunNumber();
+        int buildNumber = testPlan.getBuildNumber();
 
         String productDir = product.getName();
         String deploymentDir = deploymentPattern.getName();
@@ -243,7 +240,7 @@ public final class TestGridUtil {
             dirPrefix = getTestGridHomePath();
         }
 
-        return Paths.get(dirPrefix, productDir, deploymentDir, infraDir, String.valueOf(testRunNumber));
+        return Paths.get(dirPrefix, productDir, deploymentDir, infraDir, String.valueOf(buildNumber));
     }
 
     /**
@@ -300,7 +297,7 @@ public final class TestGridUtil {
      * @param testPlan          testPlan object
      * @return TestPlan object model
      */
-    public static TestPlan toTestPlanEntity(DeploymentPattern deploymentPattern, TestPlan testPlan)
+    public static TestPlan toTestPlanEntity(DeploymentPattern deploymentPattern, TestPlan testPlan, int buildNo)
             throws CommandExecutionException {
         try {
             String jsonInfraParams = new ObjectMapper()
@@ -317,9 +314,8 @@ public final class TestGridUtil {
             testPlanEntity.setInfraParameters(jsonInfraParams);
             deploymentPattern.addTestPlan(testPlanEntity);
 
-            // Set test run number
-            int latestTestRunNumber = getLatestTestRunNumber(deploymentPattern, testPlanEntity.getInfraParameters());
-            testPlanEntity.setTestRunNumber(latestTestRunNumber + 1);
+            // Set build number
+            testPlanEntity.setBuildNumber(buildNo);
 
             // Set test scenarios
             List<TestScenario> testScenarios = testPlan.getScenarioConfig().getScenarios();
@@ -333,29 +329,6 @@ public final class TestGridUtil {
                     .concatStrings("Error in preparing a JSON object from the given test plan infra " +
                                     "parameters: ", testPlan.getInfrastructureConfig().getParameters()), e);
         }
-    }
-
-    /**
-     * Returns the latest test run number.
-     *
-     * @param deploymentPattern deployment pattern to get the latest test run number
-     * @param infraParams       infrastructure parameters to get the latest test run number
-     * @return latest test run number
-     */
-    private static int getLatestTestRunNumber(DeploymentPattern deploymentPattern, String infraParams) {
-        // Get test plans with the same infra param
-        List<TestPlan> testPlans = new ArrayList<>();
-        for (TestPlan testPlan : deploymentPattern.getTestPlans()) {
-            if (testPlan.getInfraParameters().equals(infraParams)) {
-                testPlans.add(testPlan);
-            }
-        }
-
-        // Get the Test Plan with the latest test run number for the given infra combination
-        TestPlan latestTestPlan = Collections.max(testPlans, Comparator.comparingInt(
-                TestPlan::getTestRunNumber));
-
-        return latestTestPlan.getTestRunNumber();
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -99,6 +99,11 @@ public class GenerateTestPlanCommand implements Command {
             aliases = { "-wd" })
     private String workingDir = "";
 
+    @Option(name = "--buildNumber",
+            usage = "Provide the Jenkins Build Number.",
+            aliases = { "-bn" })
+    private int buildNo;
+
     /**
      * This is @{@link Deprecated} in favor of '--file'
      */
@@ -130,12 +135,13 @@ public class GenerateTestPlanCommand implements Command {
      * @param combinationsProvider infrastructure Combinations Provider
      * @param productUOW           the ProductUOW
      */
-    GenerateTestPlanCommand(String productName, String jobConfigFile, String workingDir,
+    GenerateTestPlanCommand(String productName, String jobConfigFile, String workingDir, int buildNo,
             InfrastructureCombinationsProvider combinationsProvider, ProductUOW productUOW,
                             DeploymentPatternUOW deploymentPatternUOW, TestPlanUOW testPlanUOW) {
         this.productName = productName;
         this.jobConfigFile = jobConfigFile;
         this.workingDir = workingDir;
+        this.buildNo = buildNo;
         this.infrastructureCombinationsProvider = combinationsProvider;
         this.productUOW = productUOW;
         this.deploymentPatternUOW = deploymentPatternUOW;
@@ -218,12 +224,12 @@ public class GenerateTestPlanCommand implements Command {
                     TestGridUtil.getDeploymentPatternName(testPlan));
 
             // Generate test plan from config
-            TestPlan testPlanEntity = TestGridUtil.toTestPlanEntity(deploymentPattern, testPlan);
+            TestPlan testPlanEntity = TestGridUtil.toTestPlanEntity(deploymentPattern, testPlan, buildNo);
 
             // Product, deployment pattern, test plan and test scenarios should be persisted
             TestPlan persistedTestPlan = testPlanUOW.persistTestPlan(testPlanEntity);
             testPlan.setId(persistedTestPlan.getId());
-            testPlan.setTestRunNumber(persistedTestPlan.getTestRunNumber());
+            testPlan.setBuildNumber(persistedTestPlan.getBuildNumber());
             //Need to set this as converting to TestPlan entity changes deployerType based on infra provisioner.
             testPlan.setDeployerType(persistedTestPlan.getDeployerType());
 

--- a/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
@@ -93,7 +93,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
 
         this.testPlan = new TestPlan();
         testPlan.setId("abc");
-        testPlan.setTestRunNumber(1);
+        testPlan.setBuildNumber(1);
 
         this.deploymentPattern = new DeploymentPattern();
         deploymentPattern.setName("default-" + random);
@@ -125,7 +125,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
                 thenReturn(Optional.of(deploymentPattern));
 
         GenerateTestPlanCommand generateTestPlanCommand = new GenerateTestPlanCommand(product.getName(),
-                jobConfigFile, workingDir, infrastructureCombinationsProvider, productUOW, deploymentPatternUOW,
+                jobConfigFile, workingDir, 1, infrastructureCombinationsProvider, productUOW, deploymentPatternUOW,
                 testPlanUOW);
         generateTestPlanCommand.execute();
 

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -126,7 +126,7 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
 
         this.testPlan = new TestPlan();
         testPlan.setId(TESTPLAN_ID);
-        testPlan.setTestRunNumber(1);
+        testPlan.setBuildNumber(1);
         testPlan.setDeploymentPattern(deploymentPattern);
         testPlan.setInfraParameters(infraParamsString);
         testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
@@ -144,7 +144,7 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         doMock();
 
         GenerateTestPlanCommand generateTestPlanCommand = new GenerateTestPlanCommand(product.getName(),
-                jobConfigFile, workingDir, infrastructureCombinationsProvider, productUOW,
+                jobConfigFile, workingDir, 100, infrastructureCombinationsProvider, productUOW,
                 deploymentPatternUOW, testPlanUOW);
         generateTestPlanCommand.execute();
 

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -1,4 +1,5 @@
 !!org.wso2.testgrid.common.TestPlan
+buildNumber: 1
 deployerType: AWS_CF
 deploymentConfig:
   deploymentPatterns:
@@ -45,6 +46,5 @@ scenarioConfig:
     testCases: [
       ]
 scenarioTestsRepository: ./src/test/resources/workspace/scenarioTests
-testRunNumber: 1
 testScenarios: [
   ]


### PR DESCRIPTION
**Purpose**

Contains changes related to persisting the Jenkins build number to the database.
Resolves #710 

**Goals**

- To clean the database periodically
- Make the report name generated for each build more context aware.

**Approach**

Replace the `test_run_number` with `build_number` in the database.
Get the build number as an input to the generate-test-plan command

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes