### PR TITLE
Add deployment-tinkerer to CD pipeline filter for copying artifacts

### DIFF
--- a/jenkins/pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins/pipelines/continuous-delivery/Jenkinsfile
@@ -1,7 +1,7 @@
 node('COMPONENT_ECS') {
     stage('Deploy to Dev'){
         deleteDir()
-        copyArtifacts(projectName: 'testgrid/testgrid', filter: 'distribution/target/*.zip, web/target/*.war, remote-session/target/*.war');
+        copyArtifacts(projectName: 'testgrid/testgrid', filter: 'distribution/target/*.zip, web/target/*.war, deployment-tinkerer/target/*.war');
         sshagent(['testgrid-dev-key']) {
             sh """
                 scp -o StrictHostKeyChecking=no web/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/ROOT.war


### PR DESCRIPTION
**Purpose**

Contains changes related to copying the deployment-tinkerer war file from latest testgrid artifacts.
Resolves #758

**Goals**

Fix failure in the execution of cd pipeline.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes