### PR TITLE
Email-able report generation

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -40,6 +40,7 @@ public class TestGridConstants {
     public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String TESTGRID_COMPRESSED_FILE_EXT = ".zip";
     public static final String TESTRUN_LOG_FILE_NAME = "test-run.log";
+    public static final String TEST_INTEGRATION_LOG_FILE_NAME = "TestSuite.txt";
     public static final String TESTGRID_BUILDS_DIR = "builds";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";
     public static final String FILE_SEPARATOR = "/";
@@ -53,6 +54,7 @@ public class TestGridConstants {
 
     public static final String DEFAULT_DEPLOYMENT_PATTERN_NAME = "default";
     public static final String TESTGRID_CONFIG_FILE = "config.properties";
+    public static final String TESTGRID_SCENARIO_OUTPUT_PROPERTY_FILE = "output.properties";
 
     public static final String WUM_USERNAME_PROPERTY = "WUMUsername";
     public static final String WUM_PASSWORD_PROPERTY = "WUMPassword";
@@ -60,4 +62,7 @@ public class TestGridConstants {
     public static final String TEST_TYPE_FUNCTIONAL = "FUNCTIONAL";
     public static final String TEST_TYPE_PERFORMANCE = "PERFORMANCE";
 
+    public static final String TEST_PLANS_URI = "test-plans";
+    public static final String HTML_LINE_SEPARATOR = "<br/>";
+    public static final String TESTGRID_EMAIL_REPORT_NAME = "EmailReport.html";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -133,7 +133,12 @@ public class ConfigurationContext {
         /**
          * Deployment Tinkerer password of TestGrid deployment.
          */
-        DEPLOYMENT_TINKERER_PASSWORD("DEPLOYMENT_TINKERER_PASSWORD");
+        DEPLOYMENT_TINKERER_PASSWORD("DEPLOYMENT_TINKERER_PASSWORD"),
+
+        /**
+         * Host-name of TestGrid deployment.
+         */
+        TESTGRID_HOST("TESTGRID_HOST");
 
         private String propertyName;
 

--- a/common/src/main/java/org/wso2/testgrid/common/config/PropertyFileReader.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/PropertyFileReader.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 
 /**
  * Implementation of a dynamic property file reader, which can be used to read properties from TestGrid property files.
- * Ex: Read values from scenario-output property file.
+ * Ex: Read values from testgrid build-output property file.
  * This also includes enums for possible defined properties in each Testgrid property files.
  */
 public class PropertyFileReader {
@@ -56,9 +56,9 @@ public class PropertyFileReader {
     }
 
     /**
-     * Defines the testgrid scenario output properties.
+     * Defines the Testgrid build output properties.
      */
-    public enum ScenarioOutputProperties {
+    public enum BuildOutputProperties {
 
         /**
          * Git revision of the source used to build the product.
@@ -70,7 +70,6 @@ public class PropertyFileReader {
          */
         GIT_LOCATION("GIT_LOCATION");
 
-
         private String propertyName;
 
         /**
@@ -78,7 +77,7 @@ public class PropertyFileReader {
          *
          * @param propertyName name of the property
          */
-        ScenarioOutputProperties(String propertyName) {
+        BuildOutputProperties(String propertyName) {
             this.propertyName = propertyName;
         }
 

--- a/common/src/main/java/org/wso2/testgrid/common/config/PropertyFileReader.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/PropertyFileReader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.common.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.exception.TestGridException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * Implementation of a dynamic property file reader, which can be used to read properties from TestGrid property files.
+ * Ex: Read values from scenario-output property file.
+ * This also includes enums for possible defined properties in each Testgrid property files.
+ */
+public class PropertyFileReader {
+    private final Logger logger = LoggerFactory.getLogger(ConfigurationContext.class);
+
+    /**
+     * Retrieve property from the property file.
+     * @param property Property key as in the property file.
+     * @return Property value read from property file.
+     */
+    public String getProperty(Enum property, String propertyFilePath) throws TestGridException {
+        Properties properties = new Properties();
+        try (InputStream inputStream = Files.newInputStream(Paths.get(propertyFilePath))) {
+            properties.load(inputStream);
+            return properties.getProperty(property.toString());
+        } catch (IOException e) {
+            String msg =
+                    "Error while trying to read " + propertyFilePath + "to retrieve property " + property.toString();
+            logger.error(msg);
+            throw new TestGridException(msg, e);
+        }
+    }
+
+    /**
+     * Defines the testgrid scenario output properties.
+     */
+    public enum ScenarioOutputProperties {
+
+        /**
+         * Git revision of the source used to build the product.
+         */
+        GIT_REVISION("GIT_REVISION"),
+
+        /**
+         * Git repository and branch of the product.
+         */
+        GIT_LOCATION("GIT_LOCATION");
+
+
+        private String propertyName;
+
+        /**
+         * Sets the name of the property.
+         *
+         * @param propertyName name of the property
+         */
+        ScenarioOutputProperties(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        @Override
+        public String toString() {
+            return this.propertyName;
+        }
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -438,6 +438,43 @@ public final class TestGridUtil {
     }
 
     /**
+     * Returns the path of the integration test log file.
+     *
+     * @param testPlan test-plan
+     * @return log file path
+     */
+    public static String deriveTestIntegrationLogFilePath(TestPlan testPlan, Boolean relative)
+            throws TestGridException {
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
+        String dirPrefix = "";
+        if (!relative) {
+            dirPrefix = getTestGridHomePath();
+        }
+        return Paths.get(dirPrefix, TestGridConstants.TESTGRID_JOB_DIR, productName,
+                TestGridConstants.TESTGRID_BUILDS_DIR, testPlanDirName,
+                TestGridConstants.TEST_INTEGRATION_LOG_FILE_NAME).toString();
+    }
+
+    /**
+     * Returns the path of the integration test log file.
+     *
+     * @param testScenario test-scenario
+     * @return log file path
+     */
+    public static String deriveScenarioOutputPropertyFilePath(TestScenario testScenario, Boolean relative)
+            throws TestGridException {
+        String productName = testScenario.getTestPlan().getDeploymentPattern().getProduct().getName();
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testScenario.getTestPlan());
+        String dirPrefix = "";
+        if (!relative) {
+            dirPrefix = getTestGridHomePath();
+        }
+        return Paths.get(dirPrefix, TestGridConstants.TESTGRID_JOB_DIR, productName,
+                TestGridConstants.TESTGRID_BUILDS_DIR, testPlanDirName,
+                TestGridConstants.TESTGRID_SCENARIO_OUTPUT_PROPERTY_FILE).toString();
+    }
+    /**
      * Returns the test-plan directory name based on the test-plan content.
      * @param testPlan test-plan
      * @return test-plan directory name.

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -459,13 +459,13 @@ public final class TestGridUtil {
     /**
      * Returns the path of the integration test log file.
      *
-     * @param testScenario test-scenario
+     * @param testPlan test-plan
      * @return log file path
      */
-    public static String deriveScenarioOutputPropertyFilePath(TestScenario testScenario, Boolean relative)
+    public static String deriveScenarioOutputPropertyFilePath(TestPlan testPlan, Boolean relative)
             throws TestGridException {
-        String productName = testScenario.getTestPlan().getDeploymentPattern().getProduct().getName();
-        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testScenario.getTestPlan());
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
         String dirPrefix = "";
         if (!relative) {
             dirPrefix = getTestGridHomePath();

--- a/core/src/main/java/org/wso2/testgrid/core/command/CommandHandler.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/CommandHandler.java
@@ -60,6 +60,8 @@ public class CommandHandler extends HelpCommand {
                                      impl = FinalizeRunTestplan.class),
                          @SubCommand(name = "generate-report",
                                      impl = GenerateReportCommand.class),
+                         @SubCommand(name = "generate-email",
+                                     impl = GenerateEmailCommand.class),
                          @SubCommand(name = "help",
                                      impl = HelpCommand.class)
                  })

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateEmailCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateEmailCommand.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.core.command;
+
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.ProductUOW;
+import org.wso2.testgrid.reporting.ReportingException;
+import org.wso2.testgrid.reporting.TestReportEngine;
+
+/**
+ * This generates an email report that consists of test results for a given product.
+ */
+public class GenerateEmailCommand implements Command {
+    private static final Logger logger = LoggerFactory.getLogger(GenerateReportCommand.class);
+
+    @Option(name = "--product",
+            usage = "Product Name",
+            aliases = {"-p"},
+            required = true)
+    private String productName = "";
+
+    @Override
+    public void execute() throws CommandExecutionException {
+        Product product = getProduct(productName);
+        try {
+            TestReportEngine testReportEngine = new TestReportEngine();
+            testReportEngine.generateEmailReport(product);
+        } catch (ReportingException e) {
+            throw new CommandExecutionException(StringUtil
+                    .concatStrings("Error occurred when generating email report for {" +
+                            " product: ", productName, " }"), e);
+        }
+    }
+
+    /**
+     * Returns an instance of {@link Product} for the given product name and product version.
+     *
+     * @param productName    product name
+     * @return an instance of {@link Product} for the given product name and product version
+     * @throws CommandExecutionException throw when error on obtaining product for the given product name and product
+     *                                   version
+     */
+    private Product getProduct(String productName)
+            throws CommandExecutionException {
+        try {
+            ProductUOW productUOW = new ProductUOW();
+            return productUOW.getProduct(productName)
+                    .orElseThrow(() -> new CommandExecutionException(StringUtil
+                            .concatStrings("No product test plan found for product {product name: ", productName,
+                                    "}. This exception should not occur in the test execution flow.")));
+        } catch (TestGridDAOException e) {
+            throw new CommandExecutionException(StringUtil
+                    .concatStrings("Error in retrieving Product {product name: ", productName,
+                            "} from the Database. This exception should not occur in the test execution flow."), e);
+        }
+    }
+}

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -62,6 +62,11 @@
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${apache.commons.lang.version}</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportGenerator.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportGenerator.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.reporting;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.Status;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+import org.wso2.testgrid.common.config.PropertyFileReader;
+import org.wso2.testgrid.common.exception.TestGridException;
+import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.dao.uow.TestPlanUOW;
+import org.wso2.testgrid.reporting.model.email.TestPlanResultSection;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.testgrid.common.TestGridConstants.HTML_LINE_SEPARATOR;
+import static org.wso2.testgrid.common.TestGridConstants.TEST_PLANS_URI;
+
+/**
+ * This class is responsible for generating all the content for the email-report for TestReportEngine.
+ * The report will consist of base details such as product status, git build details, as well as per test-plan
+ * (per infra-combination) details such as test-plan log, test-plan infra combination.
+ */
+public class EmailReportGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(EmailReportGenerator.class);
+
+    /**
+     * Populates test-plan result sections in the report considering the latest test-plans of the product.
+     *
+     * @param product product needing the results
+     * @return list of test-plan sections
+     */
+    public List<TestPlanResultSection> generatePerTestPlanSection(Product product) throws ReportingException {
+        List<TestPlanResultSection> perTestPlanMap = new ArrayList<>();
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        List<TestPlan> testPlans = testPlanUOW.getLatestTestPlans(product);
+        String testGridHost = ConfigurationContext.getProperty(ConfigurationContext.
+                ConfigurationProperties.TESTGRID_HOST);
+        String productName = product.getName();
+        for (TestPlan testPlan : testPlans) {
+            if (testPlan.getStatus().equals(Status.SUCCESS)) {
+                continue;
+            }
+            String deploymentPattern = testPlan.getDeploymentPattern().getName();
+            String testPlanId = testPlan.getId();
+            TestPlanResultSection testPlanResultSection = new TestPlanResultSection();
+            testPlanResultSection.setDeployment(deploymentPattern);
+            testPlanResultSection.setInfraCombination(testPlan.getInfraParameters());
+            try {
+                testPlanResultSection.setResult(getIntegrationTestLogResult(testPlan));
+            } catch (ReportingException e) {
+                logger.error("Integration test results of the test-plan with id " + testPlan.getId() +
+                        " is not added to the email-report due to a reporting exception occurred.", e.getMessage());
+            }
+            testPlanResultSection.setDashboardLink(Paths.get(
+                    testGridHost, productName, deploymentPattern, TEST_PLANS_URI, testPlanId).toString());
+            perTestPlanMap.add(testPlanResultSection);
+        }
+        return perTestPlanMap;
+    }
+
+    /**
+     * Returns a summary of the integration test results of a given test-plan.
+     *
+     * @param testPlan test-plan
+     * @return Summary of integration test results
+     */
+    private String getIntegrationTestLogResult(TestPlan testPlan) throws ReportingException {
+        StringBuilder stringBuilder = new StringBuilder();
+        Path filePath;
+        try {
+            filePath = Paths.get(TestGridUtil.deriveTestIntegrationLogFilePath(testPlan, false));
+        } catch (TestGridException e) {
+            throw new ReportingException("Error occurred while deriving integration-test log file path to get" +
+                    " integration test results for test-plan with id " + testPlan.getId() + "of the product " +
+                    testPlan.getDeploymentPattern().getProduct().getName() + "having infra-combination as " +
+                    testPlan.getInfraParameters(), e);
+        }
+
+        if (Files.exists(filePath)) {
+            try (BufferedReader bufferedReader = Files.newBufferedReader(filePath)) {
+                String currentLine;
+                int lineCount = 0;
+                while ((currentLine = bufferedReader.readLine()) != null) {
+                    stringBuilder.append(currentLine).append(HTML_LINE_SEPARATOR);
+                    if (++lineCount == 100) {
+                        stringBuilder.append(".........").append(HTML_LINE_SEPARATOR).append(".........")
+                                .append(HTML_LINE_SEPARATOR).append("(view complete log in detailed results..)");
+                        break;
+                    }
+                }
+                return stringBuilder.toString();
+            } catch (IOException e) {
+                throw new ReportingException("Error occurred while reading integration-test log file to get" +
+                        " integration test results for test-plan with id " + testPlan.getId() + "of the product " +
+                        testPlan.getDeploymentPattern().getProduct().getName() + "having infra-combination as " +
+                        testPlan.getInfraParameters(), e);
+            }
+        } else {
+            if (testPlan.getStatus().equals(Status.SUCCESS) || testPlan.getStatus().equals(Status.FAIL)) {
+                logger.error("Integration-test log file does not exists for test-plan with id "
+                        + testPlan.getId() + "of the product " +
+                        testPlan.getDeploymentPattern().getProduct().getName() + "having infra-combination as " +
+                        testPlan.getInfraParameters());
+                return "Integration test-log is missing. Please contact TestGrid administrator.";
+            } else {
+                return "Test status is " + testPlan.getStatus() + ". Hence can not display the log.";
+            }
+        }
+    }
+
+    /**
+     * Returns the current status of the product.
+     * @param product product
+     * @return current status of the product
+     */
+    public Status getProductStatus(Product product) {
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        return testPlanUOW.getCurrentStatus(product);
+    }
+
+    /**
+     * Returns the Git build information of the latest build of the product.
+     * This will consist of git location and git revision used to build the distribution.
+     * @param product product
+     * @return Git build information
+     */
+    public String getGitBuildDetails(Product product) {
+        StringBuilder stringBuilder = new StringBuilder();
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        List<TestPlan> testPlans = testPlanUOW.getLatestTestPlans(product);
+        TestPlan testPlan = testPlans.get(0);
+        String outputPropertyFilePath = null;
+        try {
+            outputPropertyFilePath =
+                    TestGridUtil.deriveScenarioOutputPropertyFilePath(testPlan.getTestScenarios().get(0), false);
+            PropertyFileReader propertyFileReader = new PropertyFileReader();
+            String gitRevision = propertyFileReader.
+                    getProperty(PropertyFileReader.ScenarioOutputProperties.GIT_REVISION, outputPropertyFilePath);
+            String gitLocation = propertyFileReader.
+                    getProperty(PropertyFileReader.ScenarioOutputProperties.GIT_LOCATION, outputPropertyFilePath);
+            if (gitLocation == null || gitLocation.isEmpty()) {
+                logger.error("Git location received as null/empty for test plan with id " + testPlan.getId());
+                stringBuilder.append("Git location: Unknown!");
+            } else {
+                stringBuilder.append("Git location: ").append(gitLocation);
+            }
+            stringBuilder.append(HTML_LINE_SEPARATOR);
+            if (gitRevision == null || gitRevision.isEmpty()) {
+                logger.error("Git revision received as null/empty for test plan with id " + testPlan.getId());
+                stringBuilder.append("Git revision: Unknown!");
+            } else {
+                stringBuilder.append("Git revision: ").append(gitRevision);
+            }
+        } catch (TestGridException e) {
+            logger.error("Error occurred while getting Git build details from file" + outputPropertyFilePath +
+                    "for product " + product.getName() + "" + "considering the testplan with testplan id " +
+                    testPlan.getId());
+            return "Git build details are unknown!";
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportGenerator.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportGenerator.java
@@ -159,12 +159,12 @@ public class EmailReportGenerator {
         String outputPropertyFilePath = null;
         try {
             outputPropertyFilePath =
-                    TestGridUtil.deriveScenarioOutputPropertyFilePath(testPlan.getTestScenarios().get(0), false);
+                    TestGridUtil.deriveScenarioOutputPropertyFilePath(testPlan, false);
             PropertyFileReader propertyFileReader = new PropertyFileReader();
             String gitRevision = propertyFileReader.
-                    getProperty(PropertyFileReader.ScenarioOutputProperties.GIT_REVISION, outputPropertyFilePath);
+                    getProperty(PropertyFileReader.BuildOutputProperties.GIT_REVISION, outputPropertyFilePath);
             String gitLocation = propertyFileReader.
-                    getProperty(PropertyFileReader.ScenarioOutputProperties.GIT_LOCATION, outputPropertyFilePath);
+                    getProperty(PropertyFileReader.BuildOutputProperties.GIT_LOCATION, outputPropertyFilePath);
             if (gitLocation == null || gitLocation.isEmpty()) {
                 logger.error("Git location received as null/empty for test plan with id " + testPlan.getId());
                 stringBuilder.append("Git location: Unknown!");
@@ -185,5 +185,21 @@ public class EmailReportGenerator {
             return "Git build details are unknown!";
         }
         return stringBuilder.toString();
+    }
+
+    /**
+     * Check if the latest run of a certain product include failed tests.
+     * @param product product
+     * @return if test-failures exists or not
+     */
+    public boolean hasFailedTests(Product product) {
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        List<TestPlan> testPlans = testPlanUOW.getLatestTestPlans(product);
+        for (TestPlan testPlan: testPlans) {
+            if (testPlan.getStatus().equals(Status.FAIL)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/model/email/TestPlanResultSection.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/model/email/TestPlanResultSection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.reporting.model.email;
+
+/**
+ *  Model class representing the test-plan result section in email-report.
+ */
+public class TestPlanResultSection {
+
+    private String infraCombination;
+    private String deployment;
+    private String result;
+    private String dashboardLink;
+    private String gitRevision;
+    private String gitLocation;
+
+    public String getInfraCombination() {
+        return infraCombination;
+    }
+
+    public void setInfraCombination(String infraCombination) {
+        this.infraCombination = infraCombination;
+    }
+
+    public String getDeployment() {
+        return deployment;
+    }
+
+    public void setDeployment(String deployment) {
+        this.deployment = deployment;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public String getDashboardLink() {
+        return dashboardLink;
+    }
+
+    public void setDashboardLink(String dashboardLink) {
+        this.dashboardLink = dashboardLink;
+    }
+
+    public String getGitRevision() {
+        return gitRevision;
+    }
+
+    public void setGitRevision(String gitRevision) {
+        this.gitRevision = gitRevision;
+    }
+
+    public String getGitLocation() {
+        return gitLocation;
+    }
+
+    public void setGitLocation(String gitLocation) {
+        this.gitLocation = gitLocation;
+    }
+}

--- a/reporting/src/main/resources/templates/email_report.mustache
+++ b/reporting/src/main/resources/templates/email_report.mustache
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<html>
+<head>
+    <title>WSO2 Test Grid - Test Execution Summary</title>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg" crossorigin="anonymous">
+    <style>
+        /*
+        Report table style
+         */
+        table.reportTable {
+            font-family: sans-serif;
+            border: 1px solid #000000;
+            background-color: #FFFFFF;
+            width: 95%;
+            text-align: left;
+            border-collapse: collapse;
+        }
+
+        table.reportTable td, table.reportTable th {
+            border: 1px solid #000000;
+            padding: 10px 5px;
+        }
+
+        table.reportTable tbody td {
+            font-size: 14px;
+        }
+
+        table.reportTable tr:nth-child(even) {
+            background: #F6F6F6;
+        }
+
+        table.reportTable thead {
+            background: #949494;
+            border-bottom: 2px solid #000000;
+        }
+
+        table.reportTable thead th {
+            font-size: 16px;
+            font-weight: bold;
+            color: #000000;
+            text-align: center;
+        }
+
+        table.reportTable thead th:first-child {
+            border-left: none;
+        }
+
+        /*
+        Titles
+         */
+        .tableTitle {
+            font-family: sans-serif;
+            font-weight: 600;
+            font-size: 20px;
+            line-height: 20px;
+            width: 100%;
+            color: #e46226;
+        }
+
+        .mainTitle {
+            font-family: sans-serif;
+            font-weight: 900;
+            font-size: 30px;
+            line-height: 20px;
+            width: 100%;
+            color: #e46226;
+        }
+
+        .testResultSubTitle {
+            font-family: sans-serif;
+            font-size: 14px;
+            line-height: 20px;
+            font-weight: bold;
+            color: #e46226;
+        }
+
+        .consoleLog {
+           font-family: monospace;
+            font-size: 12px;
+        }
+
+    </style>
+</head>
+<body>
+    <div style="margin: auto; background-color: #ffffff;">
+        {{#parsedReport}}
+            <table style="padding: 0 0; width: 100%; background: #ffffff;">
+                <tr>
+                    <td colspan="2"
+                        style="font-family: arial; font-size: 16px; line-height: 24px; color: #676767; border-top: 0px solid #cccccc;">
+                        <table>
+                            <tr>
+                                <td style="font-family: arial; font-size: 16px; line-height: 24px; text-align: center;">
+                                    <span class ="mainTitle">{{productName}}</span><br/><br/>
+                                    <span class ="mainTitle">integration tests {{productTestStatus}}!</span><br/>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            <br/>
+            <div><em>{{{gitBuildDetails}}}</em></div>
+            <br/>
+            <span class="testResultSubTitle">Tests are failing in following environments:-</span>
+            <!--Start of per test-plan-->
+        <table class="reportTable">
+            {{#perTestPlan}}
+            <tr>
+                <td style="border-left: hidden; border-right: hidden;">
+                    <span class="testResultSubTitle">Infrastructure:</span>
+                    <span>{{infraCombination}}</span>
+                    <br/>
+                    <span class="testResultSubTitle">Deployment:</span>
+                    <span>{{deployment}}</span>
+                    <br/>
+                    <br/>
+                    <div class="consoleLog">
+                        {{{result}}}
+                    </div>
+                    <br/>
+                    <span class="testResultSubTitle">Detailed results available @ </span>
+                    <span><a href="{{dashboardLink}}">TestGrid dashboard</a></span>
+                    <br/>
+                </td>
+            </tr>
+            {{/perTestPlan}}
+            <!--End of per test-plan-->
+        {{/parsedReport}}
+    </table>
+        <em>Tested by WSO2 TestGrid.</em>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
**Purpose**
Testgrid needs to send email alerts specifically when tests of a certain testgrid-job are failing.
The email should consist (only) failing tests details with actionable details.
Fixes #804 
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Improve alerting

**Approach**
Once the test-run is finalized, a new command is introduced to generate email-able report content (as a HTML page).
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**User stories**
As an interested party of a particular product/ testgrid-job, I should get alerts when the job is failing mentioning what is failing and why.
<!-- Summary of user stories addressed by this change> -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
**Learning**
<!-- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
