### PR TITLE
Auto generate run-scenario script file for test scenarios

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -30,6 +30,11 @@ public class TestGridConstants {
     public static final String TESTGRID_YAML = "testgrid.yaml";
     public static final String TEST_PLAN_YAML_PREFIX = "test-plan";
 
+    public static final String RUN_SCENARIO_SCRIPT = "run-scenario.sh";
+    public static final String RUN_SCENARIO_SCRIPT_TEMPLATE = "run-scenarioTemplate.vm";
+    public static final String JMETER_FOLDER = "jmeter";
+    public static final String JMETER_FILE_FILTER_PATTERN = "*.jmx";
+
     public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";
     public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";

--- a/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
@@ -17,11 +17,22 @@
  */
 package org.wso2.testgrid.common.util;
 
+import org.wso2.testgrid.common.exception.TestGridException;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class for handling file operations.
@@ -46,6 +57,44 @@ public class FileUtil {
 
         try (FileInputStream fileInputStream = new FileInputStream(new File(location))) {
             return new Yaml().loadAs(fileInputStream, type);
+        }
+    }
+
+    /**
+     * This method returns the list of files in a given directory after filtering a given glob pattern.
+     * @param directory the directory in which the files should be look-up
+     * @param glob the glob pattern to be filtered
+     * @return list of files
+     * @throws TestGridException thrown when an error occurred while accessing files on directory.
+     */
+    public static List<String> getFilesOnDirectory(String directory, String glob) throws TestGridException {
+        List<String> files = new ArrayList<>();
+        try {
+            DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(directory), glob);
+            for (Path entry : stream) {
+                files.add(entry.toString());
+            }
+        } catch (IOException e) {
+            throw new TestGridException("Error occurred while getting files on directory + " + directory, e);
+        }
+        return files;
+    }
+
+    /**
+     * Saves the content to a file with the given name in the given file path.
+     *
+     * @param content  content to write in the file
+     * @param filePath location to save the file
+     * @param fileName name of the file
+     * @throws TestGridException thrown when error on persisting file
+     */
+    public static void saveFile(String content, String filePath, String fileName) throws TestGridException {
+        String fileAbsolutePath = Paths.get(filePath, fileName).toAbsolutePath().toString();
+        try (OutputStream outputStream = new FileOutputStream(fileAbsolutePath);
+             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            outputStreamWriter.write(content);
+        } catch (IOException e) {
+            throw new TestGridException(StringUtil.concatStrings("Error in writing file ", fileName), e);
         }
     }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
@@ -69,8 +69,7 @@ public class FileUtil {
      */
     public static List<String> getFilesOnDirectory(String directory, String glob) throws TestGridException {
         List<String> files = new ArrayList<>();
-        try {
-            DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(directory), glob);
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(directory), glob)) {
             for (Path entry : stream) {
                 files.add(entry.toString());
             }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,5 +119,9 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -33,6 +33,7 @@ import org.wso2.testgrid.common.config.JobConfigFile;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.config.TestgridYaml;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.exception.TestGridRuntimeException;
 import org.wso2.testgrid.common.infrastructure.InfrastructureCombination;
 import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
@@ -54,10 +55,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -233,7 +231,11 @@ public class GenerateTestPlanCommand implements Command {
 
             //Remove reference ids from yaml
             output = output.replaceAll("[&,*]id[0-9]+", "");
-            saveFile(output, infraGenDirectory, fileName);
+            try {
+                FileUtil.saveFile(output, infraGenDirectory, fileName);
+            } catch (TestGridException e) {
+                throw new CommandExecutionException("Error while saving Testgrid yaml file.", e);
+            }
 
             /*
              * Test plans of test scenarios should be persisted. This is persisted after building the
@@ -459,24 +461,6 @@ public class GenerateTestPlanCommand implements Command {
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setPrettyFlow(true);
         return new Yaml(new NullRepresenter(), options);
-    }
-
-    /**
-     * Saves the content to a file with the given name in the given file path.
-     *
-     * @param content  content to write in the file
-     * @param filePath location to save the file
-     * @param fileName name of the file
-     * @throws CommandExecutionException thrown when error on persisting file
-     */
-    private void saveFile(String content, String filePath, String fileName) throws CommandExecutionException {
-        String fileAbsolutePath = Paths.get(filePath, fileName).toAbsolutePath().toString();
-        try (OutputStream outputStream = new FileOutputStream(fileAbsolutePath);
-                OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
-            outputStreamWriter.write(content);
-        } catch (IOException e) {
-            throw new CommandExecutionException(StringUtil.concatStrings("Error in writing file ", fileName), e);
-        }
     }
 
     /**

--- a/core/src/main/resources/run-scenarioTemplate.vm
+++ b/core/src/main/resources/run-scenarioTemplate.vm
@@ -1,0 +1,25 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+
+#set($d = "$")
+#foreach( $script in $scripts )
+${d}JMETER_HOME/bin/jmeter.sh -n -t "$script" -p resources/user.properties
+#end

--- a/pom.xml
+++ b/pom.xml
@@ -551,6 +551,11 @@
                 <artifactId>mysql-connector-java</artifactId>
                 <version>6.0.6</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity</artifactId>
+                <version>${apache.velocity.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -590,6 +595,7 @@
         <apache.httpcomponents.fluent.version>5.0-alpha3</apache.httpcomponents.fluent.version>
         <apache.commons.io.version>2.6</apache.commons.io.version>
         <apache.commons.collections4.version>4.1</apache.commons.collections4.version>
+        <apache.velocity.version>1.7</apache.velocity.version>
         <!-- Logging dependencies -->
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.core.version>2.8.2</log4j.core.version>


### PR DESCRIPTION
**Purpose**
When there is no run-scenario.sh file is provided with a scenario, testgrid have to make one including the available test-scripts.
Fixes #745 
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Approach**
Receive list of test-script files and prepare run-scenario script using apache-velocity.
The test-scripts will be added in alphabetical order.
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes