### PR TITLE
Print a summary of the execution at the end of run-testplan

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
@@ -25,12 +25,14 @@ import org.wso2.testgrid.automation.parser.JMeterResultParser;
 import org.wso2.testgrid.automation.parser.JMeterResultParserException;
 import org.wso2.testgrid.automation.parser.JMeterResultParserFactory;
 import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
-import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.common.util.EnvironmentUtil;
+import org.wso2.testgrid.common.util.StringUtil;
 
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
@@ -41,6 +43,7 @@ import java.util.Optional;
 public class JMeterExecutor extends TestExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(JMeterExecutor.class);
+    public static final String JMETER_HOME = "JMETER_HOME";
     private String testLocation;
     private String testName;
     private TestScenario testScenario;
@@ -57,7 +60,21 @@ public class JMeterExecutor extends TestExecutor {
             throws TestAutomationException {
         try {
 
-            TestGridUtil.executeCommand("bash " + script, new File(testLocation));
+            String jmeterHome = EnvironmentUtil.getSystemVariableValue(JMETER_HOME);
+            if (jmeterHome == null) {
+                logger.error(JMETER_HOME + " environment variable is not set. JMeter test execution may fail.");
+            } else {
+                logger.info(JMETER_HOME + ": " + jmeterHome);
+            }
+
+            ShellExecutor shellExecutor = new ShellExecutor(Paths.get(testLocation));
+            int exitCode = shellExecutor.executeCommand("bash " + script);
+
+            if (exitCode > 0) {
+                logger.error(StringUtil.concatStrings("Error occurred while executing the test: ", testName, ", at: ",
+                        testScenario.getDir(), ". Script exited with a status code of ", exitCode));
+            }
+
             //Parse JTL file
             Optional<JMeterResultParser> parser = JMeterResultParserFactory.getParser(this.testScenario, testLocation);
             if (parser.isPresent()) {

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
@@ -51,8 +51,7 @@ public class FunctionalTestResultParser extends JMeterResultParser {
     private static final String SAMPLE_ELEMENT = "sample";
     private static final String FAILURE_MESSAGE_ELEMENT = "failureMessage";
     private static final String TEST_NAME_ATTRIBUTE = "lb";
-    private static final String TEST_STATUS_ATTRIBUTE = "ec";
-    private static final String TEST_STATUS_FAIL = "1";
+    private static final String TEST_SUCCESS_ATTRIBUTE = "s";
 
     public FunctionalTestResultParser(TestScenario testScenario, String testLocation) {
         super(testScenario, testLocation);
@@ -136,12 +135,8 @@ public class FunctionalTestResultParser extends JMeterResultParser {
             Attribute attribute = attributes.next();
             if (TEST_NAME_ATTRIBUTE.equals(attribute.getName().getLocalPart())) {
                 testCase.setName(attribute.getValue());
-            } else if (TEST_STATUS_ATTRIBUTE.equals(attribute.getName().getLocalPart())) {
-                if (TEST_STATUS_FAIL.equals(attribute.getValue())) {
-                    testCase.setSuccess(false);
-                } else {
-                    testCase.setSuccess(true);
-                }
+            } else if (TEST_SUCCESS_ATTRIBUTE.equals(attribute.getName().getLocalPart())) {
+                testCase.setSuccess(Boolean.valueOf(attribute.getValue()));
             }
         }
         return testCase;

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/JMeterResultParserFactory.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/JMeterResultParserFactory.java
@@ -19,12 +19,16 @@
 package org.wso2.testgrid.automation.parser;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.TestScenario;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Optional;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -38,6 +42,8 @@ import javax.xml.stream.events.XMLEvent;
  * @since 1.0.0
  */
 public class JMeterResultParserFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(JMeterResultParserFactory.class);
 
     /**
      * This method returns an instance of {@link JMeterResultParser} to parse the given JMeter result file.
@@ -53,6 +59,11 @@ public class JMeterResultParserFactory {
         XMLInputFactory factory = XMLInputFactory.newInstance();
         String testScenarioName = testScenario.getName();
         String scenarioResultFile = JMeterParserUtil.getJTLFile(testLocation);
+        if (scenarioResultFile == null || scenarioResultFile.isEmpty() || !Files
+                .exists(Paths.get(scenarioResultFile))) {
+            logger.warn("A JMeter result output file (*.jtl) was not found for scenario: " + testScenarioName);
+            return Optional.empty();
+        }
         try (InputStream inputStream = new FileInputStream(scenarioResultFile)) {
             XMLEventReader eventReader = factory.createXMLEventReader(inputStream);
 

--- a/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
+++ b/common/src/main/java/org/wso2/testgrid/common/ShellExecutor.java
@@ -96,7 +96,7 @@ public class ShellExecutor {
     public int executeCommand(String command) throws CommandExecutionException {
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Running shell command : " + command + ", from directory : " + workingDirectory.toString());
+            logger.debug("Running shell command : " + command + ", from working directory : " + workingDirectory);
         }
         ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", "-c", command);
         ExecutorService executor = Executors.newFixedThreadPool(2);

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -71,6 +71,8 @@ public final class TestGridUtil {
     private static final String UNDERSCORE = "_";
 
     /**
+     * Use {@link org.wso2.testgrid.common.ShellExecutor#executeCommand(String)} instead.
+     *
      * Executes a command.
      * Used to executing a script in a given working directory.
      *
@@ -79,6 +81,7 @@ public final class TestGridUtil {
      * @return The output of script execution as a String.
      * @throws CommandExecutionException When there is an error executing the command.
      */
+    @Deprecated
     public static String executeCommand(String command, File workingDirectory) throws CommandExecutionException {
 
         if (logger.isDebugEnabled()) {
@@ -116,6 +119,8 @@ public final class TestGridUtil {
     }
 
     /**
+     * Use {@link org.wso2.testgrid.common.ShellExecutor#executeCommand(String)} instead.
+     *
      * Executes a command.
      * Used to execute a script with given deployment details as environment variables.
      *
@@ -125,6 +130,7 @@ public final class TestGridUtil {
      * @return The output of script execution as a String.
      * @throws CommandExecutionException When there is an error executing the command.
      */
+    @Deprecated
     public static String executeCommand(String command, File workingDirectory,
             DeploymentCreationResult deploymentCreationResult)
             throws CommandExecutionException {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,6 +81,15 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.testgrid.core;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Deployer;
@@ -44,6 +45,9 @@ import org.wso2.testgrid.deployment.DeployerFactory;
 import org.wso2.testgrid.infrastructure.InfrastructureProviderFactory;
 
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class is responsible for executing the provided TestPlan.
@@ -52,7 +56,9 @@ import java.nio.file.Paths;
  */
 public class TestPlanExecutor {
 
+    public static final int LINE_LENGTH = 72;
     private static final Logger logger = LoggerFactory.getLogger(TestPlanExecutor.class);
+    private static final int MAX_NAME_LENGTH = 52;
     private TestScenarioUOW testScenarioUOW;
     private TestPlanUOW testPlanUOW;
     private ScenarioExecutor scenarioExecutor;
@@ -78,6 +84,8 @@ public class TestPlanExecutor {
      */
     public void execute(TestPlan testPlan, InfrastructureConfig infrastructureConfig)
             throws TestPlanExecutorException, TestGridDAOException {
+        long startTime = System.currentTimeMillis();
+
         // Provision infrastructure
         InfrastructureProvisionResult infrastructureProvisionResult = provisionInfrastructure(infrastructureConfig,
                 testPlan);
@@ -106,12 +114,16 @@ public class TestPlanExecutor {
 
         //cleanup
         releaseInfrastructure(testPlan, infrastructureProvisionResult, deploymentCreationResult);
+
+        // Print summary
+        printSummary(testPlan, System.currentTimeMillis() - startTime);
+
     }
 
     /**
      * Run all the scenarios mentioned in the testgrid.yaml.
      *
-     * @param testPlan the test plan
+     * @param testPlan                 the test plan
      * @param deploymentCreationResult the result of the previous build step
      */
     private void runScenarioTests(TestPlan testPlan, DeploymentCreationResult deploymentCreationResult) {
@@ -350,4 +362,129 @@ public class TestPlanExecutor {
                     "Error while persisting test scenario ", testScenario.getName(), e));
         }
     }
+
+    /**
+     * Prints a summary of the executed test plan.
+     * Summary includes the list of scenarios that has been run, and their pass/fail status.
+     *
+     * @param testPlan the test plan
+     * @param totalTime time taken to run the test plan
+     */
+    void printSummary(TestPlan testPlan, long totalTime) {
+        switch (testPlan.getStatus()) {
+        case SUCCESS:
+            logger.info("all tests passed...");
+            break;
+        case ERROR:
+            logger.error("There are deployment/test errors...");
+            logger.info("Sorry, we are yet to infer an error summary!");
+            break;
+        case FAIL:
+            printFailState(testPlan);
+            break;
+        case RUNNING:
+        case PENDING:
+        case DID_NOT_RUN:
+        case INCOMPLETE:
+        default:
+            logger.error(StringUtil.concatStrings(
+                    "Inconsistent state detected (", testPlan.getStatus(), "). Please report this to testgrid team "
+                            + "at github.com/wso2/testgrid."));
+        }
+
+        printSeparator(LINE_LENGTH);
+        logger.info(StringUtil.concatStrings("Test Plan Summary for ", testPlan.getInfraParameters()), ":");
+        for (TestScenario testScenario : testPlan.getTestScenarios()) {
+            StringBuilder buffer = new StringBuilder(128);
+
+            buffer.append(testScenario.getName());
+            buffer.append(' ');
+
+            String padding = StringUtils.repeat(".", MAX_NAME_LENGTH - buffer.length());
+            buffer.append(padding);
+            buffer.append(' ');
+
+            buffer.append(testScenario.getStatus());
+            logger.info(buffer.toString());
+        }
+
+        printSeparator(LINE_LENGTH);
+        logger.info("TEST RUN " + testPlan.getStatus());
+        printSeparator(LINE_LENGTH);
+
+        logger.info("Total Time: " + getHumanReadableTimeDiff(totalTime));
+        logger.info("Finished at: " + new Date());
+        printSeparator(LINE_LENGTH);
+    }
+
+    /**
+     * Prints the logs for failure scenario.
+     *
+     * @param testPlan the test plan that has failures.
+     */
+    private static void printFailState(TestPlan testPlan) {
+        logger.warn("There are test failures...");
+        logger.info("Failed tests:");
+        AtomicInteger testCaseCount = new AtomicInteger(0);
+        AtomicInteger failedTestCaseCount = new AtomicInteger(0);
+        testPlan.getTestScenarios().stream()
+                .peek(ts -> {
+                    testCaseCount.addAndGet(ts.getTestCases().size());
+                    if (ts.getTestCases().size() == 0) {
+                        testCaseCount.incrementAndGet();
+                        failedTestCaseCount.incrementAndGet();
+                    }
+                })
+                .filter(ts -> ts.getStatus() != Status.SUCCESS)
+                .map(TestScenario::getTestCases)
+                .flatMap(Collection::stream)
+                .filter(tc -> !tc.isSuccess())
+                .forEachOrdered(
+                        tc -> {
+                            failedTestCaseCount.incrementAndGet();
+                            logger.info("  " + tc.getTestScenario().getName() + "::" + tc.getName() + ": " + tc
+                                    .getFailureMessage());
+                        });
+
+        logger.info("");
+        logger.info(
+                StringUtil.concatStrings("Tests run: ", testCaseCount, ", Failures/Errors: ", failedTestCaseCount));
+        logger.info("");
+    }
+
+    /**
+     * Prints a series of dashes ('-') into the log.
+     *
+     * @param length no of characters to print
+     */
+    private static void printSeparator(int length) {
+        logger.info(StringUtils.repeat("-", length));
+    }
+
+    /**
+     * Get time for summary logging purposes.
+     *
+     * @param timeDifferenceMilliseconds the time taken to run the test plan
+     * @return human readable elapsed time
+     */
+    private static String getHumanReadableTimeDiff(long timeDifferenceMilliseconds) {
+        long diffSeconds = timeDifferenceMilliseconds / 1000;
+        long diffMinutes = timeDifferenceMilliseconds / (60 * 1000);
+        long diffHours = timeDifferenceMilliseconds / (60 * 60 * 1000);
+        long diffDays = timeDifferenceMilliseconds / (60 * 60 * 1000 * 24);
+
+        if (diffSeconds < 1) {
+            return "less than a second";
+        } else if (diffMinutes < 1) {
+            return diffSeconds + " seconds";
+        } else if (diffHours < 1) {
+            return diffMinutes + " minutes" + " " + (diffSeconds % 60) + " seconds";
+        } else if (diffDays < 1) {
+            return diffHours + " hours" + " " + (diffMinutes % 60) + " minutes";
+        } else {
+            return diffDays + " days" + " " + (diffHours % 24) + " hours";
+        }
+
+    }
+
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -263,10 +263,7 @@ public class GenerateTestPlanCommand implements Command {
                 return optionalDeploymentPattern.get();
             }
 
-            DeploymentPattern deploymentPattern = new DeploymentPattern();
-            deploymentPattern.setName(deploymentPatternName);
-            deploymentPattern.setProduct(product);
-            return deploymentPattern;
+            return deploymentPatternUOW.persistDeploymentPattern(product, deploymentPatternName);
         } catch (TestGridDAOException e) {
             throw new CommandExecutionException(StringUtil
                     .concatStrings("Error while retrieving deployment pattern for { product: ", product,

--- a/core/src/test/java/org/wso2/testgrid/core/TestPlanExecutorTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/TestPlanExecutorTest.java
@@ -1,0 +1,91 @@
+package org.wso2.testgrid.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.testgrid.common.Status;
+import org.wso2.testgrid.common.TestCase;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.TestScenario;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests the summary log that gets printed at the end.
+ *
+ */
+public class TestPlanExecutorTest {
+    @Test
+    public void testPrintSummary() throws Exception {
+        TestPlan testPlan = new TestPlan();
+        testPlan.setInfraParameters("{DBEngine: \"mysql\"}");
+        testPlan.setStatus(Status.FAIL);
+
+        TestScenario s = new TestScenario();
+        s.setName("Sample scenario 01");
+        s.setStatus(Status.SUCCESS);
+        TestScenario s2 = new TestScenario();
+        s2.setName("Sample scenario 02");
+        s2.setStatus(Status.FAIL);
+
+        TestCase tc = new TestCase();
+        tc.setSuccess(true);
+        tc.setFailureMessage("success");
+        tc.setName("Sample Testcase 01");
+        tc.setTestScenario(s);
+        s.addTestCase(tc);
+
+        tc = new TestCase();
+        tc.setSuccess(false);
+        tc.setFailureMessage("fail");
+        tc.setName("Sample Testcase 02");
+        tc.setTestScenario(s2);
+        s2.addTestCase(tc);
+
+        tc = new TestCase();
+        tc.setSuccess(false);
+        tc.setFailureMessage("fail");
+        tc.setName("Sample Testcase 03");
+        tc.setTestScenario(s2);
+        s2.addTestCase(tc);
+
+        testPlan.setTestScenarios(Arrays.asList(s, s2));
+
+        final Path testgridLogPath = Paths.get("target", "testgrid.log");
+        Files.deleteIfExists(testgridLogPath);
+        final TestPlanExecutor testPlanExecutor = new TestPlanExecutor();
+        testPlanExecutor.printSummary(testPlan, System.currentTimeMillis() - 1525414900000L);
+
+        final List<String> testgridLog = Files.readAllLines(testgridLogPath);
+        boolean failedTestsTextFound = false;
+        boolean testPlanSummaryTextFound = false;
+        boolean testRunFailTextFound = false;
+        for (int i = 0; i < testgridLog.size(); i++) {
+            if (testgridLog.get(i).contains("Failed tests:")) {
+                Assert.assertTrue(testgridLog.get(i + 1).endsWith("Sample scenario 02::Sample Testcase 02: fail"));
+                Assert.assertTrue(testgridLog.get(i + 2).endsWith("Sample scenario 02::Sample Testcase 03: fail"));
+                Assert.assertTrue(testgridLog.get(i + 3).endsWith(" - "));
+                Assert.assertTrue(testgridLog.get(i + 4).endsWith("Tests run: 3, Failures/Errors: 2"));
+                failedTestsTextFound = true;
+            } else if (testgridLog.get(i).contains("Test Plan Summary for ")) {
+                Assert.assertTrue(testgridLog.get(i + 1).endsWith("Sample scenario 01 "
+                        + "................................. SUCCESS"));
+                Assert.assertTrue(testgridLog.get(i + 2).endsWith("Sample scenario 02 "
+                        + "................................. FAIL"));
+                testPlanSummaryTextFound = true;
+            } else if (testgridLog.get(i).contains("TEST RUN FAIL")) {
+                testRunFailTextFound = true;
+            }
+        }
+
+        Assert.assertTrue(failedTestsTextFound, "'Failed tests:' text was not found.");
+        Assert.assertTrue(testPlanSummaryTextFound, "'Test Plan Summary for:' text was not found.");
+        Assert.assertTrue(testRunFailTextFound, "'TEST RUN FAIL:' text was not found.");
+
+        Files.deleteIfExists(testgridLogPath);
+    }
+
+}

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -78,8 +78,6 @@ import static org.testng.Assert.assertTrue;
 public class RunTestPlanCommandTest extends PowerMockTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(RunTestPlanCommandTest.class);
-    private static final String EXPECTED_TEST_PLAN_PATH = Paths.get("src", "test", "resources", "test-plan-01.yaml")
-            .toString();
     private static final String TESTGRID_HOME = Paths.get("target", "testgrid-home").toString();
     private static final String infraParamsString = "{\"operating_system\":\"ubuntu_16.04\"}";
     private static final String TESTPLAN_ID = "TP_1";

--- a/core/src/test/resources/log4j2.xml
+++ b/core/src/test/resources/log4j2.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<Configuration packages="org.wso2.testgrid.logging" status="INFO">
+    <Appenders>
+        <Console name="TESTGRID_CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout pattern="%highlight{[%d{HH:mm:ss,SSS}] %m%ex%n}{ERROR=red, WARN=yellow}"/>
+        </Console>
+        <RollingFile name="AUDIT_LOGFILE" fileName="target/logs/audit.log"
+                     filePattern="target/logs/audit-%d{MM-dd-yyyy}.log">
+            <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+        </RollingFile>
+        <RollingFile name="ERROR_LOGFILE" fileName="target/logs/errors.log"
+                     filePattern="target/logs/errors-%d{MM-dd-yyyy}.log">
+            <PatternLayout pattern="[%d] %5p %X %m%ex%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+        </RollingFile>
+
+        <Routing name="Routing">
+            <Routes pattern="$${path:key2}">
+                <Route>
+                    <RollingFile name="SCENARIO_LOGFILE" fileName="target/${path:key2}"
+                                 filePattern="target/${path:key2}-%d{MM-dd-yyyy}">
+                        <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n" />
+                        <Policies>
+                            <SizeBasedTriggeringPolicy size="50 MB" />
+                        </Policies>
+                        <DefaultRolloverStrategy max="100" />
+                    </RollingFile>
+                </Route>
+            </Routes>
+        </Routing>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="TESTGRID_CONSOLE"/>
+            <AppenderRef ref="Routing" />
+            <AppenderRef ref="ERROR_LOGFILE" level="error"/>
+        </Root>
+        <Logger name="AUDIT_LOG" level="info" additivity="false">
+            <AppenderRef ref="AUDIT_LOGFILE"/>
+        </Logger>
+        <Logger name="org.eclipse.persistence" level="warn" additivity="false">
+            <AppenderRef ref="TESTGRID_CONSOLE"/>
+        </Logger>
+        <Logger name="org.eclipse.persistence" level="info" additivity="false">
+            <AppenderRef ref="Routing"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,12 @@
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.jpa</artifactId>
-                <version>${javax.persistence.version}</version>
+                <version>${org.eclipse.persistence.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.core</artifactId>
+                <version>${org.eclipse.persistence.version}</version>
             </dependency>
 
             <!-- Web app dependencies -->
@@ -480,11 +485,6 @@
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.core</artifactId>
-                <version>${javax.persistence.version}</version>
-            </dependency>
             <!--FindBugs dependencies-->
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
@@ -589,6 +589,7 @@
         <com.h2database.version>1.4.196</com.h2database.version>
         <!-- DAO dependencies -->
         <javax.persistence.version>2.2.0</javax.persistence.version>
+        <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
         <jersey.server.version>2.17</jersey.server.version>
         <!-- Web app dependencies -->
         <javax.websocket.version>1.1</javax.websocket.version>

--- a/test-scripts/local-is-deployment/Solutions/solution01/jmeter/01-TestIS540.jmx
+++ b/test-scripts/local-is-deployment/Solutions/solution01/jmeter/01-TestIS540.jmx
@@ -51,7 +51,7 @@
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check whether IS Page is loaded" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="784638524">WSO2 Carbon Server1</stringProp>
+              <stringProp name="-1637257067">WSO2 Carbon Server</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>

--- a/test-scripts/local-is-deployment/Solutions/solution01/run-scenario.sh
+++ b/test-scripts/local-is-deployment/Solutions/solution01/run-scenario.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+
+echo "running test IS jmeter script"
+$JMETER_HOME/bin/jmeter.sh -n -t "jmeter/01-TestIS540.jmx" -p resources/user.properties


### PR DESCRIPTION
**Purpose**
Print a summary of the execution at the end of run-testplan

Fixes #517 

**Goals**
Better readability of the log.
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
similar to maven
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

```
[19:40:15,550] There are test failures...
[19:40:15,550] Failed tests:
[19:40:15,555]   Sample scenario 02::Sample Testcase 02: fail
[19:40:15,555]   Sample scenario 02::Sample Testcase 03: fail
[19:40:15,555] 
[19:40:15,555] Tests run: 3, Failures/Errors: 2
[19:40:15,555] 
[19:40:15,558] ------------------------------------------------------------------------
[19:40:15,560] Test Plan Summary for {DBEngine: "mysql"}
[19:40:15,560] Sample scenario 01 ................................. SUCCESS
[19:40:15,560] Sample scenario 02 ................................. FAIL
[19:40:15,560] ------------------------------------------------------------------------
[19:40:15,560] TEST RUN FAIL
[19:40:15,561] ------------------------------------------------------------------------
[19:40:15,561] Total Time: 34 days 7 hours
[19:40:15,561] Finished at: Thu Jun 07 19:40:15 IST 2018
[19:40:15,561] ------------------------------------------------------------------------
```

**Automation tests**
Yes.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

