### PR TITLE
Fix the alternative directory creating and scenario test running failure for the same job

### DIFF
--- a/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
@@ -105,7 +105,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "getJobConfigData")
-    public void testExecute(String jobConfigFileLocation, String workingDir) throws Exception {
+    public void testExecute(String jobConfigFileLocation) throws Exception {
         infrastructureCombinationsProvider = mock(InfrastructureCombinationsProvider.class);
         productUOW = mock(ProductUOW.class);
         deploymentPatternUOW = mock(DeploymentPatternUOW.class);
@@ -128,7 +128,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
                 thenReturn(Optional.of(deploymentPattern));
 
         GenerateTestPlanCommand generateTestPlanCommand = new GenerateTestPlanCommand(product.getName(),
-                jobConfigFileLocation, workingDir, infrastructureCombinationsProvider, productUOW, deploymentPatternUOW,
+                jobConfigFileLocation, infrastructureCombinationsProvider, productUOW, deploymentPatternUOW,
                 testPlanUOW);
         generateTestPlanCommand.execute();
 
@@ -161,8 +161,8 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
     @DataProvider
     public Object[][] getJobConfigData() {
         return new Object[][] {
-                { "src/test/resources/job-config.yaml", "." },
-                { "src/test/resources/job-config2.yaml", "" }
+                { "src/test/resources/job-config.yaml" },
+                { "src/test/resources/job-config2.yaml" }
         };
     }
 

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -140,11 +140,11 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "getJobConfigData")
-    public void testExecute(String jobConfigFile, String workingDir) throws Exception {
+    public void testExecute(String jobConfigFile) throws Exception {
         doMock();
 
         GenerateTestPlanCommand generateTestPlanCommand = new GenerateTestPlanCommand(product.getName(),
-                jobConfigFile, workingDir, infrastructureCombinationsProvider, productUOW,
+                jobConfigFile, infrastructureCombinationsProvider, productUOW,
                 deploymentPatternUOW, testPlanUOW);
         generateTestPlanCommand.execute();
 
@@ -208,8 +208,8 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     @DataProvider
     public Object[][] getJobConfigData() {
         return new Object[][] {
-                { "src/test/resources/job-config.yaml", "." },
-                { "src/test/resources/job-config2.yaml", "" }
+                { "src/test/resources/job-config.yaml" },
+                { "src/test/resources/job-config2.yaml" }
         };
     }
 

--- a/core/src/test/resources/job-config.yaml
+++ b/core/src/test/resources/job-config.yaml
@@ -1,4 +1,4 @@
-infrastructureRepository: src/test/resources/workspace/infrastructure
-deploymentRepository: src/test/resources/workspace/deployment
-scenarioTestsRepository: src/test/resources/workspace/scenarioTests
-testgridYamlLocation: src/test/resources/workspace/testgrid.yaml
+infrastructureRepository: workspace/infrastructure
+deploymentRepository: workspace/deployment
+scenarioTestsRepository: workspace/scenarioTests
+testgridYamlLocation: workspace/testgrid.yaml

--- a/jenkins/pipelines/Jenkinsfile
+++ b/jenkins/pipelines/Jenkinsfile
@@ -80,8 +80,7 @@ pipeline {
                 cd ${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -99,7 +98,7 @@ pipeline {
                         cd ${TESTGRID_NAME}
                         ./testgrid run-testplan \
                             --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/${PRODUCT}/test-plans/test-plan-01.yaml"
+                            --file "${PWD}/test-plans/test-plan-01.yaml"
                         """
                     } catch (Exception err) {
                         echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -84,8 +84,7 @@ pipeline {
                 cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -111,7 +110,7 @@ pipeline {
                                     git clean -f
                                     cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                                     ./testgrid run-testplan --product ${PRODUCT} \
-                                    --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                                    --file "${PWD}/test-plans/${f.name}"
                                     """
                                 } catch (Exception err) {
                                     echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -85,8 +85,7 @@ pipeline {
                     cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                     ./testgrid generate-test-plan \
                         --product ${PRODUCT} \
-                        --file ${JOB_CONFIG_YAML_PATH} \
-                        --workingDir ${PWD}
+                        --file ${JOB_CONFIG_YAML_PATH}
                     """
             }
         }
@@ -104,7 +103,7 @@ pipeline {
                             git clean -f
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -83,8 +83,7 @@ pipeline {
                 cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -102,7 +101,7 @@ pipeline {
                             git clean -f
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -83,8 +83,7 @@ pipeline {
                 cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -102,7 +101,7 @@ pipeline {
                             git clean -f
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -83,8 +83,7 @@ pipeline {
                 cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -103,7 +102,7 @@ pipeline {
                             pwd
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -83,8 +83,7 @@ pipeline {
                 cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                 ./testgrid generate-test-plan \
                     --product ${PRODUCT} \
-                    --file ${JOB_CONFIG_YAML_PATH} \
-                    --workingDir ${PWD}
+                    --file ${JOB_CONFIG_YAML_PATH}
                 """
             }
         }
@@ -102,7 +101,7 @@ pipeline {
                             git clean -f
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -82,8 +82,7 @@ pipeline {
                     cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                     ./testgrid generate-test-plan \
                         --product ${PRODUCT} \
-                        --file ${JOB_CONFIG_YAML_PATH} \
-                        --workingDir ${PWD}
+                        --file ${JOB_CONFIG_YAML_PATH}
                     """
             }
         }
@@ -101,7 +100,7 @@ pipeline {
                             git clean -f
                             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
                             ./testgrid run-testplan --product ${PRODUCT} \
-                            --file "${TESTGRID_HOME}/jobs/${PRODUCT}/test-plans/${f.name}"
+                            --file "${PWD}/test-plans/${f.name}"
                             """
                         } catch (Exception err) {
                             echo "Error : ${err}"


### PR DESCRIPTION
**Purpose**

The purpose of this PR is to resolve alternative directory creating and scenario test running failure for the same job.  

This resolves #757

<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**

In order to fix this issue modified the test plans creating command. Therefore removed 'working-dir' parameter in the test plans creating command. When creating test plans read the file path of the job-config.yaml and if it contains 'TestGrid_Home/jobs/*' pattern, create test-plans directory and test plans yaml files inside the parent directory of job-config.yaml. Otherwise, create a directory inside the TestGrid_Home/jobs and name it as <Product_Name> and use it to create and store test-plans directory and test plans.

**Approach**
N/A

**User stories**
N/A

**Release note**
N/A

**Documentation**
N/A

**Training**
N/A

**Certification**
N/A

**Marketing**
N/A

**Automation tests**
 - Unit tests 
   N/A
 - Integration tests
   N/A

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Samples**
N/A

**Related PRs**
N/A

**Migrations (if applicable)**
N/A

**Test environment**
>JDK - 1.8
>OS - UBUNTU-18.04
 
**Learning**
N/A