### PR TITLE
Improve finalize-run-testplan logic

### DIFF
--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -251,4 +251,21 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
                 .getResultList();
         return EntityManagerHelper.refreshResultList(entityManager, resultList);
     }
+
+    /**
+     * This method returns all the test plans that are older than a specified duration.
+     *
+     * @param duration duration in hours/minutes or any other time unit
+     * @param timeUnit unit of time for duration
+     * @return a List of testplans that are older than the specified time
+     */
+    public List<TestPlan> getTestPlanOlderThan(String duration, String timeUnit) {
+        String sql = StringUtil.concatStrings(
+                "select t.* from test_plan t where t.created_timestamp < NOW() - INTERVAL ",
+                duration , " ", timeUnit, " ", " and t.status = 'PENDING' or t.status = 'RUNNING' ");
+        @SuppressWarnings("unchecked")
+        List<TestPlan> resultList = (List<TestPlan>) entityManager.createNativeQuery(sql, TestPlan.class)
+                .getResultList();
+        return EntityManagerHelper.refreshResultList(entityManager, resultList);
+    }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
@@ -168,4 +168,14 @@ public class TestPlanUOW {
     public List<TestPlan> getTestPlanHistory(TestPlan testPlan) {
         return testPlanRepository.getTestPlanHistory(testPlan);
     }
+
+    /**
+     * Returns the test plans older than a specified period of time.
+     * This will be used to resolve the statuses of testplans with erroneous statuses.
+     *
+     * @return a List of TestPlans corresponding to the query
+     */
+    public List<TestPlan> getTestPlansOlderThan(String duration, String timeUnit) {
+        return testPlanRepository.getTestPlanOlderThan(duration, timeUnit);
+    }
 }


### PR DESCRIPTION
**Purpose**

Contains changes related to improving `finalize-run-testplan` command.
Resolves #713 

**Goals**

Improve `finalize-run-testplan` command: 
- to update testplans based on the Jenkins build number
- to be able to run as cron job

**Approach**

Rework the logic to expect more arguments. Considers the build number to update testplans if provided. Else, updates all the testplans that has erroneous statuses that are older than 24 hours.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes