### PR TITLE
testgrid-prod-deploy job should first delete the old wso2-testgrid before unpacking the dist

### DIFF
--- a/jenkins/pipelines/Jenkinsfile
+++ b/jenkins/pipelines/Jenkinsfile
@@ -1,10 +1,7 @@
 pipeline {
     agent any
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
         TESTGRID_DIST_LOCATION = '/testgrid/jenkins-home/workspace/'
         TESTGRID_HOME='/testgrid/testgrid-home/'
 
@@ -25,7 +22,6 @@ pipeline {
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
 
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
         // Jmeter dependencies
         SELENIUM_JAR='https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-java/3.8.1/selenium-java-3.8.1.jar'
         HTML_UNIT_DRIVER='https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/htmlunit-driver/2.29.0/htmlunit-driver-2.29.0-jar-with-dependencies.jar'
@@ -56,10 +52,7 @@ pipeline {
 
                 sh """
                 echo ${TESTGRID_NAME}
-
-                unzip ${TESTGRID_DIST_LOCATION}/${TESTGRID_NAME}.zip
                 cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
                 curl -o ./lib/selenium-java.jar $SELENIUM_JAR
                 curl -o ./lib/html-unit-driver.jar $HTML_UNIT_DRIVER
                 """

--- a/jenkins/pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins/pipelines/continuous-delivery/Jenkinsfile
@@ -7,6 +7,13 @@ node('COMPONENT_ECS') {
                 scp -o StrictHostKeyChecking=no web/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/ROOT.war
                 scp -o StrictHostKeyChecking=no deployment-tinkerer/target/*.war ${DEV_USER}@${DEV_HOST}:/testgrid/deployment/apache-tomcat-8.5.23/webapps/
                 scp -o StrictHostKeyChecking=no distribution/target/*.zip ${DEV_USER}@${DEV_HOST}:/testgrid/testgrid-home/testgrid-dist/WSO2-TestGrid.zip
+                ssh -o StrictHostKeyChecking=no ${DEV_USER}@${DEV_HOST} /bin/bash << EOF
+                    cd /testgrid/testgrid-home/testgrid-dist/;
+                    unzip WSO2-TestGrid.zip -d WSO2-TestGrid-unzipped;
+                    rm -rf WSO2-TestGrid-backup;
+                    mv WSO2-TestGrid WSO2-TestGrid-backup;
+                    mv WSO2-TestGrid-unzipped WSO2-TestGrid;
+                    EOF
                 """
            }
     }
@@ -42,10 +49,17 @@ node('COMPONENT_ECS') {
                     scp -o StrictHostKeyChecking=no web/target/*.war ${PROD_USER}@${PROD_HOST}:/testgrid/deployment/apache-tomcat-8.5.24/webapps/ROOT.war
                     scp -o StrictHostKeyChecking=no deployment-tinkerer/target/*.war ${PROD_USER}@${PROD_HOST}:/testgrid/deployment/apache-tomcat-8.5.24/webapps/
                     scp -o StrictHostKeyChecking=no distribution/target/*.zip ${PROD_USER}@${PROD_HOST}:/testgrid/testgrid-home/testgrid-dist/WSO2-TestGrid.zip
+                    ssh -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_HOST} /bin/bash << EOF
+                        cd /testgrid/testgrid-home/testgrid-dist/;
+                        unzip WSO2-TestGrid.zip -d WSO2-TestGrid-unzipped;
+                        rm -rf WSO2-TestGrid-backup;
+                        mv WSO2-TestGrid WSO2-TestGrid-backup;
+                        mv WSO2-TestGrid-unzipped WSO2-TestGrid;
+                        EOF
                  """
             }
         } else {
-            echo "Not proceeding with pre prod"
+            echo "Not proceeding with prod deployment."
         }
     }
 

--- a/jenkins/pipelines/continuous-delivery/Jenkinsfile
+++ b/jenkins/pipelines/continuous-delivery/Jenkinsfile
@@ -1,4 +1,6 @@
 node('COMPONENT_ECS') {
+    def MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
+
     stage('Deploy to Dev'){
         deleteDir()
         copyArtifacts(projectName: 'testgrid/testgrid', filter: 'distribution/target/*.zip, web/target/*.war, deployment-tinkerer/target/*.war');
@@ -10,6 +12,7 @@ node('COMPONENT_ECS') {
                 ssh -o StrictHostKeyChecking=no ${DEV_USER}@${DEV_HOST} /bin/bash << EOF
                     cd /testgrid/testgrid-home/testgrid-dist/;
                     unzip WSO2-TestGrid.zip -d WSO2-TestGrid-unzipped;
+                    curl -o ./WSO2-TestGrid-unzipped/lib/mysql.jar ${MYSQL_DRIVER_LOCATION}
                     rm -rf WSO2-TestGrid-backup;
                     mv WSO2-TestGrid WSO2-TestGrid-backup;
                     mv WSO2-TestGrid-unzipped WSO2-TestGrid;
@@ -52,6 +55,7 @@ node('COMPONENT_ECS') {
                     ssh -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_HOST} /bin/bash << EOF
                         cd /testgrid/testgrid-home/testgrid-dist/;
                         unzip WSO2-TestGrid.zip -d WSO2-TestGrid-unzipped;
+                        curl -o ./WSO2-TestGrid-unzipped/lib/mysql.jar ${MYSQL_DRIVER_LOCATION}
                         rm -rf WSO2-TestGrid-backup;
                         mv WSO2-TestGrid WSO2-TestGrid-backup;
                         mv WSO2-TestGrid-unzipped WSO2-TestGrid;

--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -14,10 +14,7 @@ pipeline {
 
     environment {
             CONCURRENT_JOBS = 4
-            TESTGRID_VERSION = '0.9.0-SNAPSHOT'
             TESTGRID_NAME = 'WSO2-TestGrid'
-            TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                    'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
             TESTGRID_DIST_LOCATION = '/testgrid/testgrid-home/testgrid-dist/'
             TESTGRID_HOME='/testgrid/testgrid-home/'
 
@@ -40,7 +37,6 @@ pipeline {
             JOB_CONFIG_YAML = "job-config.yaml"
             JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
 
-            MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
     }
 
     tools {
@@ -65,14 +61,6 @@ pipeline {
                 dir("${INFRA_LOCATION}"){
                     git url:"${INFRASTRUCTURE_REPOSITORY}"
                 }
-
-                sh """
-                echo ${TESTGRID_NAME}
-		        cd ${TESTGRID_DIST_LOCATION}
-                unzip -o ${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                """
 
                 sh """
                 echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -13,10 +13,7 @@ pipeline {
     }
 
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
         TESTGRID_DIST_LOCATION = '/testgrid/testgrid-home/testgrid-dist/'
         TESTGRID_HOME='/testgrid/testgrid-home/'
 
@@ -38,8 +35,6 @@ pipeline {
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
     }
 
     tools {
@@ -67,12 +62,9 @@ pipeline {
                     sh """
                     echo ${TESTGRID_NAME}
                     cd ${TESTGRID_DIST_LOCATION}
-                    unzip -o ${TESTGRID_NAME}.zip
                     cd ${TESTGRID_NAME}
 
                     sed -i 's/-Xms256m -Xmx1024m/-Xmx2G -Xms2G/g' testgrid
-
-                    curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
                     """
 
                     sh """

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -13,10 +13,7 @@ pipeline {
         }
 
         environment {
-            TESTGRID_VERSION = '0.9.0-SNAPSHOT'
             TESTGRID_NAME = 'WSO2-TestGrid'
-            TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                    'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
             TESTGRID_DIST_LOCATION = '/testgrid/testgrid-home/testgrid-dist/'
             TESTGRID_HOME='/testgrid/testgrid-home/'
 
@@ -38,8 +35,6 @@ pipeline {
             PWD=pwd()
             JOB_CONFIG_YAML = "job-config.yaml"
             JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-            MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
         }
 
     tools {
@@ -64,14 +59,6 @@ pipeline {
                 dir("${INFRA_LOCATION}"){
                     git url:"${INFRASTRUCTURE_REPOSITORY}"
                 }
-
-                sh """
-                echo ${TESTGRID_NAME}
-		        cd ${TESTGRID_DIST_LOCATION}
-                unzip -o ${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                """
 
                 sh """
                 echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -12,10 +12,7 @@ pipeline {
         }
     }
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}.zip'
         TESTGRID_HOME='/testgrid/testgrid-home'
         TESTGRID_DIST_LOCATION = '${TESTGRID_HOME}/testgrid-dist'
 
@@ -38,8 +35,6 @@ pipeline {
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
     }
 
     tools {
@@ -64,14 +59,6 @@ pipeline {
                 dir("${INFRA_LOCATION}"){
                     git branch: '5.3.0', url:"${INFRASTRUCTURE_REPOSITORY}"
                 }
-
-                sh """
-                echo ${TESTGRID_NAME}
-		        cd ${TESTGRID_DIST_LOCATION}
-                unzip -o ${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                """
 
                 sh """
                 echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -12,10 +12,7 @@ pipeline {
         }
     }
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}.zip'
         TESTGRID_HOME='/testgrid/testgrid-home'
         TESTGRID_DIST_LOCATION = '${TESTGRID_HOME}/testgrid-dist'
 
@@ -38,8 +35,6 @@ pipeline {
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
     }
 
     tools {
@@ -64,14 +59,6 @@ pipeline {
                 dir("${INFRA_LOCATION}"){
                     git url:"${INFRASTRUCTURE_REPOSITORY}"
                 }
-
-                sh """
-                echo ${TESTGRID_NAME}
-		        cd ${TESTGRID_DIST_LOCATION}
-                unzip -o ${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                """
 
                 sh """
                 echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -12,10 +12,7 @@ pipeline {
         }
     }
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}.zip'
         TESTGRID_HOME='/testgrid/testgrid-home'
         TESTGRID_DIST_LOCATION = '${TESTGRID_HOME}/testgrid-dist'
 
@@ -38,8 +35,6 @@ pipeline {
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
      }
 
     tools {
@@ -64,14 +59,6 @@ pipeline {
                 dir("${INFRA_LOCATION}"){
                     git url:"${INFRASTRUCTURE_REPOSITORY}"
                 }
-
-                sh """
-                echo ${TESTGRID_NAME}
-		        cd ${TESTGRID_DIST_LOCATION}
-                unzip -o ${TESTGRID_NAME}.zip
-                cd ${TESTGRID_NAME}
-                curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                """
 
                 sh """
                 echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -13,10 +13,7 @@ pipeline {
     }
 
     environment {
-        TESTGRID_VERSION = '0.9.0-SNAPSHOT'
         TESTGRID_NAME = 'WSO2-TestGrid'
-        TESTGRID_DIST_URL = 'https://wso2.org/jenkins/job/testgrid/job/testgrid/' +
-                'lastSuccessfulBuild/artifact/distribution/target/${TESTGRID_NAME}-${TESTGRID_VERSION}.zip'
         TESTGRID_DIST_LOCATION = '/testgrid/testgrid-home/testgrid-dist'
         TESTGRID_HOME='/testgrid/testgrid-home'
 
@@ -38,8 +35,6 @@ pipeline {
         PWD=pwd()
         JOB_CONFIG_YAML = "job-config.yaml"
         JOB_CONFIG_YAML_PATH = "${PWD}/${JOB_CONFIG_YAML}"
-
-        MYSQL_DRIVER_LOCATION='http://central.maven.org/maven2/mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar'
     }
 
     tools {
@@ -63,14 +58,6 @@ pipeline {
                     dir("${INFRA_LOCATION}"){
                         git url:"${INFRASTRUCTURE_REPOSITORY}"
                     }
-
-                    sh """
-                    echo ${TESTGRID_NAME}
-                    cd ${TESTGRID_DIST_LOCATION}
-                    unzip -o ${TESTGRID_NAME}.zip
-                    cd ${TESTGRID_NAME}
-                    curl -o ./lib/mysql.jar $MYSQL_DRIVER_LOCATION
-                    """
 
                     sh """
                     echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}


### PR DESCRIPTION
**Purpose**
testgrid-prod-deploy job should first delete the old wso2-testgrid before unpacking the dist

Fixes #791 

<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Fixes
```
[main] INFO org.wso2.testgrid.core.Main - TestGrid Home	: /testgrid/testgrid-home
Exception in thread "main" java.lang.NoSuchMethodError: org.wso2.testgrid.common.util.TestGridUtil.deriveLogFilePath(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
	at org.wso2.testgrid.core.command.GenerateTestPlanCommand.execute(GenerateTestPlanCommand.java:138)
	at org.wso2.testgrid.core.command.CommandHandler.execute(CommandHandler.java:124)
	at org.wso2.testgrid.core.Main.main(Main.java:47)
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }

```
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**

<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

