### PR TITLE
Fix the report downloading issue through the dashboard.

### DIFF
--- a/web/src/main/java/org/wso2/testgrid/web/plugins/ArtifactReadable.java
+++ b/web/src/main/java/org/wso2/testgrid/web/plugins/ArtifactReadable.java
@@ -57,4 +57,11 @@ public interface ArtifactReadable {
      */
     InputStream getArtifactStream(String key);
 
+    /**
+     * Verify the existence of the artifact for the given key.
+     *
+     * @param key           key of the artifact to download
+     * @return {@link Boolean} If artifact exist in the remote storage return True otherwise return False
+     */
+    Boolean isExistArtifact(String key);
 }

--- a/web/src/main/react-dashboard/src/components/ProductStatusView.js
+++ b/web/src/main/react-dashboard/src/components/ProductStatusView.js
@@ -80,11 +80,8 @@ class ProductStatusView extends Component {
   downloadReport(productName) {
     let url = TESTGRID_CONTEXT + '/api/products/reports?product-name=' + productName;
     fetch(url, {
-      method: "GET",
+      method: "HEAD",
       credentials: 'same-origin',
-      headers: {
-        'Accept': 'application/html'
-      }
     }).then(response => {
         if (response.status === HTTP_NOT_FOUND) {
           let errorMessage = "Unable to locate report in the remote storage, please contact the administrator.";
@@ -93,6 +90,8 @@ class ProductStatusView extends Component {
           let errorMessage = "Internal server error. Couldn't download the report at the moment, please " +
             "contact the administrator.";
           this.toggle(errorMessage);
+        } else if (response.status === HTTP_OK) {
+          document.location = url;
         }
       }
     ).catch(error => console.error(error));


### PR DESCRIPTION


**Purpose**
The purpose of this PR is to fix report downloading issue through the Test grid dashboard. This resolves #765

**Goals**
Since the report downloading API returns stream it doesn't convert to file when we invoke API through fetch. Hence added HEAD API and it verifies the existence of the report and it doesn't return a body as well. Thereafter check the response code of HEAD API invocation and invoke the GET API to download the report. The GET API will be invoked in the callback of the first request.

**Approach**
N/A

**User stories**
N/A

**Release note**
N/A

**Documentation**
N/A

**Training**
N/A

**Certification**
N/A

**Marketing**
N/A

**Automation tests**
 - Unit tests 
   N/A
 - Integration tests
   N/A

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Samples**
N/A

**Related PRs**
N/A

**Migrations (if applicable)**
N/A

**Test environment**
JDK - Oracle 1.8
OS - UBUNTU 18.04
DB - MySQL 5.7
Browser - Chrome
 
**Learning**
N/A
