### PR TITLE
[AWS] Testgrid infrastructure creation failed when AWS credentials are not in environment variables.

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -74,8 +74,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class AWSProvider implements InfrastructureProvider {
 
-    public static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
-    public static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     private static final String AWS_PROVIDER = "AWS";
     private static final Logger logger = LoggerFactory.getLogger(AWSProvider.class);
     private static final String AWS_REGION_PARAMETER = "region";
@@ -103,13 +101,6 @@ public class AWSProvider implements InfrastructureProvider {
 
     @Override
     public void init() throws TestGridInfrastructureException {
-        String awsIdentity = System.getenv(AWS_ACCESS_KEY_ID);
-        String awsSecret = System.getenv(AWS_SECRET_ACCESS_KEY);
-        if (StringUtil.isStringNullOrEmpty(awsIdentity) || StringUtil.isStringNullOrEmpty(awsSecret)) {
-            throw new TestGridInfrastructureException(StringUtil
-                    .concatStrings("AWS Credentials must be set as environment variables: ", AWS_ACCESS_KEY_ID,
-                            ", ", AWS_SECRET_ACCESS_KEY));
-        }
         cfScriptPreprocessor = new CloudFormationScriptPreprocessor();
         amiMapper = new AMIMapper();
     }

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -72,6 +72,8 @@ import java.util.Set;
                 })
 public class AWSProviderTest extends PowerMockTestCase {
 
+    private static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    private static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     private static final String AWS_ACCESS_KEY_ID_VALUE = "aws_key_value";
     private static final String AWS_SECRET_ACCESS_KEY_VALUE = "aws_secret_value";
 
@@ -83,8 +85,8 @@ public class AWSProviderTest extends PowerMockTestCase {
     public void testManagerCreation() throws Exception {
         //set environment variables for
         Map<String, String> map = new HashMap<>();
-        map.put(AWSProvider.AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
-        map.put(AWSProvider.AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
+        map.put(AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
+        map.put(AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
         set(map);
         AMIMapper awsAMIMapper = Mockito.mock(AMIMapper.class);
         PowerMockito.whenNew(AMIMapper.class).withAnyArguments().thenReturn(awsAMIMapper);
@@ -103,7 +105,7 @@ public class AWSProviderTest extends PowerMockTestCase {
             InterruptedException, NoSuchFieldException, IllegalAccessException {
         String secret2 = "AWS_SCERET2";
         Map<String, String> map = new HashMap<>();
-        map.put(AWSProvider.AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
+        map.put(AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
         set(map);
         //invoke without no secret key environment variable set.
         AWSProvider awsProvider = new AWSProvider();
@@ -120,8 +122,8 @@ public class AWSProviderTest extends PowerMockTestCase {
         String matchedAmi = "123464";
 
         Map<String, String> map = new HashMap<>();
-        map.put(AWSProvider.AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
-        map.put(AWSProvider.AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
+        map.put(AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
+        map.put(AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
         set(map);
         InfrastructureConfig infrastructureConfig = getDummyInfrastructureConfig(patternName);
 
@@ -208,8 +210,8 @@ public class AWSProviderTest extends PowerMockTestCase {
 
         //set environment variables for
         Map<String, String> map = new HashMap<>();
-        map.put(AWSProvider.AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
-        map.put(AWSProvider.AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
+        map.put(AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
+        map.put(AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
         set(map);
         InfrastructureConfig dummyInfrastructureConfig = getDummyInfrastructureConfig(patternName);
         File resourcePath = new File("src/test/resources");


### PR DESCRIPTION
**Purpose**
Fixed test grid infrastructure creation fail issue when AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not in environment variables.

**Goals**
Fix https://github.com/wso2/testgrid/issues/716

**Approach**
Remove unnecessary environment variable validation

**Release note**
Fixed https://github.com/wso2/testgrid/issues/716

**Automation tests**
Does not effected

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Related PRs**
https://github.com/wso2/testgrid/pull/511

**Test environment**
Ubuntu x64 16.04.4 LTS, JDK 1.8.0_171-b11, MySQL 5.7.21
