### PR TITLE
Support execution of init and cleanup scripts to provision infrastructure required for samples

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutor.java
@@ -20,11 +20,14 @@ package org.wso2.testgrid.automation.executor;
 
 import org.wso2.testgrid.automation.TestAutomationException;
 import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.Host;
+import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
-import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Interface for Test executors.
@@ -66,11 +69,16 @@ public abstract class TestExecutor {
      * @return The response of script execution.
      * @throws TestAutomationException Throws exception when there is an error executing the script.
      */
-    public String executeEnvironmentScript(Path script, DeploymentCreationResult deploymentCreationResult)
+    public int executeEnvironmentScript(Path script, DeploymentCreationResult deploymentCreationResult)
             throws TestAutomationException {
         try {
-            return TestGridUtil.executeCommand("bash " + script.toString(), null,
-                    deploymentCreationResult);
+            ShellExecutor shellExecutor = new ShellExecutor();
+            Map<String, String> environment = new HashMap<>();
+
+            for (Host host : deploymentCreationResult.getHosts()) {
+                environment.put(host.getLabel(), host.getIp());
+            }
+            return shellExecutor.executeCommand("bash " + script.toString(), environment);
         } catch (CommandExecutionException e) {
             throw new TestAutomationException("Error executing " + script.toString(), e);
         }

--- a/common/src/main/java/org/wso2/testgrid/common/InfrastructureProvider.java
+++ b/common/src/main/java/org/wso2/testgrid/common/InfrastructureProvider.java
@@ -45,7 +45,13 @@ public interface InfrastructureProvider {
      * Initialization may include usecases such as the initial log-in into a
      * cloud provider.
      */
-    void init() throws TestGridInfrastructureException;
+    void init(TestPlan testPlan) throws TestGridInfrastructureException;
+
+    /**
+     * This method can be used to cleanup any additional infrastructure provided.
+     * This should be executed after running all the scenarios.
+     */
+    void cleanup(TestPlan testPlan) throws TestGridInfrastructureException;
 
     /**
      * This method creates the necessary infrastructureConfig using the provided configuration.

--- a/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
+++ b/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
@@ -18,7 +18,6 @@
 
 package org.wso2.testgrid.common;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
@@ -74,7 +73,7 @@ public class ShellExecutor {
         @Override
         public void run() {
             new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
-                    .forEach(consumer::accept);
+                    .forEach(consumer);
         }
     }
 
@@ -94,7 +93,6 @@ public class ShellExecutor {
      * @return boolean for successful/unsuccessful command execution (success == true)
      * @throws CommandExecutionException if an {@link IOException} occurs while executing the command
      */
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public int executeCommand(String command) throws CommandExecutionException {
 
         if (logger.isDebugEnabled()) {
@@ -115,8 +113,8 @@ public class ShellExecutor {
             StreamGobbler outputStreamGobbler = new StreamGobbler(process.getInputStream(), logger::info);
             StreamGobbler errorStreamGobbler = new StreamGobbler(process.getErrorStream(), logger::error);
 
-            executor.submit(outputStreamGobbler);
-            executor.submit(errorStreamGobbler);
+            executor.execute(outputStreamGobbler);
+            executor.execute(errorStreamGobbler);
 
             return process.waitFor();
 
@@ -137,11 +135,12 @@ public class ShellExecutor {
      * Executes a shell command.
      *
      * @param command Command to execute
+     * @param environment environment variables to be set before execution of the script
      * @return boolean for successful/unsuccessful command execution (success == true)
+     *
      * @throws CommandExecutionException if an {@link IOException} occurs while executing the command
      */
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
-    public int executeCommand(String command, Map<String, String> map) throws CommandExecutionException {
+    public int executeCommand(String command, Map<String, String> environment) throws CommandExecutionException {
 
         if (logger.isDebugEnabled()) {
             logger.debug("Running shell command : " + command + ", from directory : " + workingDirectory.toString());
@@ -156,16 +155,16 @@ public class ShellExecutor {
                     processBuilder.directory(workDirectory);
                 }
             }
-            if (map.size() > 0) {
-                processBuilder.environment().putAll(map);
+            if (environment.size() > 0) {
+                processBuilder.environment().putAll(environment);
             }
             Process process = processBuilder.start();
 
             StreamGobbler outputStreamGobbler = new StreamGobbler(process.getInputStream(), logger::info);
             StreamGobbler errorStreamGobbler = new StreamGobbler(process.getErrorStream(), logger::error);
 
-            executor.submit(outputStreamGobbler);
-            executor.submit(errorStreamGobbler);
+            executor.execute(outputStreamGobbler);
+            executor.execute(errorStreamGobbler);
 
             return process.waitFor();
 

--- a/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
@@ -33,6 +33,7 @@ public class ScenarioConfig implements Serializable {
     private static final long serialVersionUID = 6295205041044769906L;
 
     private List<TestScenario> scenarios;
+    private List<Script> scripts;
 
     /**
      * This method returns the list of scenarios.
@@ -45,5 +46,15 @@ public class ScenarioConfig implements Serializable {
 
     public void setScenarios(List<TestScenario> scenarios) {
         this.scenarios = scenarios;
+    }
+
+    public List<Script> getScripts() {
+
+        return scripts;
+    }
+
+    public void setScripts(List<Script> scripts) {
+
+        this.scripts = scripts;
     }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
@@ -49,12 +49,10 @@ public class ScenarioConfig implements Serializable {
     }
 
     public List<Script> getScripts() {
-
         return scripts;
     }
 
     public void setScripts(List<Script> scripts) {
-
         this.scripts = scripts;
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -264,7 +264,6 @@ public class TestPlanExecutor {
             infrastructureProvider.release(infrastructureConfig, testPlan.getInfrastructureRepository());
             // Destroy additional infra created for test execution
             infrastructureProvider.cleanup(testPlan);
-
         } catch (TestGridInfrastructureException e) {
             throw new TestPlanExecutorException(StringUtil
                     .concatStrings("Error on infrastructure removal for deployment pattern '",

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -210,7 +210,7 @@ public class TestPlanExecutor {
             }
             InfrastructureProvider infrastructureProvider = InfrastructureProviderFactory
                     .getInfrastructureProvider(infrastructureConfig);
-            infrastructureProvider.init();
+            infrastructureProvider.init(testPlan);
             InfrastructureProvisionResult provisionResult = infrastructureProvider.provision(testPlan);
 
             provisionResult.setName(infrastructureConfig.getProvisioners().get(0).getName());
@@ -262,6 +262,9 @@ public class TestPlanExecutor {
             InfrastructureProvider infrastructureProvider = InfrastructureProviderFactory
                     .getInfrastructureProvider(infrastructureConfig);
             infrastructureProvider.release(infrastructureConfig, testPlan.getInfrastructureRepository());
+            // Destroy additional infra created for test execution
+            infrastructureProvider.cleanup(testPlan);
+
         } catch (TestGridInfrastructureException e) {
             throw new TestPlanExecutorException(StringUtil
                     .concatStrings("Error on infrastructure removal for deployment pattern '",

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -41,12 +41,14 @@ import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Host;
 import org.wso2.testgrid.common.InfrastructureProvider;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
+import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TimeOutBuilder;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.Script;
+import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.common.exception.TestGridInfrastructureException;
 import org.wso2.testgrid.common.util.LambdaExceptionUtils;
 import org.wso2.testgrid.common.util.StringUtil;
@@ -100,9 +102,46 @@ public class AWSProvider implements InfrastructureProvider {
     }
 
     @Override
-    public void init() throws TestGridInfrastructureException {
+    public void init(TestPlan testPlan) throws TestGridInfrastructureException {
         cfScriptPreprocessor = new CloudFormationScriptPreprocessor();
         amiMapper = new AMIMapper();
+        String scriptsLocation = testPlan.getScenarioTestsRepository();
+        ShellExecutor shellExecutor = new ShellExecutor(Paths.get(scriptsLocation));
+
+        if (testPlan.getScenarioConfig().getScripts() != null
+                && testPlan.getScenarioConfig().getScripts().size() > 0) {
+            for (Script script : testPlan.getScenarioConfig().getScripts()) {
+                if (Script.Phase.CREATE.equals(script.getPhase())) {
+                    try {
+                        logger.info("Provisioning additional infra");
+                        shellExecutor.executeCommand("sh " + script.getFile());
+                    } catch (CommandExecutionException e) {
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void cleanup(TestPlan testPlan) throws TestGridInfrastructureException {
+        String scriptsLocation = testPlan.getScenarioTestsRepository();
+        ShellExecutor shellExecutor = new ShellExecutor(Paths.get(scriptsLocation));
+
+        if (testPlan.getScenarioConfig().getScripts() != null
+                && testPlan.getScenarioConfig().getScripts().size() > 0) {
+            for (Script script : testPlan.getScenarioConfig().getScripts()) {
+                if (Script.Phase.DESTROY.equals(script.getPhase())) {
+                    try {
+                        shellExecutor.executeCommand("sh " + script.getFile());
+                    } catch (CommandExecutionException e) {
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -114,9 +114,14 @@ public class AWSProvider implements InfrastructureProvider {
                 if (Script.Phase.CREATE.equals(script.getPhase())) {
                     try {
                         logger.info("Provisioning additional infra");
-                        shellExecutor.executeCommand("sh " + script.getFile());
+                        int exitCode = shellExecutor.executeCommand("sh " + script.getFile());
+                        if (exitCode > 0) {
+                            throw new TestGridInfrastructureException(StringUtil.concatStrings(
+                                    "Error while executing ", script.getFile(),
+                                    ". Script exited with a non-zero exit code (exit code = ", exitCode, ")"));
+                        }
                     } catch (CommandExecutionException e) {
-                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile(), e);
                     }
                     break;
                 }
@@ -134,9 +139,14 @@ public class AWSProvider implements InfrastructureProvider {
             for (Script script : testPlan.getScenarioConfig().getScripts()) {
                 if (Script.Phase.DESTROY.equals(script.getPhase())) {
                     try {
-                        shellExecutor.executeCommand("sh " + script.getFile());
+                        int exitCode = shellExecutor.executeCommand("sh " + script.getFile());
+                        if (exitCode > 0) {
+                            throw new TestGridInfrastructureException(StringUtil.concatStrings(
+                                    "Error while executing ", script.getFile(),
+                                    ". Script exited with a non-zero exit code (exit code = ", exitCode, ")"));
+                        }
                     } catch (CommandExecutionException e) {
-                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile(), e);
                     }
                     break;
                 }

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/OpenStackProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/OpenStackProvider.java
@@ -43,7 +43,12 @@ public class OpenStackProvider implements InfrastructureProvider {
     }
 
     @Override
-    public void init() throws TestGridInfrastructureException {
+    public void init(TestPlan testPlan) throws TestGridInfrastructureException {
+        // empty
+    }
+
+    @Override
+    public void cleanup(TestPlan testPlan) throws TestGridInfrastructureException {
         // empty
     }
 

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
@@ -65,9 +65,14 @@ public class ShellScriptProvider implements InfrastructureProvider {
                 if (Script.Phase.CREATE.equals(script.getPhase())) {
                     try {
                         logger.info("Provisioning additional infra");
-                        shellExecutor.executeCommand("sh " + script.getFile());
+                        int exitCode = shellExecutor.executeCommand("sh " + script.getFile());
+                        if (exitCode > 0) {
+                            throw new TestGridInfrastructureException(StringUtil.concatStrings(
+                                    "Error while executing ", script.getFile(),
+                                    ". Script exited with a non-zero exit code (exit code = ", exitCode, ")"));
+                        }
                     } catch (CommandExecutionException e) {
-                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile(), e);
                     }
                     break;
                 }
@@ -84,9 +89,14 @@ public class ShellScriptProvider implements InfrastructureProvider {
             for (Script script : testPlan.getScenarioConfig().getScripts()) {
                 if (Script.Phase.DESTROY.equals(script.getPhase())) {
                     try {
-                        shellExecutor.executeCommand("sh " + script.getFile());
+                        int exitCode = shellExecutor.executeCommand("sh " + script.getFile());
+                        if (exitCode > 0) {
+                            throw new TestGridInfrastructureException(StringUtil.concatStrings(
+                                    "Error while executing ", script.getFile(),
+                                    ". Script exited with a non-zero exit code (exit code = ", exitCode, ")"));
+                        }
                     } catch (CommandExecutionException e) {
-                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile(), e);
                     }
                     break;
                 }

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
@@ -56,8 +56,42 @@ public class ShellScriptProvider implements InfrastructureProvider {
     }
 
     @Override
-    public void init() throws TestGridInfrastructureException {
-        // empty
+    public void init(TestPlan testPlan) throws TestGridInfrastructureException {
+        String scriptsLocation = testPlan.getScenarioTestsRepository();
+        ShellExecutor shellExecutor = new ShellExecutor(Paths.get(scriptsLocation));
+        if (testPlan.getScenarioConfig().getScripts() != null
+                && testPlan.getScenarioConfig().getScripts().size() > 0) {
+            for (Script script : testPlan.getScenarioConfig().getScripts()) {
+                if (Script.Phase.CREATE.equals(script.getPhase())) {
+                    try {
+                        logger.info("Provisioning additional infra");
+                        shellExecutor.executeCommand("sh " + script.getFile());
+                    } catch (CommandExecutionException e) {
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void cleanup(TestPlan testPlan) throws TestGridInfrastructureException {
+        String scriptsLocation = testPlan.getScenarioTestsRepository();
+        ShellExecutor shellExecutor = new ShellExecutor(Paths.get(scriptsLocation));
+        if (testPlan.getScenarioConfig().getScripts() != null
+                && testPlan.getScenarioConfig().getScripts().size() > 0) {
+            for (Script script : testPlan.getScenarioConfig().getScripts()) {
+                if (Script.Phase.DESTROY.equals(script.getPhase())) {
+                    try {
+                        shellExecutor.executeCommand("sh " + script.getFile());
+                    } catch (CommandExecutionException e) {
+                        throw new TestGridInfrastructureException("Error while executing " + script.getFile());
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     @Override

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -56,6 +56,7 @@ import org.wso2.testgrid.infrastructure.providers.aws.StackCreationWaiter;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,17 +86,18 @@ public class AWSProviderTest extends PowerMockTestCase {
     private String mockStackName = "MockStack";
 
     private TestPlan testPlan;
-    private List<Script> scripts;
-    private String scenarioRepo = "src/test/resources/scenarios";
+    private static final String scenarioRepo = Paths.get("src/test/resources/scenarios").toString();
 
     @BeforeMethod (description = "Creates a dummy testplan before running a test.")
     public void setUp() throws Exception {
         testPlan = new TestPlan();
-        scripts = new ArrayList<>();
+        List<Script> scripts = new ArrayList<>();
         Script initScript = new Script();
         initScript.setFile("init.sh");
+        initScript.setPhase(Script.Phase.CREATE);
         Script cleanupScript = new Script();
         cleanupScript.setFile("cleanup.sh");
+        cleanupScript.setPhase(Script.Phase.DESTROY);
         scripts.add(initScript);
         scripts.add(cleanupScript);
 
@@ -181,9 +183,7 @@ public class AWSProviderTest extends PowerMockTestCase {
         PowerMockito.whenNew(StackCreationWaiter.class).withAnyArguments().thenReturn(validatorMock);
 
         AWSProvider awsProvider = new AWSProvider();
-
         awsProvider.init(testPlan);
-
         testPlan.setInfrastructureConfig(infrastructureConfig);
         testPlan.setInfrastructureRepository(resourcePath.getAbsolutePath());
         InfrastructureProvisionResult provisionResult = awsProvider
@@ -212,20 +212,6 @@ public class AWSProviderTest extends PowerMockTestCase {
         provisioner.setScripts(Collections.singletonList(script));
         infrastructureConfig.setProvisioners(Collections.singletonList(provisioner));
         return infrastructureConfig;
-    }
-
-    private ScenarioConfig getDummyScenarioConfig(String patternName) {
-        //create dummy script object
-        Script initScript = new Script();
-        initScript.setFile("init.sh");
-        Script cleanupScript = new Script();
-        cleanupScript.setFile("cleanup.sh");
-        scripts.add(initScript);
-        scripts.add(cleanupScript);
-
-        ScenarioConfig scenarioConfig = new ScenarioConfig();
-        scenarioConfig.setScripts(scripts);
-        return scenarioConfig;
     }
 
     @Test(description = "This test case tests destroying infrastructure given a already built stack name.")

--- a/infrastructure/src/test/resources/scenarios/cleanup.sh
+++ b/infrastructure/src/test/resources/scenarios/cleanup.sh
@@ -19,5 +19,7 @@
 #
 # ----------------------------------------------------------------------------
 
+set -e
+
 # Test init.sh script to run before running scenarios
 echo "Running cleanup.sh test script"

--- a/infrastructure/src/test/resources/scenarios/cleanup.sh
+++ b/infrastructure/src/test/resources/scenarios/cleanup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+
+# Test init.sh script to run before running scenarios
+echo "Running cleanup.sh test script"

--- a/infrastructure/src/test/resources/scenarios/init.sh
+++ b/infrastructure/src/test/resources/scenarios/init.sh
@@ -19,5 +19,7 @@
 #
 # ----------------------------------------------------------------------------
 
+set -e
+
 # Test init.sh script to run before running scenarios
 echo "Running init.sh test script"

--- a/infrastructure/src/test/resources/scenarios/init.sh
+++ b/infrastructure/src/test/resources/scenarios/init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+
+# Test init.sh script to run before running scenarios
+echo "Running init.sh test script"


### PR DESCRIPTION
**Purpose**

Standardizes the provision of infrastructure need to execute scenario tests through two scripts. 
Resolves #725

**Goals**

Provide a standardized approach to provision infrastructure required for scenario tests. Eg. tomcat deployment for IS scenarios, MSF4J services for APIM scenarios

**Approach**

Support running a `init.sh` before running scenarios to provision necessary infrastructure and a `cleanup.sh` after running scenarios to destroy provisioned infrastructure.

The scenario test repos should contains these two scripts if additional infrastructure is required and this should be specified with `scripts` element in testgrid.yaml in the same repo as follows.
```

scenarioConfig:
  scenarios:
  -
    name: scenario03
    description: 'App Development with APIs'
    dir: scenario03
  -
    name: scenario04
    description: 'API Lifecycle Management'
    dir: scenario04
  scripts:
  -
    file: "init.sh"
    phase: CREATE
  -
    file: "cleanup.sh"
    phase: DESTROY
```

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes