### PR TITLE
Add last success column to the TG home page

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/Product.java
+++ b/common/src/main/java/org/wso2/testgrid/common/Product.java
@@ -21,6 +21,7 @@ package org.wso2.testgrid.common;
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -71,6 +72,11 @@ public class Product extends AbstractUUIDEntity implements Serializable {
     @Column(name = "name", nullable = false, length = 50)
     private String name;
 
+    @Column(name = "last_success_timestamp")
+    private Timestamp lastSuccessTimestamp;
+
+    @Column(name = "last_failure_timestamp")
+    private Timestamp lastFailureTimestamp;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DeploymentPattern> deploymentPatterns = new ArrayList<>();
@@ -111,6 +117,44 @@ public class Product extends AbstractUUIDEntity implements Serializable {
         this.deploymentPatterns = deploymentPatterns;
     }
 
+    /**
+     * Returns the last success timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastSuccessTimestamp() {
+        return lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last success timestamp of the product build.
+     *
+     * @param lastSuccessTimestamp timestamp
+     */
+    public void setLastSuccessTimestamp(Timestamp lastSuccessTimestamp) {
+        this.lastSuccessTimestamp =
+                this.lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Returns the last failure timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastFailureTimestamp() {
+        return lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last failure timestamp of the product build.
+     *
+     * @param lastFailureTimestamp timestamp
+     */
+    public void setLastFailureTimestamp(Timestamp lastFailureTimestamp) {
+        this.lastFailureTimestamp =
+                this.lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
+    }
+
     @Override
     public String toString() {
         String id = this.getId() != null ? this.getId() : "";
@@ -121,6 +165,8 @@ public class Product extends AbstractUUIDEntity implements Serializable {
                 ", name='", name, "\'",
                 ", createdTimestamp='", createdTimestamp, "\'",
                 ", modifiedTimestamp='", modifiedTimestamp, "\'",
+                ", lastSuccessTimestamp='", lastSuccessTimestamp, "\'",
+                ", lastFailureTimestamp='", lastFailureTimestamp, "\'",
                 '}');
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
@@ -25,17 +25,24 @@ import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.util.FileUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.ProductUOW;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.logging.plugins.LogFilePathLookup;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Resolves the invalid statuses caused by any failures.
@@ -57,11 +64,18 @@ public class FinalizeRunTestplan implements Command {
             aliases = { "-f" })
     private String testPlanYamlFilePath = "";
 
+    @Option(name = "--workspace",
+            usage = "Workspace Of The Job",
+            aliases = { "-w" })
+    private String workspace = "";
+
     private TestPlanUOW testPlanUOW;
+    private ProductUOW productUOW;
     private List<TestPlan> testPlans;
 
     public FinalizeRunTestplan() {
         testPlanUOW = new TestPlanUOW();
+        productUOW = new ProductUOW();
     }
 
     @Override
@@ -69,10 +83,9 @@ public class FinalizeRunTestplan implements Command {
 
         LogFilePathLookup.setLogFilePath(
                 TestGridUtil.deriveTestGridLogFilePath(productName, TestGridConstants.TESTGRID_LOG_FILE_NAME));
-
-        if (Paths.get(testPlanYamlFilePath).toFile().exists()) {
-            //Read test plan id from test-plan yaml file
-            try {
+        try {
+            if (Paths.get(testPlanYamlFilePath).toFile().exists()) {
+                //Read test plan id from test-plan yaml file
                 TestPlan testPlan = FileUtil.readYamlFile(testPlanYamlFilePath, TestPlan.class);
                 Optional<TestPlan> testPlanEntity = testPlanUOW.getTestPlanById(testPlan.getId());
                 if (testPlanEntity.isPresent()) {
@@ -81,21 +94,17 @@ public class FinalizeRunTestplan implements Command {
                 } else {
                     testPlans = testPlanUOW.getTestPlansOlderThan(TIME_DURATION, TIME_UNIT);
                 }
-            } catch (IOException e) {
-                logger.error("Error occurred while trying to read " + testPlanYamlFilePath);
-            } catch (TestGridDAOException e) {
-                logger.error("Error while fetching test plan from database.");
-            }
-        } else {
-            testPlans = testPlanUOW.getTestPlansOlderThan(TIME_DURATION, TIME_UNIT);
-        }
 
-        logger.info("Finalizing test plan status...");
-        boolean isExistsFailedScenarios = false;
-        for (TestPlan testPlan : testPlans) {
-            //Set statuses of scenarios
-            for (TestScenario testScenario : testPlan.getTestScenarios()) {
-                switch (testScenario.getStatus()) {
+            } else {
+                testPlans = testPlanUOW.getTestPlansOlderThan(TIME_DURATION, TIME_UNIT);
+            }
+
+            logger.info("Finalizing test plan status...");
+            boolean isExistsFailedScenarios = false;
+            for (TestPlan testPlan : testPlans) {
+                //Set statuses of scenarios
+                for (TestScenario testScenario : testPlan.getTestScenarios()) {
+                    switch (testScenario.getStatus()) {
                     case PENDING:
                         testScenario.setStatus(Status.DID_NOT_RUN);
                         break;
@@ -109,10 +118,10 @@ public class FinalizeRunTestplan implements Command {
                         break;
                     default:
                         break;
+                    }
                 }
-            }
-            //Set statuses of testplans
-            switch (testPlan.getStatus()) {
+                //Set statuses of testplans
+                switch (testPlan.getStatus()) {
                 case PENDING:
                     testPlan.setStatus(Status.DID_NOT_RUN);
                     persistTestPlan(testPlan);
@@ -120,6 +129,7 @@ public class FinalizeRunTestplan implements Command {
                 case RUNNING:
                     if (isExistsFailedScenarios) {
                         testPlan.setStatus(Status.FAIL);
+                        isExistsFailedScenarios = false;
                     } else {
                         testPlan.setStatus(Status.INCOMPLETE);
                     }
@@ -127,7 +137,15 @@ public class FinalizeRunTestplan implements Command {
                     break;
                 default:
                     break;
+                }
             }
+            updateProductStatus();
+        } catch (IOException e) {
+            logger.error("Error occurred while trying to read " + testPlanYamlFilePath);
+        } catch (TestGridDAOException e) {
+            logger.error("Error while fetching test plan from database.");
+        } catch (TestGridException e) {
+            logger.error("Error occured while updating the product status.");
         }
     }
 
@@ -141,6 +159,50 @@ public class FinalizeRunTestplan implements Command {
             testPlanUOW.persistTestPlan(testPlan);
         } catch (TestGridDAOException e) {
             logger.error("Error occurred while persisting the test plan. ", e);
+        }
+    }
+
+    /**
+     * Update the last success timestamp of the product build or last failure timestamp of the product build
+     * by considering status of test plans.
+     *
+     */
+    private void updateProductStatus() throws TestGridException {
+        Path source = Paths.get(workspace + "/test-plans");
+        String productId;
+        Boolean isCompleteBuild = true;
+        try (Stream<Path> stream = Files.list(source).filter(Files::isRegularFile)) {
+            List<Path> paths = stream.sorted().collect(Collectors.toList());
+            for (Iterator<Path> iterator = paths.iterator(); iterator.hasNext(); ) {
+                Path path = iterator.next();
+                if (!path.toFile().exists()) {
+                    throw new TestGridException(
+                            "Test Plan File doesn't exist. File path is " + path.toAbsolutePath().toString());
+                }
+                TestPlan testPlan = FileUtil.readYamlFile(path.toAbsolutePath().toString(), TestPlan.class);
+                Optional<TestPlan> testPlanEntity = testPlanUOW.getTestPlanById(testPlan.getId());
+                if (testPlanEntity.isPresent()) {
+                    if (Status.FAIL.equals(testPlanEntity.get().getStatus())) {
+                        productId = testPlanEntity.get().getDeploymentPattern().getProduct().getId();
+                        productUOW.updateProductStatusTimestamp(Status.FAIL, productId);
+                        break;
+                    } else if ((Status.DID_NOT_RUN.equals(testPlanEntity.get().getStatus()) || Status.INCOMPLETE
+                            .equals(testPlanEntity.get().getStatus())) && isCompleteBuild) {
+                        isCompleteBuild = false;
+                    }
+                } else {
+                    throw new TestGridException(
+                            "Test Plan doesn't exist in the TG database. Test Plan id: " + testPlan.getId());
+                }
+                if (!iterator.hasNext() && isCompleteBuild) {
+                    productId = testPlanEntity.get().getDeploymentPattern().getProduct().getId();
+                    productUOW.updateProductStatusTimestamp(Status.SUCCESS, productId);
+                }
+            }
+        } catch (TestGridDAOException e) {
+            logger.error("Error occured when updating the product table of TG");
+        } catch (IOException e) {
+            logger.error("Error occured when reading a test plan yaml file");
         }
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
@@ -141,11 +141,11 @@ public class FinalizeRunTestplan implements Command {
             }
             updateProductStatus();
         } catch (IOException e) {
-            logger.error("Error occurred while trying to read " + testPlanYamlFilePath);
+            logger.error("Error occurred while trying to read " + testPlanYamlFilePath, e);
         } catch (TestGridDAOException e) {
-            logger.error("Error while fetching test plan from database.");
+            logger.error("Error while fetching test plan from database.", e);
         } catch (TestGridException e) {
-            logger.error("Error occured while updating the product status.");
+            logger.error("Error occured while updating the product status.", e);
         }
     }
 
@@ -168,7 +168,7 @@ public class FinalizeRunTestplan implements Command {
      *
      */
     private void updateProductStatus() throws TestGridException {
-        Path source = Paths.get(workspace + "/test-plans");
+        Path source = Paths.get(workspace, "test-plans");
         String productId;
         Boolean isCompleteBuild = true;
         try (Stream<Path> stream = Files.list(source).filter(Files::isRegularFile)) {
@@ -200,9 +200,9 @@ public class FinalizeRunTestplan implements Command {
                 }
             }
         } catch (TestGridDAOException e) {
-            logger.error("Error occured when updating the product table of TG");
+            logger.error("Error occured when updating the product table of TG", e);
         } catch (IOException e) {
-            logger.error("Error occured when reading a test plan yaml file");
+            logger.error("Error occured when reading a test plan yaml file", e);
         }
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
@@ -177,9 +177,7 @@ public class ProductRepository extends AbstractRepository<Product> {
             // Commit transaction
             entityManager.getTransaction().commit();
         } catch (Exception e) {
-            throw new TestGridDAOException(
-                    StringUtil.concatStrings("Error on executing the native SQL" + " query to update product table"),
-                    e);
+            throw new TestGridDAOException("Error on executing the native SQL query to update product table.", e);
         }
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
@@ -153,31 +153,25 @@ public class ProductRepository extends AbstractRepository<Product> {
     /**
      * This method updates the last_success_timestamp column or last_failure_timestamp column with given timestamp.
      * The column is selected by considering product status.
+     * ex:- UPDATE product SET last_failure_timestamp = <timestamp> where id = <product_id>;
      *
      * @param status Status of the product
      * @param timestamp Current timestamp
      * @param productId Id of the product
      */
-    public void updateProductStatusTimestamp(Status status, Date timestamp, String productId)
-            throws TestGridDAOException {
-        try {
-            String queryStr = "UPDATE product SET ";
-            if (status.equals(Status.SUCCESS)) {
-                queryStr += "last_success_timestamp = ";
-            } else if (status.equals(Status.FAIL)) {
-                queryStr += "last_failure_timestamp = ";
-            }
-            queryStr += "'" + timestamp + "' where id = '" + productId + "';";
-
-            // Begin entity manager transaction
-            entityManager.getTransaction().begin();
-
-            entityManager.createNativeQuery(queryStr).executeUpdate();
-
-            // Commit transaction
-            entityManager.getTransaction().commit();
-        } catch (Exception e) {
-            throw new TestGridDAOException("Error on executing the native SQL query to update product table.", e);
+    public void updateProductStatusTimestamp(Status status, Date timestamp, String productId) {
+        String queryStr = "UPDATE product SET ";
+        if (status.equals(Status.SUCCESS)) {
+            queryStr += "last_success_timestamp = ";
+        } else if (status.equals(Status.FAIL)) {
+            queryStr += "last_failure_timestamp = ";
         }
+
+        // Begin entity manager transaction
+        entityManager.getTransaction().begin();
+        entityManager.createNativeQuery(
+                StringUtil.concatStrings(queryStr, "'", timestamp, "' where id = '", productId, "';")).executeUpdate();
+        // Commit transaction
+        entityManager.getTransaction().commit();
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/ProductRepository.java
@@ -20,6 +20,7 @@ package org.wso2.testgrid.dao.repository;
 import com.google.common.collect.LinkedListMultimap;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.ProductTestStatus;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.SortOrder;
@@ -27,6 +28,7 @@ import org.wso2.testgrid.dao.TestGridDAOException;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import javax.persistence.EntityManager;
@@ -146,5 +148,38 @@ public class ProductRepository extends AbstractRepository<Product> {
                                                         (String) result[2], (String) result[4], (Timestamp) result[5]));
         }
         return productTestStatuses;
+    }
+
+    /**
+     * This method updates the last_success_timestamp column or last_failure_timestamp column with given timestamp.
+     * The column is selected by considering product status.
+     *
+     * @param status Status of the product
+     * @param timestamp Current timestamp
+     * @param productId Id of the product
+     */
+    public void updateProductStatusTimestamp(Status status, Date timestamp, String productId)
+            throws TestGridDAOException {
+        try {
+            String queryStr = "UPDATE product SET ";
+            if (status.equals(Status.SUCCESS)) {
+                queryStr += "last_success_timestamp = ";
+            } else if (status.equals(Status.FAIL)) {
+                queryStr += "last_failure_timestamp = ";
+            }
+            queryStr += "'" + timestamp + "' where id = '" + productId + "';";
+
+            // Begin entity manager transaction
+            entityManager.getTransaction().begin();
+
+            entityManager.createNativeQuery(queryStr).executeUpdate();
+
+            // Commit transaction
+            entityManager.getTransaction().commit();
+        } catch (Exception e) {
+            throw new TestGridDAOException(
+                    StringUtil.concatStrings("Error on executing the native SQL" + " query to update product table"),
+                    e);
+        }
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/ProductUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/ProductUOW.java
@@ -19,6 +19,7 @@ package org.wso2.testgrid.dao.uow;
 
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.ProductTestStatus;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.dao.EntityManagerHelper;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.repository.ProductRepository;
@@ -109,5 +110,15 @@ public class ProductUOW {
      */
     public List<ProductTestStatus> getProductTestHistory(Timestamp date) throws TestGridDAOException {
         return productRepository.getProductTestHistory(date);
+    }
+
+    /**
+     * This method update the last success timestamp or last failure timestamp according to the product status.
+     *
+     * @param status status of the product
+     * @param productId Id of the product
+     */
+    public void updateProductStatusTimestamp(Status status, String productId) throws TestGridDAOException {
+        productRepository.updateProductStatusTimestamp(status, new Timestamp(System.currentTimeMillis()), productId);
     }
 }

--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -140,7 +140,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT --workspace ${PWD}}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
            sh """
             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
            sh """
             cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
@@ -49,6 +49,8 @@ class APIUtil {
         if (product != null) {
             productBean.setId(product.getId());
             productBean.setName(product.getName());
+            productBean.setLastSuccessTimestamp(product.getLastSuccessTimestamp());
+            productBean.setLastFailureTimestamp(product.getLastFailureTimestamp());
         }
         return productBean;
     }

--- a/web/src/main/java/org/wso2/testgrid/web/api/ProductService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/ProductService.java
@@ -125,8 +125,8 @@ public class ProductService {
                 ProductStatus status = new ProductStatus();
                 status.setProductId(product.getId());
                 status.setProductName(product.getName());
-                status.setLastfailed(APIUtil.getTestPlanBean(testPlanUOW.getLastFailure(product), false));
-                status.setLastBuild(APIUtil.getTestPlanBean(testPlanUOW.getLastBuild(product), false));
+                status.setLastSuccessTimestamp(product.getLastSuccessTimestamp());
+                status.setLastFailureTimestamp(product.getLastFailureTimestamp());
                 status.setProductStatus(testPlanUOW.getCurrentStatus(product).toString());
                 list.add(status);
             }
@@ -161,8 +161,8 @@ public class ProductService {
                 product = productInstance.get();
                 productStatus.setProductId(product.getId());
                 productStatus.setProductName(product.getName());
-                productStatus.setLastfailed(APIUtil.getTestPlanBean(testPlanUOW.getLastFailure(product), false));
-                productStatus.setLastBuild(APIUtil.getTestPlanBean(testPlanUOW.getLastBuild(product), false));
+                productStatus.setLastSuccessTimestamp(product.getLastSuccessTimestamp());
+                productStatus.setLastFailureTimestamp(product.getLastFailureTimestamp());
                 productStatus.setProductStatus(testPlanUOW.getCurrentStatus(product).toString());
             } else {
                 String msg = "Could not found the product:" + productName + " in TestGrid. Please check the "

--- a/web/src/main/java/org/wso2/testgrid/web/bean/Product.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/Product.java
@@ -18,12 +18,16 @@
 
 package org.wso2.testgrid.web.bean;
 
+import java.sql.Timestamp;
+
 /**
  * Bean class of Product object used in APIs.
  */
 public class Product {
     private String id;
     private String name;
+    private Timestamp lastSuccessTimestamp;
+    private Timestamp lastFailureTimestamp;
 
     /**
      * Returns the id of the product test plan.
@@ -61,4 +65,39 @@ public class Product {
         this.name = name;
     }
 
+    /**
+     * Returns the last success timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastSuccessTimestamp() {
+        return lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last success timestamp of the product build.
+     *
+     * @param lastSuccessTimestamp timestamp
+     */
+    public void setLastSuccessTimestamp(Timestamp lastSuccessTimestamp) {
+        this.lastSuccessTimestamp = lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Returns the last failure timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastFailureTimestamp() {
+        return lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last failure timestamp of the product build.
+     *
+     * @param lastFailureTimestamp timestamp
+     */
+    public void setLastFailureTimestamp(Timestamp lastFailureTimestamp) {
+        this.lastFailureTimestamp = lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
+    }
 }

--- a/web/src/main/java/org/wso2/testgrid/web/bean/ProductStatus.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/ProductStatus.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.testgrid.web.bean;
 
+import java.sql.Timestamp;
+
 /**
  * Bean class for Aggregated product productStatus reponses.
  *
@@ -28,10 +30,10 @@ public class ProductStatus {
     private String productName;
     private String reportLink;
     private String productStatus;
-    private TestPlan lastBuild;
-    private TestPlan lastfailed;
     private String executeLink;
     private String configLink;
+    private Timestamp lastSuccessTimestamp;
+    private Timestamp lastFailureTimestamp;
 
     /**
      * Returns the productId of the product.
@@ -108,44 +110,6 @@ public class ProductStatus {
     }
 
     /**
-     * Returns the last build TestPlan of the product
-     *
-     * @return {@link TestPlan} for the last build
-     */
-    public TestPlan getLastBuild() {
-        return lastBuild;
-    }
-
-    /**
-     *
-     * Sets the last build for the product.
-     *
-     * @param lastBuild the last build {@link TestPlan}
-     */
-    public void setLastBuild(TestPlan lastBuild) {
-        this.lastBuild = lastBuild;
-    }
-
-    /**
-     *
-     * Returns the last failed TestPlan of the product.
-     *
-     * @return {@link TestPlan} for last failed build
-     */
-    public TestPlan getLastfailed() {
-        return lastfailed;
-    }
-
-    /**
-     *Sets the last failed build for the product
-     *
-     * @param lastfailed {@link TestPlan} for last failed build
-     */
-    public void setLastfailed(TestPlan lastfailed) {
-        this.lastfailed = lastfailed;
-    }
-
-    /**
      *Returns the executable link for the product that contains all the jobs.
      *
      * @return executable URL for the product
@@ -179,5 +143,41 @@ public class ProductStatus {
      */
     public void setConfigLink(String configLink) {
         this.configLink = configLink;
+    }
+
+    /**
+     * Returns the last success timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastSuccessTimestamp() {
+        return lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last success timestamp of the product build.
+     *
+     * @param lastSuccessTimestamp timestamp
+     */
+    public void setLastSuccessTimestamp(Timestamp lastSuccessTimestamp) {
+        this.lastSuccessTimestamp = lastSuccessTimestamp == null ? null : new Timestamp(lastSuccessTimestamp.getTime());
+    }
+
+    /**
+     * Returns the last failure timestamp of the product build.
+     *
+     * @return timestamp
+     */
+    public Timestamp getLastFailureTimestamp() {
+        return lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
+    }
+
+    /**
+     * Sets the last failure timestamp of the product build.
+     *
+     * @param lastFailureTimestamp timestamp
+     */
+    public void setLastFailureTimestamp(Timestamp lastFailureTimestamp) {
+        this.lastFailureTimestamp = lastFailureTimestamp == null ? null : new Timestamp(lastFailureTimestamp.getTime());
     }
 }

--- a/web/src/main/java/org/wso2/testgrid/web/bean/ProductStatus.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/ProductStatus.java
@@ -110,7 +110,7 @@ public class ProductStatus {
     }
 
     /**
-     *Returns the executable link for the product that contains all the jobs.
+     * Returns the executable link for the product that contains all the jobs.
      *
      * @return executable URL for the product
      */
@@ -119,7 +119,7 @@ public class ProductStatus {
     }
 
     /**
-     *Set the executable link for the product.
+     * Set the executable link for the product.
      *
      * @param executeLink URL for the job execution of product
      */
@@ -137,7 +137,7 @@ public class ProductStatus {
     }
 
     /**
-     *Set the Jenkins configuration link for the product.
+     * Set the Jenkins configuration link for the product.
      *
      * @param configLink URL for configuration console
      */

--- a/web/src/main/react-dashboard/src/components/ProductStatusView.js
+++ b/web/src/main/react-dashboard/src/components/ProductStatusView.js
@@ -109,31 +109,30 @@ class ProductStatusView extends Component {
         </th>
         <td style={{fontSize: '16px'}}>
           {(() => {
-            if (product.lastBuild.modifiedTimestamp) {
+            if (product.lastSuccessTimestamp) {
               return (
-                <SingleRecord value={product.lastBuild.status}
-                              nevigate={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
+                <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
                                 product.productName, {
                                 productId: product.productId,
                                 productName: product.productName,
                                 productStatus: product.productStatus
-                              })} time={product.lastBuild.modifiedTimestamp}
-                />)
+                })}> time={Moment(product.lastSuccessTimestamp).fromNow()}</i>
+                )
             } else {
-              return ("No builds yet!");
+              return ("No Success builds yet!");
             }
           })()}
         </td>
         <td style={{fontSize: '16px'}}>
           {(() => {
-            if (product.lastfailed.modifiedTimestamp) {
+            if (product.lastFailureTimestamp) {
               return (
                 <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" + product.productName, {
                   productId: product.productId,
                   productName: product.productName,
                   productStatus: product.productStatus
                 })} style={{cursor: 'pointer'}}>
-                  {Moment(product.lastfailed.modifiedTimestamp).fromNow()}</i>
+                  {Moment(product.lastFailureTimestamp).fromNow()}</i>
               );
             } else {
               return ("No failed builds yet!")
@@ -169,7 +168,7 @@ class ProductStatusView extends Component {
           <tr>
             <th>Status</th>
             <th>Job</th>
-            <th>Latest Build</th>
+            <th>Last Success</th>
             <th>Last Failure</th>
             <th>Execute</th>
             <th>Configure</th>


### PR DESCRIPTION
**Purpose**
The purpose of this PR is to add last success field into TG home page. This resolves #797.

**Goals**
In order to increase the sense of displaying data on the home page, removed the latest build column from the home page and add the last success column. To maintain the product status modified the finalize-test-plan command. Loop all test plan files and get status of the test plan. If one of the test plans is in the FAIL status update the last_failure_timestamp column in the product table. If all test plans are in success status update the last_success_timestamp.

**Approach**
![tg1](https://user-images.githubusercontent.com/7247568/41410146-18c80d30-6ff6-11e8-85f2-b8866284d6a9.png)

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
>JDK - Oracle 1.8
>OS - UBUNTU 18.04
>DB - MySQL 5.7
>Browser - Chrome