### PR TITLE
Option to persist test scenario results in S3 and download per-scenario

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -107,6 +107,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
 
         <!-- Jacoco agent -->
         <dependency>

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.testgrid.automation.executor;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.automation.TestAutomationException;
@@ -26,12 +27,19 @@ import org.wso2.testgrid.automation.parser.JMeterResultParserException;
 import org.wso2.testgrid.automation.parser.JMeterResultParserFactory;
 import org.wso2.testgrid.common.DeploymentCreationResult;
 import org.wso2.testgrid.common.Status;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.exception.TestGridException;
+import org.wso2.testgrid.common.util.FileUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
+
+import static org.wso2.testgrid.common.TestGridConstants.SCENARIO_RESULTS_FILTER_PATTERN;
 
 /**
  * Responsible for performing the tasks related to execution of single JMeter solution.
@@ -62,6 +70,7 @@ public class JMeterExecutor extends TestExecutor {
             Optional<JMeterResultParser> parser = JMeterResultParserFactory.getParser(this.testScenario, testLocation);
             if (parser.isPresent()) {
                 parser.get().parseResults();
+                persistResultArtifacts(testLocation);
             } else {
                 this.testScenario.setStatus(Status.ERROR);
                 throw new TestAutomationException("Unable to parse the JMeter results file.");
@@ -75,4 +84,31 @@ public class JMeterExecutor extends TestExecutor {
             throw new TestAutomationException("Unable to parse the JMeter results file.", e);
         }
     }
+
+    /**
+     * This method moves the test-result artifacts (ex: JTL files, logs) to relevant TestGrid build directory to
+     * persist for future references. In addition, it also creates a compressed file of all the result artifacts.
+     *
+     * @param testLocation directory belongs to the scenario where all the output artifacts can be found.
+     */
+    private void persistResultArtifacts(String testLocation) throws TestAutomationException {
+        try {
+            List<String> files = FileUtil.getFilesOnDirectory(testLocation, SCENARIO_RESULTS_FILTER_PATTERN);
+            if (!files.isEmpty()) {
+                String zipFilePath = TestGridUtil.deriveScenarioArtifactPath(testScenario,
+                        testScenario.getDir() + TestGridConstants.TESTGRID_COMPRESSED_FILE_EXT);
+                for (String filePath : files) {
+                    File file = new File(filePath);
+                    File destinationFile = new File(
+                            TestGridUtil.deriveScenarioArtifactPath(testScenario, file.getName()));
+                    FileUtils.copyFile(file, destinationFile);
+                }
+                FileUtil.compressFiles(files, zipFilePath);
+            }
+        } catch (IOException | TestGridException e) {
+            throw new TestAutomationException("Error occurred while persisting scenario test-results." +
+                    "Scenario ID: " + testScenario.getId() + ", Scenario Directory: " + testScenario.getDir(), e);
+        }
+    }
+
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -86,5 +86,9 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -34,9 +34,11 @@ public class TestGridConstants {
     public static final String RUN_SCENARIO_SCRIPT_TEMPLATE = "run-scenarioTemplate.vm";
     public static final String JMETER_FOLDER = "jmeter";
     public static final String JMETER_FILE_FILTER_PATTERN = "*.jmx";
+    public static final String SCENARIO_RESULTS_FILTER_PATTERN = "*.{log,jtl}";
 
     public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";
     public static final String TESTGRID_LOGS_DIR = "logs";
+    public static final String TESTGRID_COMPRESSED_FILE_EXT = ".zip";
     public static final String TESTRUN_LOG_FILE_NAME = "test-run.log";
     public static final String TESTGRID_BUILDS_DIR = "builds";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -404,6 +404,21 @@ public final class TestGridUtil {
     }
 
     /**
+     * Derives the relative path of a scenario-artifact.
+     *
+     * @param testScenario test-scenario of the artifact
+     * @param fileName name of the artifact
+     * @return relative path of the artifact
+     */
+    public static String deriveScenarioArtifactPath(TestScenario testScenario, String fileName)
+            throws TestGridException {
+        String productName = testScenario.getTestPlan().getDeploymentPattern().getProduct().getName();
+        return Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR, productName,
+                TestGridConstants.TESTGRID_BUILDS_DIR, deriveTestPlanDirName(testScenario.getTestPlan()),
+                testScenario.getDir(), fileName).toString();
+    }
+
+    /**
      * Returns the path of the test-run log file.
      *
      * @param testPlan test-plan

--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
                                     }
                                     withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                         // Upload artifacts to S3
-                                        s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                        s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                                     }
                                 }
                                 echo "RESULT: ${currentBuild.result}"

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
                             }
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                     }

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
 
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                     }

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                             // Archive jtl files
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                     }

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                             }
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                         echo "RESULT: ${currentBuild.result}"

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                             }
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                     }

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 
                             withAWS(credentials:'TESTGRID_BOT_CREDENTIALS') {
                                 // Upload artifacts to S3
-                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/${f.name}")
+                                s3Upload(workingDir:"${TESTGRID_HOME}", includePathPattern:"**/*.jtl", bucket:"${bucket}", path:"artifacts/")
                             }
                         }
                     }

--- a/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioSummary.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/ScenarioSummary.java
@@ -31,6 +31,7 @@ public class ScenarioSummary {
     private final long totalFail;
     private final double successPercentage;
     private final Status scenarioStatus;
+    private final String scenarioDir;
 
     /**
      * Constructs an instance of a {@link ScenarioSummary}.
@@ -40,12 +41,14 @@ public class ScenarioSummary {
      * @param totalFail      total number of failed test cases
      * @param scenarioStatus test scenario overall result
      */
-    public ScenarioSummary(String scenarioDescription, long totalSuccess, long totalFail, Status scenarioStatus) {
+    public ScenarioSummary(String scenarioDescription, long totalSuccess, long totalFail, Status scenarioStatus,
+                           String scenarioDir) {
         this.scenarioDescription = scenarioDescription;
         this.totalSuccess = totalSuccess;
         this.totalFail = totalFail;
         this.successPercentage = (double) totalSuccess / ((double) totalSuccess + (double) totalFail) * 100d;
         this.scenarioStatus = scenarioStatus;
+        this.scenarioDir = scenarioDir;
     }
 
     /**
@@ -91,6 +94,15 @@ public class ScenarioSummary {
      */
     public Status getScenarioStatus() {
         return scenarioStatus;
+    }
+
+    /**
+     * Returns the directory of the test scenario.
+     *
+     * @return directory of the test scenario
+     */
+    public String getScenarioDir() {
+        return scenarioDir;
     }
 
     @Override

--- a/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
+++ b/web/src/main/java/org/wso2/testgrid/web/utils/Constants.java
@@ -67,5 +67,8 @@ public class Constants extends TestGridConstants {
 
     public static final String HTML_EXTENSION = ".html";
     public static final String AWS_BUCKET_ARTIFACT_DIR = "artifacts";
-    public static final String HTTP_FILE_NOT_FOUND = "404";
+    public static final String RESPONSE_HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+    public static final String RESPONSE_HEADER_VALUE_ATTACHMENT = "attachment";
+    public static final String RESPONSE_HEADER_VALUE_APPLICATION_ZIP = "application/zip";
+    public static final String RESPONSE_HEADER_FILE_NAME = "filename";
 }


### PR DESCRIPTION
**Purpose**
Fixes #795 
Now the logs are persisted in S3 as below;

![readme - testgrid s3 structure revealed](https://user-images.githubusercontent.com/8229975/41339715-29179144-6f13-11e8-9bd8-6841fb7b5948.png)

The user is also able to download per-scenario results as below;
![result](https://user-images.githubusercontent.com/8229975/41339776-503cfde0-6f13-11e8-89a8-8d7b86fd2fc4.png)


<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
