### PR TITLE
Add backward-compatibility between old/new testgrid yaml file.

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -27,7 +27,7 @@ import java.nio.file.Paths;
  */
 public class TestGridConstants {
 
-    public static final String TESTGRID_YAML = ".testgrid.yaml";
+    public static final String TESTGRID_YAML = "testgrid.yaml";
     public static final String TEST_PLAN_YAML_PREFIX = "test-plan";
 
     public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -34,6 +34,7 @@ public class TestGridConstants {
     public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";
     public static final String FILE_SEPARATOR = "/";
+    public static final String HIDDEN_FILE_INDICATOR = ".";
     public static final String LOG_FILE_EXTENSION = ".log";
 
     public static final String WORKSPACE = "workspace";

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -635,13 +635,13 @@ public class GenerateTestPlanCommand implements Command {
      * @return testgrid yaml file path
      */
     private Path getTestGridYamlLocation(String directory) {
-        String hiddenFileDot = ".";
-        Path yamlPathIfHidden = Paths.get(directory, hiddenFileDot + TestGridConstants.TESTGRID_YAML);
-        Path yamlPathIfNotHidden = Paths.get(directory, TestGridConstants.TESTGRID_YAML);
-        if (Files.exists(yamlPathIfHidden)) {
-            return yamlPathIfHidden;
+        Path hiddenYamlPath = Paths.get(
+                directory, TestGridConstants.HIDDEN_FILE_INDICATOR + TestGridConstants.TESTGRID_YAML);
+        Path defaultYamlPath = Paths.get(directory, TestGridConstants.TESTGRID_YAML);
+        if (Files.exists(hiddenYamlPath)) {
+            return hiddenYamlPath;
         } else {
-            return yamlPathIfNotHidden;
+            return defaultYamlPath;
         }
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -349,19 +349,17 @@ public class GenerateTestPlanCommand implements Command {
         StringBuilder testgridYamlBuilder = new StringBuilder();
         String ls = System.lineSeparator();
         testgridYamlBuilder
-                .append(getTestgridYamlFor(Paths.get(infraRepositoryLocation, TestGridConstants.TESTGRID_YAML)))
+                .append(getTestgridYamlFor(getTestGridYamlLocation(infraRepositoryLocation)))
                 .append(ls);
         String testgridYamlContent = testgridYamlBuilder.toString().trim();
         if (!testgridYamlContent.isEmpty()) {
             if (!testgridYamlContent.contains("deploymentConfig")) {
                 testgridYamlBuilder
-                        .append(getTestgridYamlFor(
-                                Paths.get(deployRepositoryLocation, TestGridConstants.TESTGRID_YAML)))
+                        .append(getTestgridYamlFor(getTestGridYamlLocation(deployRepositoryLocation)))
                         .append(ls);
             }
             testgridYamlBuilder
-                    .append(getTestgridYamlFor(
-                            Paths.get(scenarioTestsRepositoryLocation, TestGridConstants.TESTGRID_YAML)))
+                    .append(getTestgridYamlFor(getTestGridYamlLocation(scenarioTestsRepositoryLocation)))
                     .append(ls);
         } else {
             logger.warn(StringUtil.concatStrings(
@@ -628,6 +626,22 @@ public class GenerateTestPlanCommand implements Command {
             } else {
                 return super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
             }
+        }
+    }
+
+    /**
+     * If the testgrid yaml file is hidden in the directory, change the URI as to refer the hidden file.
+     * @param directory directory where the testgrid yaml file exists
+     * @return testgrid yaml file path
+     */
+    private Path getTestGridYamlLocation(String directory) {
+        String hiddenFileDot = ".";
+        Path yamlPathIfHidden = Paths.get(directory, hiddenFileDot + TestGridConstants.TESTGRID_YAML);
+        Path yamlPathIfNotHidden = Paths.get(directory, TestGridConstants.TESTGRID_YAML);
+        if (Files.exists(yamlPathIfHidden)) {
+            return yamlPathIfHidden;
+        } else {
+            return yamlPathIfNotHidden;
         }
     }
 }


### PR DESCRIPTION
**Purpose**
Since testgrid.yaml only has a usage within TestGrid, it is been kept hidden with recent updates.
But however we should still support if the testgrid.yaml is not hidden.
Fixes #767
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Keep backward compatibility with old configurations.
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
When referring to testgrid yaml file, check if there exists a testgrid yaml file as a hidden file. If so, proceed with that.
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Related PRs**
#760
<!-- List any other related PRs -->
