### PR TITLE
Fetch tomcat credentials from credentials plugin and archive jtl file…

### DIFF
--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -28,6 +28,8 @@ pipeline {
 
             AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
             AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+            tomcatUsername=credentials('TOMCAT_USERNAME')
+            tomcatPassword=credentials('TOMCAT_PASSWORD')
             PWD=pwd()
             JOB_CONFIG_YAML = "job-config.yaml"
             JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -114,6 +116,11 @@ pipeline {
                                 } catch (Exception err) {
                                     echo "Error : ${err}"
                                     currentBuild.result = 'FAILURE'
+                                }
+                                // Archive jtl files
+                                withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                                    // Upload artifacts to S3
+                                    s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
                                 }
                                 echo "RESULT: ${currentBuild.result}"
                             }

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
         AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+        tomcatUsername=credentials('TOMCAT_USERNAME')
+        tomcatPassword=credentials('TOMCAT_PASSWORD')
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -110,11 +112,12 @@ pipeline {
                         }
                         echo "RESULT: ${currentBuild.result}"
 
-                        // Archive artifacts
-            withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
-              // Upload artifacts to S3
-              s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.log", bucket:"jenkins-testrun-artifacts", path:"artifacts/")
-            }
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
+                        }
+
                     }
                 }
             }

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
             AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
             AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+            tomcatUsername=credentials('TOMCAT_USERNAME')
+            tomcatPassword=credentials('TOMCAT_PASSWORD')
             PWD=pwd()
             JOB_CONFIG_YAML = "job-config.yaml"
             JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -107,6 +109,11 @@ pipeline {
                             currentBuild.result = 'FAILURE'
                         }
                         echo "RESULT: ${currentBuild.result}"
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
+                        }
                     }
                 }
             }

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
         AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+        tomcatUsername=credentials('TOMCAT_USERNAME')
+        tomcatPassword=credentials('TOMCAT_PASSWORD')
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -107,6 +109,11 @@ pipeline {
                             currentBuild.result = 'FAILURE'
                         }
                         echo "RESULT: ${currentBuild.result}"
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
+                        }
                     }
                 }
             }

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
         AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+        tomcatUsername=credentials('TOMCAT_USERNAME')
+        tomcatPassword=credentials('TOMCAT_PASSWORD')
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -106,6 +108,11 @@ pipeline {
                         } catch (Exception err) {
                             echo "Error : ${err}"
                             currentBuild.result = 'FAILURE'
+                        }
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
                         }
                         echo "RESULT: ${currentBuild.result}"
                     }

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
         AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+        tomcatUsername=credentials('TOMCAT_USERNAME')
+        tomcatPassword=credentials('TOMCAT_PASSWORD')
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -107,6 +109,11 @@ pipeline {
                             currentBuild.result = 'FAILURE'
                         }
                         echo "RESULT: ${currentBuild.result}"
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
+                        }
                     }
                 }
             }

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
 
         AWS_ACCESS_KEY_ID=credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY=credentials('AWS_SECRET_ACCESS_KEY')
+        tomcatUsername=credentials('TOMCAT_USERNAME')
+        tomcatPassword=credentials('TOMCAT_PASSWORD')
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
@@ -106,6 +108,11 @@ pipeline {
                             currentBuild.result = 'FAILURE'
                         }
                         echo "RESULT: ${currentBuild.result}"
+                        // Archive jtl files
+                        withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
+                            // Upload artifacts to S3
+                            s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"jenkins-testrun-artifacts", path:"artifacts/${f.name}")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Description**

We need to fetch tomcat credentials from Jenkins and inject it to test scripts and archive the jtl files. This change will add the necessary changes to the jenkins job configurations.

