### PR TITLE
Add Tinkerer Log download operation

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/Agent.java
+++ b/common/src/main/java/org/wso2/testgrid/common/Agent.java
@@ -11,19 +11,23 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-package org.wso2.testgrid.deployment.tinkerer.beans;
+package org.wso2.testgrid.common;
+
+import java.io.Serializable;
 
 /**
  * This class holds Agent data.
  *
  * @since 1.0.0
  */
-public class Agent {
+public class Agent implements Serializable {
+
+    private static final long serialVersionUID = 9208056724380972876L;
 
     private String agentId;
     private String provider;

--- a/common/src/main/java/org/wso2/testgrid/common/Agent.java
+++ b/common/src/main/java/org/wso2/testgrid/common/Agent.java
@@ -31,15 +31,18 @@ public class Agent {
     private String testPlanId;
     private String instanceId;
     private String instanceName;
+    private String instanceIp;
+    private String instanceUser;
 
     public Agent(String agentId) {
         this.agentId = agentId;
         String[] params = agentId.split(":");
-        if (params.length == 4) {
+        if (params.length == 5) {
             this.provider = params[0];
             this.region = params[1];
             this.testPlanId = params[2];
             this.instanceId = params[3];
+            this.instanceIp = params[4];
         }
     }
 
@@ -89,5 +92,21 @@ public class Agent {
 
     public void setInstanceName(String instanceName) {
         this.instanceName = instanceName;
+    }
+
+    public String getInstanceIp() {
+        return instanceIp;
+    }
+
+    public void setInstanceIp(String instanceIp) {
+        this.instanceIp = instanceIp;
+    }
+
+    public String getInstanceUser() {
+        return instanceUser;
+    }
+
+    public void setInstanceUser(String instanceUser) {
+        this.instanceUser = instanceUser;
     }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/DeploymentCreationResult.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DeploymentCreationResult.java
@@ -20,6 +20,7 @@
 package org.wso2.testgrid.common;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -37,6 +38,8 @@ public class DeploymentCreationResult implements Serializable {
     private String name;
     private Properties properties = new Properties();
     private List<Host> hosts = Collections.emptyList();
+    private List<Agent> agents;
+    private String bastianIP;
 
     public String getName() {
         return name;
@@ -77,4 +80,19 @@ public class DeploymentCreationResult implements Serializable {
         this.hosts = hosts;
     }
 
+    public void setAgents(List<Agent> agents) {
+        this.agents = agents;
+    }
+
+    public List<Agent> getAgents() {
+        return agents != null ? agents : new ArrayList<>();
+    }
+
+    public void setBastianIP(String bastianIP) {
+        this.bastianIP = bastianIP;
+    }
+
+    public String getBastianIP() {
+        return bastianIP;
+    }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -59,5 +59,10 @@ public class TestGridConstants {
 
     public static final String TEST_TYPE_FUNCTIONAL = "FUNCTIONAL";
     public static final String TEST_TYPE_PERFORMANCE = "PERFORMANCE";
+    public static final String TEST_TYPE_INTEGRATION = "INTEGRATION";
+
+    public static final String OUTPUT_BASTIAN_IP = "BastionEIP";
+
+
 
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -102,6 +102,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     @Transient
     private ResultFormat resultFormat;
 
+    @Transient
+    private String keyFileLocation;
+
     /**
      * Returns the status of the infrastructure.
      *
@@ -314,6 +317,24 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
      */
     public void setResultFormat(ResultFormat resultFormat) {
         this.resultFormat = resultFormat;
+    }
+
+    /**
+     * Get the location of the key file used to access the instances.
+     *
+     * @return location of the key file
+     */
+    public String getKeyFileLocation() {
+        return keyFileLocation;
+    }
+
+    /**
+     * Sets the location of the key file.
+     *
+     * @param keyFileLocation location of the key file
+     */
+    public void setKeyFileLocation(String keyFileLocation) {
+        this.keyFileLocation = keyFileLocation;
     }
 
     @Override

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -133,7 +133,13 @@ public class ConfigurationContext {
         /**
          * Deployment Tinkerer password of TestGrid deployment.
          */
-        DEPLOYMENT_TINKERER_PASSWORD("DEPLOYMENT_TINKERER_PASSWORD");
+        DEPLOYMENT_TINKERER_PASSWORD("DEPLOYMENT_TINKERER_PASSWORD"),
+
+        /**
+         * Base path of deployment Tinkerer rest api
+         */
+        DEPLOYMENT_TINKERER_REST_BASE_PATH("DEPLOYMENT_TINKERER_REST_BASE_PATH");
+
 
         private String propertyName;
 

--- a/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
@@ -33,6 +33,7 @@ public class JobConfigFile {
     private String infrastructureRepository;
     private String deploymentRepository;
     private String scenarioTestsRepository;
+    private String keyFileLocation;
 
     /**
      * @see #isRelativePaths()
@@ -148,6 +149,14 @@ public class JobConfigFile {
         this.workingDir = workingDir;
     }
 
+    public String getKeyFileLocation() {
+        return keyFileLocation;
+    }
+
+    public void setKeyFileLocation(String keyFileLocation) {
+        this.keyFileLocation = keyFileLocation;
+    }
+
     @Override
     public String toString() {
         return "JobConfigFile{" +
@@ -156,6 +165,7 @@ public class JobConfigFile {
                 ", scenarioTestsRepository='" + scenarioTestsRepository + '\'' +
                 ", isRelativePaths=" + isRelativePaths +
                 ", testgridYamlLocation='" + testgridYamlLocation + '\'' +
+                ", testgridKeyFileLocation='" + keyFileLocation + '\'' +
                 '}';
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -117,6 +117,14 @@
             <groupId>org.wso2.testgrid</groupId>
             <artifactId>org.wso2.testgrid.logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5-fluent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
         <!-- Jacoco agent -->
         <dependency>
             <groupId>org.jacoco</groupId>

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -163,11 +163,10 @@ public class TestPlanExecutor {
             logger.warn(String.format("Unable retrieve agents for  test plan with id %s , %n " +
                     "Continuing the build with no log download support", testPlan.getId()));
         }
-        OSCategory osCategory = getOsCatagory(testPlan.getInfraParameters());
+        OSCategory osCategory = getOSCatagory(testPlan.getInfraParameters());
         try {
             Optional<TinkererClient> executer = TinkererClientFactory.getExecuter(osCategory);
             if (executer.isPresent()) {
-                logger.info("Initiating log file downloading..");
                 executer.get().downloadLogs(deploymentCreationResult, testPlan);
             } else {
                 logger.error("Unable to find a Tinker Executor for OS category " + osCategory);
@@ -193,7 +192,7 @@ public class TestPlanExecutor {
         persistTestPlanStatus(testPlan);
 
         //cleanup
-//        releaseInfrastructure(testPlan, infrastructureProvisionResult, deploymentCreationResult);
+        releaseInfrastructure(testPlan, infrastructureProvisionResult, deploymentCreationResult);
 
         // Print summary
         printSummary(testPlan, System.currentTimeMillis() - startTime);
@@ -676,10 +675,12 @@ public class TestPlanExecutor {
 
     /**
      *
-     * @param infraParameters
-     * @return
+     * Returns the Category of the Operating system in the infra parameter String
+     *
+     * @param infraParameters the infrastructure parameters.
+     * @return the Catagory of the Operating System
      */
-    private OSCategory getOsCatagory(String infraParameters) {
+    private OSCategory getOSCatagory(String infraParameters) {
         if (infraParameters.contains(OSCategory.WINDOWS.toString().toLowerCase(Locale.ENGLISH))) {
             return OSCategory.WINDOWS;
         } else {

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -18,7 +18,11 @@
 
 package org.wso2.testgrid.core;
 
+import com.google.gson.Gson;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.client5.http.fluent.Response;
+import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.automation.exception.ReportGeneratorException;
@@ -28,6 +32,7 @@ import org.wso2.testgrid.automation.parser.ResultParser;
 import org.wso2.testgrid.automation.parser.ResultParserFactory;
 import org.wso2.testgrid.automation.report.ReportGenerator;
 import org.wso2.testgrid.automation.report.ReportGeneratorFactory;
+import org.wso2.testgrid.common.Agent;
 import org.wso2.testgrid.common.Deployer;
 import org.wso2.testgrid.common.DeploymentCreationResult;
 import org.wso2.testgrid.common.Host;
@@ -38,6 +43,7 @@ import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
+import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.exception.DeployerInitializationException;
@@ -54,11 +60,19 @@ import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.dao.uow.TestScenarioUOW;
 import org.wso2.testgrid.deployment.DeployerFactory;
 import org.wso2.testgrid.infrastructure.InfrastructureProviderFactory;
+import org.wso2.testgrid.tinkerer.TinkererClient;
+import org.wso2.testgrid.tinkerer.TinkererClientFactory;
+import org.wso2.testgrid.tinkerer.exception.TinkererOperationException;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -122,6 +136,46 @@ public class TestPlanExecutor {
         }
         // Run test scenarios.
         runScenarioTests(testPlan, deploymentCreationResult);
+        //download log files
+
+        //Call the rest api of tinkerer and get the agents for current test plan
+        try {
+            String tinkererEndpoint = ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties
+                    .DEPLOYMENT_TINKERER_REST_BASE_PATH);
+            String username = ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties
+                    .DEPLOYMENT_TINKERER_USERNAME);
+            String password = ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties
+                    .DEPLOYMENT_TINKERER_PASSWORD);
+            String agentsPath = tinkererEndpoint + "test-plan/" + testPlan.getId() + "/agents";
+            Response execute = Request.Get(agentsPath)
+                    .setHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(
+                            StringUtil.concatStrings(username, ":", password).getBytes(
+                                    Charset.defaultCharset())))
+                    .execute();
+            String agentContent = execute.returnContent().toString();
+            logger.debug("AgentContent" + agentContent);
+            Agent[] agents = new Gson().fromJson(agentContent, Agent[].class);
+            for (Agent agent : Arrays.asList(agents)) {
+                logger.info("Agent registered : " + agent.getAgentId());
+            }
+            deploymentCreationResult.setAgents(Arrays.asList(agents));
+        } catch (IOException e) {
+            logger.warn(String.format("Unable retrieve agents for  test plan with id %s , %n " +
+                    "Continuing the build with no log download support", testPlan.getId()));
+        }
+        OSCategory osCategory = getOsCatagory(testPlan.getInfraParameters());
+        try {
+            Optional<TinkererClient> executer = TinkererClientFactory.getExecuter(osCategory);
+            if (executer.isPresent()) {
+                logger.info("Initiating log file downloading..");
+                executer.get().downloadLogs(deploymentCreationResult, testPlan);
+            } else {
+                logger.error("Unable to find a Tinker Executor for OS category " + osCategory);
+            }
+        } catch (TinkererOperationException e) {
+            logger.error("Error while downloading the log files for TestPlan" +
+                    testPlan.getDeploymentPattern().getProduct().getName());
+        }
         //report generation
         try {
             ReportGenerator reportGenerator = ReportGeneratorFactory.getReportGenerator(testPlan);
@@ -139,7 +193,7 @@ public class TestPlanExecutor {
         persistTestPlanStatus(testPlan);
 
         //cleanup
-        releaseInfrastructure(testPlan, infrastructureProvisionResult, deploymentCreationResult);
+//        releaseInfrastructure(testPlan, infrastructureProvisionResult, deploymentCreationResult);
 
         // Print summary
         printSummary(testPlan, System.currentTimeMillis() - startTime);
@@ -150,7 +204,7 @@ public class TestPlanExecutor {
      * Run all the pre-scenario scripts mentioned in the testgrid.yaml.
      *
      * @param testPlan the test plan
-     * @return  a boolean value indicating the status of the operation
+     * @return a boolean value indicating the status of the operation
      */
     private boolean runPreScenariosScripts(TestPlan testPlan, DeploymentCreationResult deploymentCreationResult) {
         String scriptsLocation = testPlan.getScenarioTestsRepository();
@@ -190,7 +244,7 @@ public class TestPlanExecutor {
      * Run all the post-scenario scripts mentioned in the testgrid.yaml.
      *
      * @param testPlan the test plan
-     * @return  a boolean value indicating the status of the operation
+     * @return a boolean value indicating the status of the operation
      */
     private boolean runPostScenariosScripts(TestPlan testPlan, DeploymentCreationResult deploymentCreationResult) {
         String scriptsLocation = testPlan.getScenarioTestsRepository();
@@ -297,7 +351,7 @@ public class TestPlanExecutor {
      * @throws TestPlanExecutorException thrown when error on creating deployment
      */
     private DeploymentCreationResult createDeployment(InfrastructureConfig infrastructureConfig, TestPlan testPlan,
-            InfrastructureProvisionResult infrastructureProvisionResult)
+                                                      InfrastructureProvisionResult infrastructureProvisionResult)
             throws TestPlanExecutorException {
         try {
             if (!infrastructureProvisionResult.isSuccess()) {
@@ -346,7 +400,7 @@ public class TestPlanExecutor {
      * @param testPlan             test plan
      */
     private InfrastructureProvisionResult provisionInfrastructure(InfrastructureConfig infrastructureConfig,
-            TestPlan testPlan) {
+                                                                  TestPlan testPlan) {
         try {
             if (infrastructureConfig == null) {
                 persistTestPlanStatus(testPlan, Status.FAIL);
@@ -396,8 +450,8 @@ public class TestPlanExecutor {
      *                                   infrastructure
      */
     private void releaseInfrastructure(TestPlan testPlan,
-            InfrastructureProvisionResult infrastructureProvisionResult,
-            DeploymentCreationResult deploymentCreationResult)
+                                       InfrastructureProvisionResult infrastructureProvisionResult,
+                                       DeploymentCreationResult deploymentCreationResult)
             throws TestPlanExecutorException {
         try {
             InfrastructureConfig infrastructureConfig = testPlan.getInfrastructureConfig();
@@ -501,29 +555,29 @@ public class TestPlanExecutor {
      * Prints a summary of the executed test plan.
      * Summary includes the list of scenarios that has been run, and their pass/fail status.
      *
-     * @param testPlan the test plan
+     * @param testPlan  the test plan
      * @param totalTime time taken to run the test plan
      */
     void printSummary(TestPlan testPlan, long totalTime) {
         switch (testPlan.getStatus()) {
-        case SUCCESS:
-            logger.info("all tests passed...");
-            break;
-        case ERROR:
-            logger.error("There are deployment/test errors...");
-            logger.info("Sorry, we are yet to infer an error summary!");
-            break;
-        case FAIL:
-            printFailState(testPlan);
-            break;
-        case RUNNING:
-        case PENDING:
-        case DID_NOT_RUN:
-        case INCOMPLETE:
-        default:
-            logger.error(StringUtil.concatStrings(
-                    "Inconsistent state detected (", testPlan.getStatus(), "). Please report this to testgrid team "
-                            + "at github.com/wso2/testgrid."));
+            case SUCCESS:
+                logger.info("all tests passed...");
+                break;
+            case ERROR:
+                logger.error("There are deployment/test errors...");
+                logger.info("Sorry, we are yet to infer an error summary!");
+                break;
+            case FAIL:
+                printFailState(testPlan);
+                break;
+            case RUNNING:
+            case PENDING:
+            case DID_NOT_RUN:
+            case INCOMPLETE:
+            default:
+                logger.error(StringUtil.concatStrings(
+                        "Inconsistent state detected (", testPlan.getStatus(), "). Please report this to testgrid team "
+                                + "at github.com/wso2/testgrid."));
         }
 
         printSeparator(LINE_LENGTH);
@@ -618,7 +672,40 @@ public class TestPlanExecutor {
         } else {
             return diffDays + " days" + " " + (diffHours % 24) + " hours";
         }
+    }
+
+    /**
+     *
+     * @param infraParameters
+     * @return
+     */
+    private OSCategory getOsCatagory(String infraParameters) {
+        if (infraParameters.contains(OSCategory.WINDOWS.toString().toLowerCase(Locale.ENGLISH))) {
+            return OSCategory.WINDOWS;
+        } else {
+            return OSCategory.UNIX;
+        }
+    }
+
+    /**
+     *
+     */
+    public enum OSCategory {
+
+        UNIX("UNIX", ""),
+        WINDOWS("WINDOWS", "");
+
+        private final String osCategory;
+        OSCategory(String osCategory, String logPath) {
+            this.osCategory = osCategory;
+        }
+
+        @Override
+        public String toString() {
+            return this.osCategory;
+        }
 
     }
 
 }
+

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -216,6 +216,7 @@ public class GenerateTestPlanCommand implements Command {
 
             String fileName = String
                     .format("%s-%02d%s", TestGridConstants.TEST_PLAN_YAML_PREFIX, (i + 1), FileUtil.YAML_EXTENSION);
+            testPlan.setKeyFileLocation(jobConfigFile.getKeyFileLocation());
             String output = yaml.dump(testPlan);
 
             //Remove reference ids from yaml
@@ -290,7 +291,11 @@ public class GenerateTestPlanCommand implements Command {
             //scenarios
             repoPath = Paths.get(parent, jobConfigFile.getScenarioTestsRepository());
             jobConfigFile.setScenarioTestsRepository(resolvePath(repoPath, jobConfigFile));
-
+            //keyfile
+            if (jobConfigFile.getKeyFileLocation() != null) {
+                repoPath = Paths.get(parent, jobConfigFile.getKeyFileLocation());
+                jobConfigFile.setKeyFileLocation(resolvePath(repoPath, jobConfigFile));
+            }
             if (jobConfigFile.getTestgridYamlLocation() != null) {
                 //testgrid.yaml
                 repoPath = Paths.get(parent, jobConfigFile.getTestgridYamlLocation());

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/TinkererClient.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/TinkererClient.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.tinkerer;
+
+
+import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+import org.wso2.testgrid.tinkerer.exception.TinkererOperationException;
+
+/**
+ *This is an abstraction for the deployment tinkerer client.
+ *
+ * @since 1.0.0
+ */
+public abstract class TinkererClient {
+
+    private String tinkererBase;
+    private String tinkererUserName;
+    private String tinkererPassword;
+
+    /**
+     *This constructor will save the current deployment tinkerer properties as a super class.
+     *
+     */
+    TinkererClient() {
+        this.tinkererBase = ConfigurationContext.getProperty(ConfigurationContext
+                .ConfigurationProperties.DEPLOYMENT_TINKERER_REST_BASE_PATH);
+        this.tinkererUserName = ConfigurationContext.getProperty(ConfigurationContext
+                .ConfigurationProperties.DEPLOYMENT_TINKERER_USERNAME);
+        this.tinkererPassword = ConfigurationContext.getProperty(ConfigurationContext
+                .ConfigurationProperties.DEPLOYMENT_TINKERER_PASSWORD);
+    }
+
+    public String getTinkererBase() {
+        return tinkererBase;
+    }
+
+    public void setTinkererBase(String tinkererBase) {
+        this.tinkererBase = tinkererBase;
+    }
+
+    public String getTinkererUserName() {
+        return tinkererUserName;
+    }
+
+    public void setTinkererUserName(String tinkererUserName) {
+        this.tinkererUserName = tinkererUserName;
+    }
+
+    public String getTinkererPassword() {
+        return tinkererPassword;
+    }
+
+    public void setTinkererPassword(String tinkererPassword) {
+        this.tinkererPassword = tinkererPassword;
+    }
+
+    /**
+     * This method will download all the log files from the instance.
+     * The log files location will be derived from Test type and Operating system.
+     * all the files inside the derived log location will be downloaded to the destination
+     *
+     * @param deploymentCreationResult the output form the deployment stage that contains the information
+     *                                 about the instances.
+     * @param testPlan The Test plan object for the job
+     * @throws TinkererOperationException When there is an error downloading the logs.
+     */
+    public abstract void downloadLogs(DeploymentCreationResult deploymentCreationResult, TestPlan testPlan)
+            throws TinkererOperationException;
+}
+

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/TinkererClientFactory.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/TinkererClientFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.tinkerer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.core.TestPlanExecutor;
+import java.util.Optional;
+
+/**
+ *
+ * This Factory class creates the appropriate Deployment tinkerer client for the Operating system
+ * category.
+ *
+ * @since 1.0.0
+ */
+public class TinkererClientFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(TinkererClientFactory.class);
+
+    /**
+     * This method returns the correct Deployment tinkerer client for the {@link TestPlanExecutor.OSCategory}
+     * type.
+     *
+     * @param osCategory os category of the instance where tinkerer agent is running
+     * @return the subclass of {@link TinkererClient}
+     */
+    public static Optional<TinkererClient> getExecuter(TestPlanExecutor.OSCategory osCategory) {
+        if (osCategory.equals(TestPlanExecutor.OSCategory.UNIX)) {
+            logger.info("OSCatagory is UNIX");
+            return Optional.of(new UnixClient());
+        } else if (osCategory.equals(TestPlanExecutor.OSCategory.WINDOWS)) {
+            logger.info("OSCatagory is WINDOWS");
+            return Optional.of(new WindowsClient());
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
@@ -18,12 +18,18 @@
 package org.wso2.testgrid.tinkerer;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.FileUtils;
 import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.client5.http.fluent.Response;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Agent;
@@ -51,7 +57,6 @@ import java.util.regex.Pattern;
  * UNIX operating systems.
  *
  * @since 1.0.0
- *
  */
 public class UnixClient extends TinkererClient {
 
@@ -65,58 +70,112 @@ public class UnixClient extends TinkererClient {
 
         String testType = testPlan.getScenarioConfig().getTestType();
         logger.info("TestType is : " + testType);
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
-        try {
-            for (Agent agent : deploymentCreationResult.getAgents()) {
-                String productBasePath = "";
-                String logLocation = "";
-                String operationPath = this.getTinkererBase() + "test-plan/" + agent.getTestPlanId()
-                        + "/agent/" + agent.getInstanceName() + "/operation";
-                if (TestGridConstants.TEST_TYPE_FUNCTIONAL.equals(testType)) {
-                    //get the carbon.home from the instance where the product is running
+        for (Agent agent : deploymentCreationResult.getAgents()) {
+            logger.info("Initiating LOG file download for Agent " + agent.getInstanceName()
+                    + "\n agent instance ID " + agent.getInstanceId()
+                    + "\n test plan " + testPlan.getId());
+
+            String productBasePath = "";
+            String logLocation = "";
+            String operationPath = this.getTinkererBase() + "test-plan/" + agent.getTestPlanId()
+                    + "/agent/" + agent.getInstanceName() + "/operation";
+            if (TestGridConstants.TEST_TYPE_FUNCTIONAL.equals(testType)) {
+                //get the carbon.home from the instance where the product is running
+                String content = "";
+                try {
+                    Map<String, Object> payload = new HashMap<>();
+                    payload.put("code", "SHELL");
+                    payload.put("request", "ps -ef | grep 'carbon.home'");
                     Response execute = Request.Post(operationPath).setHeader
                             (HttpHeaders.CONTENT_TYPE, "application/json")
                             .setHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder()
                                     .encodeToString(StringUtil.concatStrings(this.getTinkererUserName(),
                                             ":", this.getTinkererPassword()).getBytes(Charset.defaultCharset())))
-                            .bodyString("{\"code\":\"SHELL\",\"request\":\"ps -ef |grep 'carbon.home'\"}",
-                                    ContentType.APPLICATION_JSON).execute();
+                            .bodyString(gson.toJson(payload), ContentType.APPLICATION_JSON)
+                            .execute();
 
-                    String content = execute.returnContent().toString();
-                    if (content.contains("carbon.home")) {
-                        String patternString = "carbon\\.home=[a-z\\/0-9-.]*";
-                        Pattern pattern = Pattern.compile(patternString);
-                        Matcher matcher = pattern.matcher(content);
+                    HttpResponse httpResponse = execute.returnResponse();
+                    if (httpResponse.getCode() != HttpStatus.SC_OK) {
+                        throw new TinkererOperationException("Error occurred while performing tinkerer " +
+                                "REST api call for retrieving carbon.home. \nError message :" +
+                                EntityUtils.toString(((CloseableHttpResponse) httpResponse).getEntity()));
+                    }
 
-                        if (matcher.find()) {
-                            productBasePath = matcher.group().split("=")[1];
-                        }
-                    }
-                    logLocation = productBasePath + SCENARIO_LOG_LOCATION;
-                } else if (TestGridConstants.TEST_TYPE_INTEGRATION.equals(testType)) {
-                    for (Host host : deploymentCreationResult.getHosts()) {
-                        if (host.getLabel().equals("workspace")) {
-                            productBasePath = host.getIp();
-                            break;
-                        }
-                    }
-                    logLocation = productBasePath + INTEGRATION_LOG_LOCATION;
+                    content = EntityUtils.toString(((CloseableHttpResponse) httpResponse).getEntity());
+                } catch (IOException e) {
+                    throw new TinkererOperationException("Error occurred while retrieving the carbon.home value" +
+                            "from agent" + agent.getAgentId()
+                            + "\nRunning on instance : " + agent.getInstanceName()
+                            + "\nfor test plan " + testPlan.getId(), e);
+                } catch (ParseException e) {
+                    throw new TinkererOperationException("Error occurred while parsing the response " +
+                            "wile retrieving carbon.home from agent" + agent.getAgentId()
+                            + "\nRunning on instance : " + agent.getInstanceName()
+                            + "\nfor test plan " + testPlan.getId(), e);
                 }
-                logger.info("Product base path found " + productBasePath);
+                if (content.contains("carbon.home")) {
+                    String patternString = "carbon\\.home=[a-z\\/0-9-.]*";
+                    Pattern pattern = Pattern.compile(patternString);
+                    Matcher matcher = pattern.matcher(content);
+
+                    if (matcher.find()) {
+                        productBasePath = matcher.group().split("=")[1];
+                    }
+                }
+                logLocation = productBasePath + SCENARIO_LOG_LOCATION;
+            } else if (TestGridConstants.TEST_TYPE_INTEGRATION.equals(testType)) {
+                for (Host host : deploymentCreationResult.getHosts()) {
+                    if (host.getLabel().equals("workspace")) {
+                        productBasePath = host.getIp();
+                        break;
+                    }
+                }
+                logLocation = productBasePath + INTEGRATION_LOG_LOCATION;
+            }
+            logger.info("Product base path found " + productBasePath);
+            Map<String, String> resultMap;
+            try {
+                Map<String, Object> payload = new HashMap<>();
+                payload.put("code", "SHELL");
+                payload.put("request", "ls " + logLocation);
                 Response logFiles = Request.Post(operationPath).setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .setHeader(HttpHeaders.AUTHORIZATION,
                                 "Basic " + Base64.getEncoder().encodeToString(
                                         StringUtil.concatStrings(this.getTinkererUserName(),
                                                 ":", this.getTinkererPassword()).getBytes(Charset.defaultCharset())))
-                        .bodyString("{\"code\":\"SHELL\",\"request\":\"ls " + logLocation + "\"}",
-                                ContentType.APPLICATION_JSON).execute();
-                Map<String, String> resultMap = new Gson().fromJson(logFiles.returnContent().asString(),
+                        .bodyString(gson.toJson(payload), ContentType.APPLICATION_JSON).execute();
+                //check if REST api call was successful
+                HttpResponse response = logFiles.returnResponse();
+                if (response.getCode() != HttpStatus.SC_OK) {
+                    throw new TinkererOperationException("Error occurred while performing tinkerer " +
+                            "REST api call for getting list of log files. \nError message :"
+                            + EntityUtils.toString(((CloseableHttpResponse) response).getEntity()));
+                }
+                //create a map of json response
+                resultMap = new Gson().fromJson(EntityUtils.toString(((CloseableHttpResponse) response).getEntity()),
                         new PropertyType().getType());
-                if (resultMap.containsKey("response")) {
-                    String response = resultMap.get("response");
-                    List<String> logFileNames = Arrays.asList(response.split("\n"));
+            } catch (IOException e) {
+                throw new TinkererOperationException("Error occurred while retrieving the list of log files from the" +
+                        "log location : " + logLocation
+                        + "\nfrom agent :" + agent.getAgentId()
+                        + "\nRunning on instance : " + agent.getInstanceName()
+                        + "\nfor test plan :" + testPlan.getId(), e);
+            } catch (ParseException e) {
+                throw new TinkererOperationException("Error occurred while parsing the list of log files from the" +
+                        "log location : " + logLocation
+                        + "\nfrom agent :" + agent.getAgentId()
+                        + "\nRunning on instance : " + agent.getInstanceName()
+                        + "\nfor test plan :" + testPlan.getId(), e);
+            }
+            if (resultMap != null && resultMap.containsKey("response")) {
+                String response = resultMap.get("response");
+                List<String> logFileNames = Arrays.asList(response.split("\n"));
 
-                    for (String logFileName : logFileNames) {
+
+                for (String logFileName : logFileNames) {
+                    try {
                         logger.info("Downloading log file : " + logFileName);
                         String key = Base64.getEncoder()
                                 .encodeToString(FileUtils.readFileToByteArray(new File(testPlan.getKeyFileLocation())));
@@ -124,34 +183,65 @@ public class UnixClient extends TinkererClient {
                         String destination = TestGridUtil.getTestGridHomePath() + File.separator +
                                 testPlan.getDeploymentPattern().getProduct().getName() + logFileName;
                         String bastianIP = deploymentCreationResult.getBastianIP();
-                        //TODO set correct download path so the log files are in the correct place in the folder hierarchy
+                        //TODO set correct download path so the log files are in the correct place in the
+                        // folder hierarchy
                         String downloadPath = this.getTinkererBase() + "test-plan/" + agent.getTestPlanId() +
                                 "/agent/" + agent.getInstanceName() + "/stream-file";
-                        Request.Post(downloadPath)
+
+                        Map<String, Object> payload = new HashMap<>();
+                        payload.put("code", "STREAM_FILE");
+                        Map<String, Object> subPayload = new HashMap<>();
+                        subPayload.put("key", key);
+                        subPayload.put("source", source);
+                        subPayload.put("destination", destination);
+                        subPayload.put("destination", destination);
+                        if (bastianIP != null) {
+                            subPayload.put("bastian-ip", bastianIP);
+                        }
+                        payload.put("data", subPayload);
+                        Response execute = Request.Post(downloadPath)
                                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                                .bodyString("{" +
-                                                "\"code\":\"STREAM_FILE\"," +
-                                                "\"data\":{\"key\":\"" + key + "\"," +
-                                                "\"source\":\"" + source + "\"," +
-                                                "\"destination\":\"" + destination + "\"" +
-                                                (bastianIP != null ? ",\"bastian-ip\":\"" +
-                                                        bastianIP + "\"" : "") + "}}"
-                                        , ContentType.APPLICATION_JSON)
+                                .setHeader(HttpHeaders.AUTHORIZATION,
+                                        "Basic " + Base64.getEncoder().encodeToString(
+                                                StringUtil.concatStrings(this.getTinkererUserName(),
+                                                        ":", this.getTinkererPassword())
+                                                        .getBytes(Charset.defaultCharset())))
+                                .bodyString(gson.toJson(payload), ContentType.APPLICATION_JSON)
                                 .execute();
+                        //check if REST api call was successful
+                        HttpResponse httpResponse = execute.returnResponse();
+                        if (httpResponse.getCode() != HttpStatus.SC_OK) {
+                            throw new TinkererOperationException("Error occurred while" +
+                                    " performing tinkerer REST api call for log download." +
+                                    "\nError message :"
+                                    + EntityUtils.toString(((CloseableHttpResponse) httpResponse).getEntity()));
+                        }
                         logger.debug("Download Location :" + destination);
+                    } catch (IOException e) {
+                        throw new TinkererOperationException("Error occurred while downloading " +
+                                "the log file location : " + logFileName
+                                + "\nfrom agent :" + agent.getAgentId()
+                                + "\nRunning on instance : " + agent.getInstanceName()
+                                + "\nfor test plan :" + testPlan.getId(), e);
+                    } catch (ParseException e) {
+                        throw new TinkererOperationException("Error occurred while parsing the " +
+                                "response from download " +
+                                "logfile operation : " + logFileName
+                                + "\nfrom agent :" + agent.getAgentId()
+                                + "\nRunning on instance : " + agent.getInstanceName()
+                                + "\nfor test plan :" + testPlan.getId(), e);
                     }
-                    logger.info("Successfully downloaded all log files ");
                 }
+                logger.info("Successfully downloaded all log files ");
             }
-        } catch (IOException e) {
-            throw new TinkererOperationException("Error occurred while executing the Tinkerer operation ", e);
         }
     }
 
     /**
      * The static inner class used as a type reference for parsing the json response
-     * to a map of strings
+     * to a map of strings.
      */
-    private static class PropertyType extends TypeToken<HashMap<String, String>> {}
+    private static class PropertyType extends TypeToken<HashMap<String, String>> {
+    }
 }
 

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.tinkerer;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.io.FileUtils;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.client5.http.fluent.Response;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.http.HttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Agent;
+import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.Host;
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.tinkerer.exception.TinkererOperationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class is the {@link TinkererClient} implementation for agents that are running in
+ * UNIX operating systems.
+ *
+ * @since 1.0.0
+ *
+ */
+public class UnixClient extends TinkererClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(UnixClient.class);
+    private static final String SCENARIO_LOG_LOCATION = "/repository/logs/";
+    private static final String INTEGRATION_LOG_LOCATION = "/logs";
+
+    @Override
+    public void downloadLogs(DeploymentCreationResult deploymentCreationResult, TestPlan testPlan)
+            throws TinkererOperationException {
+
+        String testType = testPlan.getScenarioConfig().getTestType();
+        logger.info("TestType is : " + testType);
+
+        try {
+            for (Agent agent : deploymentCreationResult.getAgents()) {
+                String productBasePath = "";
+                String logLocation = "";
+                String operationPath = this.getTinkererBase() + "test-plan/" + agent.getTestPlanId()
+                        + "/agent/" + agent.getInstanceName() + "/operation";
+                if (TestGridConstants.TEST_TYPE_FUNCTIONAL.equals(testType)) {
+                    //get the carbon.home from the instance where the product is running
+                    Response execute = Request.Post(operationPath).setHeader
+                            (HttpHeaders.CONTENT_TYPE, "application/json")
+                            .setHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder()
+                                    .encodeToString(StringUtil.concatStrings(this.getTinkererUserName(),
+                                            ":", this.getTinkererPassword()).getBytes(Charset.defaultCharset())))
+                            .bodyString("{\"code\":\"SHELL\",\"request\":\"ps -ef |grep 'carbon.home'\"}",
+                                    ContentType.APPLICATION_JSON).execute();
+
+                    String content = execute.returnContent().toString();
+                    if (content.contains("carbon.home")) {
+                        String patternString = "carbon\\.home=[a-z\\/0-9-.]*";
+                        Pattern pattern = Pattern.compile(patternString);
+                        Matcher matcher = pattern.matcher(content);
+
+                        if (matcher.find()) {
+                            productBasePath = matcher.group().split("=")[1];
+                        }
+                    }
+                    logLocation = productBasePath + SCENARIO_LOG_LOCATION;
+                } else if (TestGridConstants.TEST_TYPE_INTEGRATION.equals(testType)) {
+                    for (Host host : deploymentCreationResult.getHosts()) {
+                        if (host.getLabel().equals("workspace")) {
+                            productBasePath = host.getIp();
+                            break;
+                        }
+                    }
+                    logLocation = productBasePath + INTEGRATION_LOG_LOCATION;
+                }
+                logger.info("Product base path found " + productBasePath);
+                Response logFiles = Request.Post(operationPath).setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                        .setHeader(HttpHeaders.AUTHORIZATION,
+                                "Basic " + Base64.getEncoder().encodeToString(
+                                        StringUtil.concatStrings(this.getTinkererUserName(),
+                                                ":", this.getTinkererPassword()).getBytes(Charset.defaultCharset())))
+                        .bodyString("{\"code\":\"SHELL\",\"request\":\"ls " + logLocation + "\"}",
+                                ContentType.APPLICATION_JSON).execute();
+                Map<String, String> resultMap = new Gson().fromJson(logFiles.returnContent().asString(),
+                        new PropertyType().getType());
+                if (resultMap.containsKey("response")) {
+                    String response = resultMap.get("response");
+                    List<String> logFileNames = Arrays.asList(response.split("\n"));
+
+                    for (String logFileName : logFileNames) {
+                        logger.info("Downloading log file : " + logFileName);
+                        String key = Base64.getEncoder()
+                                .encodeToString(FileUtils.readFileToByteArray(new File(testPlan.getKeyFileLocation())));
+                        String source = logLocation + logFileName;
+                        String destination = TestGridUtil.getTestGridHomePath() + File.separator +
+                                testPlan.getDeploymentPattern().getProduct().getName() + logFileName;
+                        String bastianIP = deploymentCreationResult.getBastianIP();
+                        //TODO set correct download path so the log files are in the correct place in the folder hierarchy
+                        String downloadPath = this.getTinkererBase() + "test-plan/" + agent.getTestPlanId() +
+                                "/agent/" + agent.getInstanceName() + "/stream-file";
+                        Request.Post(downloadPath)
+                                .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .bodyString("{" +
+                                                "\"code\":\"STREAM_FILE\"," +
+                                                "\"data\":{\"key\":\"" + key + "\"," +
+                                                "\"source\":\"" + source + "\"," +
+                                                "\"destination\":\"" + destination + "\"" +
+                                                (bastianIP != null ? ",\"bastian-ip\":\"" +
+                                                        bastianIP + "\"" : "") + "}}"
+                                        , ContentType.APPLICATION_JSON)
+                                .execute();
+                        logger.debug("Download Location :" + destination);
+                    }
+                    logger.info("Successfully downloaded all log files ");
+                }
+            }
+        } catch (IOException e) {
+            throw new TinkererOperationException("Error occurred while executing the Tinkerer operation ", e);
+        }
+    }
+
+    /**
+     * The static inner class used as a type reference for parsing the json response
+     * to a map of strings
+     */
+    private static class PropertyType extends TypeToken<HashMap<String, String>> {}
+}
+

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/WindowsClient.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/WindowsClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.tinkerer;
+
+import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.TestPlan;
+
+/**
+ * This class is the {@link TinkererClient} implementation for agents that are running in
+ * WINDOWS operating systems.
+ *
+ * @since 1.0.0
+ *
+ */
+public class WindowsClient extends TinkererClient {
+
+    @Override
+    public void downloadLogs(DeploymentCreationResult deploymentCreationResult, TestPlan testPlan) {
+        //TODO implement the windows behaviour
+    }
+}

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/exception/TinkererOperationException.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/exception/TinkererOperationException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.tinkerer.exception;
+
+import org.wso2.testgrid.common.exception.TestGridException;
+
+/**
+ * Indicates an error has occurred when performing a tinkerer operation
+ *
+ * @since 1.0.0
+ *
+ */
+public class TinkererOperationException extends TestGridException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message of the exception
+     */
+    public TinkererOperationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the message provided and the cause.
+     *
+     * @param message the detailed message of the exception
+     * @param cause   the cause of the exception
+     */
+    public TinkererOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
@@ -144,7 +144,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
                 .replaceAll(repoPath, Paths.get(repoPath).toAbsolutePath().normalize().toString());
 
         Assert.assertEquals(generatedTestPlanContent, expectedTestPlanContent,
-                String.format("Generated test-plan is not correct: \n%s", generatedTestPlanContent));
+                String.format("Generated test-plan is not correct: %n%s", generatedTestPlanContent));
     }
 
     @AfterMethod

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -57,6 +57,8 @@ import org.wso2.testgrid.dao.uow.TestCaseUOW;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.dao.uow.TestScenarioUOW;
 import org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider;
+
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -161,7 +163,7 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         final Path generatedDeploymentFile = infrastructurePath.resolve("my-deployment.txt");
         assertTrue(Files.exists(generatedDeploymentFile), "Deployment creation script failed to run. Files does not "
                 + "exist: " + generatedDeploymentFile);
-        String content = new String(Files.readAllBytes(generatedDeploymentFile));
+        String content = new String(Files.readAllBytes(generatedDeploymentFile), StandardCharsets.UTF_8);
         Assert.assertEquals(content, "Deploy server1\n", "my-deployment.txt file does not contain expected content.");
     }
 

--- a/core/src/test/resources/job-config.yaml
+++ b/core/src/test/resources/job-config.yaml
@@ -2,3 +2,4 @@ infrastructureRepository: workspace/infrastructure
 deploymentRepository: workspace/deployment
 scenarioTestsRepository: workspace/scenarioTests
 testgridYamlLocation: workspace/testgrid.yaml
+keyFileLocation: workspace/testkey.pem

--- a/core/src/test/resources/job-config2.yaml
+++ b/core/src/test/resources/job-config2.yaml
@@ -2,3 +2,4 @@ infrastructureRepository: workspace/infrastructure
 deploymentRepository: workspace/deployment
 scenarioTestsRepository: workspace/scenarioTests
 testgridYamlLocation: workspace/testgrid.yaml
+keyFileLocation: workspace/testkey.pem

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -36,6 +36,7 @@ infrastructureConfig:
       phase: DESTROY
       type: SHELL
 infrastructureRepository: ./src/test/resources/workspace/infrastructure
+keyFileLocation: ./src/test/resources/workspace/testkey.pem
 scenarioConfig:
   scenarios:
   - description: Test Scenario

--- a/core/src/test/resources/workspace/testkey.pem
+++ b/core/src/test/resources/workspace/testkey.pem
@@ -1,0 +1,1 @@
+#key-content

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/SessionManager.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/SessionManager.java
@@ -20,17 +20,17 @@ package org.wso2.testgrid.deployment.tinkerer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.testgrid.deployment.tinkerer.beans.Agent;
+import org.wso2.testgrid.common.Agent;
 import org.wso2.testgrid.deployment.tinkerer.beans.OperationResponse;
 import org.wso2.testgrid.deployment.tinkerer.providers.AWSProvider;
 import org.wso2.testgrid.deployment.tinkerer.providers.Provider;
 
+import javax.websocket.Session;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.websocket.Session;
 
 /**
  * This class manage sessions of agents corresponding to agent ids.
@@ -71,6 +71,7 @@ public class SessionManager {
         String instanceId = agent.getInstanceId();
         if (provider != null && region != null && instanceId != null) {
             agent.setInstanceName(getInstanceName(provider, region, instanceId));
+            agent.setInstanceUser(getInstanceUser(provider, region, instanceId));
             agentSessions.put(agentId, agentSession);
             agents.put(agentId, agent);
         }
@@ -204,6 +205,32 @@ public class SessionManager {
             return infraProvider.getInstanceName(region, instanceId);
         } else {
             return instanceId;
+        }
+    }
+
+    /**
+     * Get the instance username that is used to log into the instance depending on the cloud provider.
+     *
+     * @param provider Provider Name
+     * @param region Region of the instance
+     * @param instanceId ID of the instance
+     * @return Username of the instance
+     */
+    private static String getInstanceUser(String provider, String region, String instanceId) {
+
+        Provider infraProvider = null;
+        switch (provider) {
+            case "aws":
+                infraProvider = new AWSProvider();
+                break;
+            default:
+                logger.warn("Unknown cloud provider: " + provider);
+        }
+        if (infraProvider != null) {
+            Optional<String> instanceUserName = infraProvider.getInstanceUserName(region, instanceId);
+            return instanceUserName.orElse(null);
+        } else {
+            return null;
         }
     }
 

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/SessionManager.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/SessionManager.java
@@ -25,12 +25,12 @@ import org.wso2.testgrid.deployment.tinkerer.beans.OperationResponse;
 import org.wso2.testgrid.deployment.tinkerer.providers.AWSProvider;
 import org.wso2.testgrid.deployment.tinkerer.providers.Provider;
 
-import javax.websocket.Session;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.websocket.Session;
 
 /**
  * This class manage sessions of agents corresponding to agent ids.

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/api/DeploymentTinkerer.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/api/DeploymentTinkerer.java
@@ -20,15 +20,22 @@ package org.wso2.testgrid.deployment.tinkerer.api;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Agent;
 import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
 import org.wso2.testgrid.deployment.tinkerer.SessionManager;
-import org.wso2.testgrid.common.Agent;
 import org.wso2.testgrid.deployment.tinkerer.beans.ErrorResponse;
 import org.wso2.testgrid.deployment.tinkerer.beans.OperationRequest;
 import org.wso2.testgrid.deployment.tinkerer.utils.Constants;
 import org.wso2.testgrid.deployment.tinkerer.utils.SSHHelper;
 
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import javax.websocket.Session;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -38,13 +45,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * This class represents REST service implementation of Deployment Tinkerer service.

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/beans/Operation.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/beans/Operation.java
@@ -18,8 +18,10 @@
 
 package org.wso2.testgrid.deployment.tinkerer.beans;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.gson.Gson;
 
+import java.util.Map;
 /**
  * This class holds abstract operation data.
  *
@@ -29,6 +31,16 @@ public abstract class Operation {
 
     private String operationId;
     private OperationCode code;
+    @JsonIgnoreProperties
+    private Map<String, String> data;
+
+    public Map<String, String> getData() {
+        return data;
+    }
+
+    public void setData(Map<String, String> data) {
+        this.data = data;
+    }
 
     public String getOperationId() {
         return operationId;
@@ -62,6 +74,6 @@ public abstract class Operation {
      * @since 1.0.0
      */
     public enum OperationCode {
-        SHELL, PING
+        SHELL, PING, STREAM_FILE
     }
 }

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/exception/DeploymentTinkererException.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/exception/DeploymentTinkererException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.deployment.tinkerer.exception;
+
+import org.wso2.testgrid.common.exception.TestGridException;
+
+/**
+ * Indicates an error with deployment tinkerer
+ *
+ * @since 1.0.0
+ */
+public class DeploymentTinkererException extends TestGridException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message of the exception
+     */
+    public DeploymentTinkererException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the message provided and the cause.
+     *
+     * @param message the detailed message of the exception
+     * @param cause   the cause of the exception
+     */
+    public DeploymentTinkererException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/AWSProvider.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/AWSProvider.java
@@ -21,8 +21,11 @@ package org.wso2.testgrid.deployment.tinkerer.providers;
 import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,5 +83,51 @@ public class AWSProvider implements Provider {
             return tagOptional.get().getValue();
         }
         return instanceId;
+    }
+
+    /**
+     *  This method will retrieve the instance username that is used to log into the instance via ssh.
+     *  E.g Ubuntu instance has username ubuntu
+     *  CentOS instance has username centos
+     *  The username must be present in the ami as a TAG with key USERNAME.
+     *
+     * @param region The aws region where instance is located
+     * @param instanceId ID value for the instance
+     * @return The username extracted from the TAG
+     */
+    public Optional<String> getInstanceUserName(String region, String instanceId) {
+
+        final AmazonEC2 amazonEC2 = AmazonEC2ClientBuilder.standard()
+                .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
+                .withRegion(region)
+                .build();
+
+        List<String> instanceIds = new ArrayList<>();
+        instanceIds.add(instanceId);
+        DescribeInstancesRequest request = new DescribeInstancesRequest();
+        request.setInstanceIds(instanceIds);
+        DescribeInstancesResult result = amazonEC2.describeInstances(request);
+        //Get instance id from the results
+        Optional<String> imageId = result.getReservations().stream()
+                .flatMap(reservation -> reservation.getInstances().stream())
+                .findFirst()
+                .map(Instance::getImageId);
+
+        if (imageId.isPresent()) {
+            List<String> imageIds = new ArrayList<>();
+            imageIds.add(imageId.get());
+            //get ami from the instance ID
+            DescribeImagesRequest imageReq = new DescribeImagesRequest();
+            imageReq.setImageIds(imageIds);
+            //Get the Tag containing the username from the ami
+            DescribeImagesResult describeImagesResult = amazonEC2.describeImages(imageReq);
+            Optional<String> userName = describeImagesResult.getImages().stream()
+                    .flatMap(image -> image.getTags().stream())
+                    .filter(tag -> tag.getKey().equals("USERNAME"))
+                    .findFirst()
+                    .map(Tag::getValue);
+            return userName;
+        }
+        return Optional.empty();
     }
 }

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/InfraProviderFactory.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/InfraProviderFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.deployment.tinkerer.providers;
+
+import java.util.Optional;
+
+/**
+ * This is the factory implementation for the {@link Provider} interface.
+ * the appropriate provider subclass will be created depending on the provider
+ * String provided.
+ *
+ * @since 1.0.0
+ */
+public class InfraProviderFactory {
+
+    private static final String AWS_PROVIDER = "aws";
+
+    /**
+     * Returns an Optional Provider implementation. the Optional will be empty if the
+     * provider is not identified.
+     *
+     * @param provider the cloud provider identifier
+     * @return Optional of the Provider implementation
+     */
+    public static Optional<Provider> getInfrastructureProvider(String provider) {
+
+        if (AWS_PROVIDER.equalsIgnoreCase(provider)) {
+            return Optional.of(new AWSProvider());
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
@@ -36,14 +36,14 @@ public interface Provider {
      * @param instanceId - Id of the instance.
      * @return The name of the instance.
      */
-    String getInstanceName(String region, String instanceId);
+    Optional<String> getInstanceName(String region, String instanceId);
 
     /**
      * Returns the instance username for the OS
      *
      * @param region region of the stack.
-     * @param imageId Id of the instance
+     * @param instanceId Id of the instance
      * @return An Optional instance of the username
      */
-    Optional<String> getInstanceUserName(String region, String imageId);
+    Optional<String> getInstanceUserName(String region, String instanceId);
 }

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
@@ -39,10 +39,11 @@ public interface Provider {
     String getInstanceName(String region, String instanceId);
 
     /**
+     * Returns the instance username for the OS
      *
-     * @param region
-     * @param imageId
-     * @return
+     * @param region region of the stack.
+     * @param imageId Id of the instance
+     * @return An Optional instance of the username
      */
     Optional<String> getInstanceUserName(String region, String imageId);
 }

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/providers/Provider.java
@@ -18,6 +18,7 @@
 
 package org.wso2.testgrid.deployment.tinkerer.providers;
 
+import java.util.Optional;
 /**
  * Interface for Cloud provider specific functionality.
  *
@@ -36,4 +37,12 @@ public interface Provider {
      * @return The name of the instance.
      */
     String getInstanceName(String region, String instanceId);
+
+    /**
+     *
+     * @param region
+     * @param imageId
+     * @return
+     */
+    Optional<String> getInstanceUserName(String region, String imageId);
 }

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/utils/SSHHelper.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/utils/SSHHelper.java
@@ -20,6 +20,7 @@ package org.wso2.testgrid.deployment.tinkerer.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Agent;
+import org.wso2.testgrid.deployment.tinkerer.exception.DeploymentTinkererException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,18 +47,19 @@ public class SSHHelper {
     private static final Logger logger = LoggerFactory.getLogger(SSHHelper.class);
 
     /**
-     *
      * Adds and entry to the ssh config file  that will enable direct access to the instance
      * via the bastian instance.
-     *
+     * <p>
      * The instance will contain a proxy access entry that will route the connection via the bastian
      * instance.
+     *
      * @param keyContent the content of the security key file (.pem file) that is used to access the instance
-     * @param bastianIP The IP address of the bastian instance.
-     * @param agent The {@link Agent} object corresponding to the remote agent running on the instance
+     * @param bastianIP  The IP address of the bastian instance.
+     * @param agent      The {@link Agent} object corresponding to the remote agent running on the instance
      * @throws IOException When there is an error creating the config entry
      */
-    public static void addConfigEntry(String keyContent, String bastianIP, Agent agent) throws IOException {
+    public static void addConfigEntry(String keyContent, String bastianIP, Agent agent) throws
+            IOException, DeploymentTinkererException {
 
         Path config = Paths.get(System.getProperty("user.home"), ".ssh", "config");
         Path keyPath = Paths.get(System.getProperty("user.home"), ".ssh", agent.getInstanceId() + "-key.pem");
@@ -72,77 +74,63 @@ public class SSHHelper {
                 logger.info("Created new ssh config file");
             }
         }
-        //check if the bastian entry has been made
         String bastianEntry = "bastian:" + agent.getTestPlanId();
-        if (!containsEntry(file, bastianEntry)) {
-            //add entry
-            String entry = String.format("Host %s%n" +
-                            "  StrictHostKeyChecking=no%n" +
-                            "  UserKnownHostsFile=/dev/null%n" +
-                            "  User ubuntu%n" +
-                            "  HostName %s%n" +
-                            "  IdentityFile %s%n",
-                    bastianEntry, bastianIP, keyPath.toAbsolutePath().toString());
-            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-        }
-        String hostEntry = "host:" + agent.getInstanceId();
-
-        if (!containsEntry(file, hostEntry)) {
-            //add Host entry
-            String entry = String.format("%n%nHost %s%n  StrictHostKeyChecking=no%n" +
-                            "  UserKnownHostsFile=/dev/null%n" +
-                            "  User %s%n" +
-                            "  HostName %s%n" +
-                            "  IdentityFile %s%n" +
-                            "  " +
-                            "ProxyCommand ssh %s@%s -W %%h:%%p%n"
-                    , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
-                    keyPath.toAbsolutePath().toString(), agent.getInstanceUser(), bastianEntry);
-            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-        }
-    }
-
-    /**
-     * Adds the config entry when there is no bastian instance.
-     * This method can be used the instance can be accessed directly
-     *
-     * @param keyContent Contents of the security key file used to access the instance
-     * @param agent The {@link Agent} object corresponding to the remote agent running on the instance
-     * @throws IOException when there is an error crating the config entry
-     */
-    public static void addConfigEntry(String keyContent, Agent agent) throws IOException {
-
-        Path config = Paths.get(System.getProperty("user.home"), ".ssh", "config");
-        Path keyPath = Paths.get(System.getProperty("user.home"), ".ssh", agent.getInstanceId() + "-key.pem");
-        saveKeyFile(keyContent, keyPath);
-        File file = config.toFile();
-        //Create the file if it does not exist
-        if (!Files.exists(config) || !Files.isRegularFile(config)) {
-            boolean mkdirs = file.getParentFile().mkdirs();
-            boolean newFile = file.createNewFile();
-            if (mkdirs || newFile) {
-                logger.info("Created new ssh config file");
-            }
-        }
-
         String hostEntry = "host:" + agent.getInstanceName();
-        if (!containsEntry(file, agent.getInstanceId())) {
-            //add Host entry
-            String entry = String.format("Host %s%n  StrictHostKeyChecking=no%n" +
-                            "  UserKnownHostsFile=/dev/null%n" +
-                            "  User %s%n" +
-                            "  HostName %s%n" +
-                            "  IdentityFile %s%n" +
-                            "  "
-                    , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
-                    keyPath.toAbsolutePath().toString());
-            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        if (bastianIP != null) {
+            //check if the bastian entry has been made
+            if (!containsEntry(file, bastianEntry)) {
+                //add entry
+                String entry = String.format("Host %s%n" +
+                                "  StrictHostKeyChecking=no%n" +
+                                "  UserKnownHostsFile=/dev/null%n" +
+                                "  User ubuntu%n" +
+                                "  HostName %s%n" +
+                                "  IdentityFile %s%n",
+                        bastianEntry, bastianIP, keyPath.toAbsolutePath().toString());
+                Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+            }
+            if (!containsEntry(file, hostEntry)) {
+                if (agent.getInstanceUser() != null) {
+                    //add Host entry
+                    String entry = String.format("%n%nHost %s%n  StrictHostKeyChecking=no%n" +
+                                    "  UserKnownHostsFile=/dev/null%n" +
+                                    "  User %s%n" +
+                                    "  HostName %s%n" +
+                                    "  IdentityFile %s%n" +
+                                    "ProxyCommand ssh %s@%s -W %%h:%%p%n"
+                            , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
+                            keyPath.toAbsolutePath().toString(), agent.getInstanceUser(), bastianEntry);
+                    Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                } else {
+                    throw new DeploymentTinkererException("Host entry value is null, Please make sure that" +
+                            "instance user is correctly set according to the cloud provider!");
+                }
+            }
+        } else {
+            if (!containsEntry(file, agent.getInstanceId())) {
+                if (agent.getInstanceUser() != null) {
+                    //add Host entry
+                    String entry = String.format("Host %s%n  StrictHostKeyChecking=no%n" +
+                                    "  UserKnownHostsFile=/dev/null%n" +
+                                    "  User %s%n" +
+                                    "  HostName %s%n" +
+                                    "  IdentityFile %s%n" +
+                                    "  "
+                            , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
+                            keyPath.toAbsolutePath().toString());
+                    Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                } else {
+                    throw new DeploymentTinkererException("Host entry value is null, Please make sure that" +
+                            "instance user is correctly set according to the cloud provider!");
+                }
+            }
         }
     }
 
     /**
      * Checks if a particular host entry has already been made in the config file
-     * @param file File object for the ssh config file
+     *
+     * @param file  File object for the ssh config file
      * @param entry Entry to be checked
      * @return true if the entry is already existing , false otherwise
      * @throws FileNotFoundException when there is an error finding the config file
@@ -161,8 +149,8 @@ public class SSHHelper {
     /**
      * Saves the security key file in the local filesystem so it could be used when accessing the instances
      *
-     * @param keyFile Contents of the key file
-     * @param path Path where the key file will be saved
+     * @param keyFile Base64 encoded Contents of the key file
+     * @param path    Path where the key file will be saved
      * @throws IOException When there is an error saving the file.
      */
     public static void saveKeyFile(String keyFile, Path path) throws IOException {

--- a/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/utils/SSHHelper.java
+++ b/deployment-tinkerer/src/main/java/org/wso2/testgrid/deployment/tinkerer/utils/SSHHelper.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.deployment.tinkerer.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Agent;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+/**
+ * This class contains the SSH config file operations.
+ * The file is located at the path "~/.ssh/config"
+ *
+ * @since 1.0.0
+ */
+public class SSHHelper {
+
+    private static final Logger logger = LoggerFactory.getLogger(SSHHelper.class);
+
+    /**
+     *
+     * Adds and entry to the ssh config file  that will enable direct access to the instance
+     * via the bastian instance.
+     *
+     * The instance will contain a proxy access entry that will route the connection via the bastian
+     * instance.
+     * @param keyContent the content of the security key file (.pem file) that is used to access the instance
+     * @param bastianIP The IP address of the bastian instance.
+     * @param agent The {@link Agent} object corresponding to the remote agent running on the instance
+     * @throws IOException When there is an error creating the config entry
+     */
+    public static void addConfigEntry(String keyContent, String bastianIP, Agent agent) throws IOException {
+
+        Path config = Paths.get(System.getProperty("user.home"), ".ssh", "config");
+        Path keyPath = Paths.get(System.getProperty("user.home"), ".ssh", agent.getInstanceId() + "-key.pem");
+        saveKeyFile(keyContent, keyPath);
+
+        File file = config.toFile();
+        //Create the file if it does not exist
+        if (!Files.exists(config) || !Files.isRegularFile(config)) {
+            boolean mkdirs = file.getParentFile().mkdirs();
+            boolean newFile = file.createNewFile();
+            if (mkdirs || newFile) {
+                logger.info("Created new ssh config file");
+            }
+        }
+        //check if the bastian entry has been made
+        String bastianEntry = "bastian:" + agent.getTestPlanId();
+        if (!containsEntry(file, bastianEntry)) {
+            //add entry
+            String entry = String.format("Host %s%n" +
+                            "  StrictHostKeyChecking=no%n" +
+                            "  UserKnownHostsFile=/dev/null%n" +
+                            "  User ubuntu%n" +
+                            "  HostName %s%n" +
+                            "  IdentityFile %s%n",
+                    bastianEntry, bastianIP, keyPath.toAbsolutePath().toString());
+            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
+        String hostEntry = "host:" + agent.getInstanceId();
+
+        if (!containsEntry(file, hostEntry)) {
+            //add Host entry
+            String entry = String.format("%n%nHost %s%n  StrictHostKeyChecking=no%n" +
+                            "  UserKnownHostsFile=/dev/null%n" +
+                            "  User %s%n" +
+                            "  HostName %s%n" +
+                            "  IdentityFile %s%n" +
+                            "  " +
+                            "ProxyCommand ssh %s@%s -W %%h:%%p%n"
+                    , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
+                    keyPath.toAbsolutePath().toString(), agent.getInstanceUser(), bastianEntry);
+            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
+    }
+
+    /**
+     * Adds the config entry when there is no bastian instance.
+     * This method can be used the instance can be accessed directly
+     *
+     * @param keyContent Contents of the security key file used to access the instance
+     * @param agent The {@link Agent} object corresponding to the remote agent running on the instance
+     * @throws IOException when there is an error crating the config entry
+     */
+    public static void addConfigEntry(String keyContent, Agent agent) throws IOException {
+
+        Path config = Paths.get(System.getProperty("user.home"), ".ssh", "config");
+        Path keyPath = Paths.get(System.getProperty("user.home"), ".ssh", agent.getInstanceId() + "-key.pem");
+        saveKeyFile(keyContent, keyPath);
+        File file = config.toFile();
+        //Create the file if it does not exist
+        if (!Files.exists(config) || !Files.isRegularFile(config)) {
+            boolean mkdirs = file.getParentFile().mkdirs();
+            boolean newFile = file.createNewFile();
+            if (mkdirs || newFile) {
+                logger.info("Created new ssh config file");
+            }
+        }
+
+        String hostEntry = "host:" + agent.getInstanceName();
+        if (!containsEntry(file, agent.getInstanceId())) {
+            //add Host entry
+            String entry = String.format("Host %s%n  StrictHostKeyChecking=no%n" +
+                            "  UserKnownHostsFile=/dev/null%n" +
+                            "  User %s%n" +
+                            "  HostName %s%n" +
+                            "  IdentityFile %s%n" +
+                            "  "
+                    , hostEntry, agent.getInstanceUser(), agent.getInstanceIp(),
+                    keyPath.toAbsolutePath().toString());
+            Files.write(config, entry.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
+    }
+
+    /**
+     * Checks if a particular host entry has already been made in the config file
+     * @param file File object for the ssh config file
+     * @param entry Entry to be checked
+     * @return true if the entry is already existing , false otherwise
+     * @throws FileNotFoundException when there is an error finding the config file
+     */
+    private static boolean containsEntry(File file, String entry) throws FileNotFoundException {
+        Scanner scanner = new Scanner(file, StandardCharsets.UTF_8.name());
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains(entry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Saves the security key file in the local filesystem so it could be used when accessing the instances
+     *
+     * @param keyFile Contents of the key file
+     * @param path Path where the key file will be saved
+     * @throws IOException When there is an error saving the file.
+     */
+    public static void saveKeyFile(String keyFile, Path path) throws IOException {
+        if (!Files.exists(path) || !Files.isRegularFile(path)) {
+            File file = path.toFile();
+            boolean mkdirs = file.getParentFile().mkdirs();
+            boolean newFile = file.createNewFile();
+            if (mkdirs || newFile) {
+                logger.info("Created new key file in location : " + path.toString());
+            }
+            Files.write(path, Base64.getDecoder().decode(keyFile));
+            //change the file permission to owner read only i.e chomod 400
+            Set<PosixFilePermission> perms = new HashSet<>();
+            perms.add(PosixFilePermission.OWNER_READ);
+            Files.setPosixFilePermissions(path, perms);
+        }
+    }
+}
+
+

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -87,6 +87,14 @@
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5-fluent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
 
         <!-- Jacoco agent -->
         <dependency>

--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/AWSDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/AWSDeployer.java
@@ -24,6 +24,7 @@ import org.wso2.testgrid.common.Deployer;
 import org.wso2.testgrid.common.DeploymentCreationResult;
 import org.wso2.testgrid.common.Host;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TimeOutBuilder;
 import org.wso2.testgrid.common.config.DeploymentConfig;
@@ -33,6 +34,7 @@ import org.wso2.testgrid.deployment.DeploymentValidator;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -56,7 +58,7 @@ public class AWSDeployer implements Deployer {
 
     @Override
     public DeploymentCreationResult deploy(TestPlan testPlan,
-            InfrastructureProvisionResult infrastructureProvisionResult)
+                                           InfrastructureProvisionResult infrastructureProvisionResult)
             throws TestGridDeployerException {
         //wait for server startup
         DeploymentConfig.DeploymentPattern deploymentPatternConfig = testPlan.getDeploymentConfig()
@@ -86,6 +88,11 @@ public class AWSDeployer implements Deployer {
         DeploymentCreationResult deploymentCreationResult = new DeploymentCreationResult();
         deploymentCreationResult.setName(deploymentPatternConfig.getName());
         deploymentCreationResult.setHosts(infrastructureProvisionResult.getHosts());
+        //store bastian ip
+        Optional<Host> bastionEIP = infrastructureProvisionResult.getHosts()
+                .stream().filter(host -> host.getLabel().equals(TestGridConstants.OUTPUT_BASTIAN_IP)).findFirst();
+        bastionEIP.ifPresent(host -> deploymentCreationResult.setBastianIP(host.getIp()));
+
         return deploymentCreationResult;
     }
 }

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/aws/AMIMapper.java
@@ -52,6 +52,7 @@ public class AMIMapper {
     //AMI lookup parameters
     private static final String AMI_TAG_OS = "OS";
     private static final String AMI_TAG_OS_VERSION = "OSVersion";
+    private static final String AMI_TAG_AGENT_READY = "AGENT_READY";
 
     private final AmazonEC2 amazonEC2;
 
@@ -143,6 +144,7 @@ public class AMIMapper {
                 }
             }
         }
+        lookupParams.setProperty(AMI_TAG_AGENT_READY, "true");
         return lookupParams;
     }
 

--- a/remoting-agent/src/main/bin/init.sh
+++ b/remoting-agent/src/main/bin/init.sh
@@ -26,4 +26,5 @@ echo "provider=$4" >> /opt/testgrid/agent-config.properties
 echo "userName=$5" >> /opt/testgrid/agent-config.properties
 echo "password=$6" >> /opt/testgrid/agent-config.properties
 echo "instanceId=$(wget -qO- http://169.254.169.254/latest/meta-data/instance-id)" >> /opt/testgrid/agent-config.properties
+echo "instanceIP=$(wget -qO- http://169.254.169.254/latest/meta-data/local-ipv4)" >> /opt/testgrid/agent-config.properties
 service testgrid-agent restart

--- a/remoting-agent/src/main/java/org/wso2/testgrid/agent/AgentApplication.java
+++ b/remoting-agent/src/main/java/org/wso2/testgrid/agent/AgentApplication.java
@@ -81,7 +81,8 @@ public class AgentApplication {
                 wsEndpoint = prop.getProperty("wsEndpoint");
                 //aws:us-west-1:6718f976-7150-316d-9ec6-db29b7a2675f:i-0658922f45d25856f
                 agentId = prop.getProperty("provider") + ":" + prop.getProperty("region") + ":" +
-                        prop.getProperty("testPlanId") + ":" + prop.getProperty("instanceId");
+                        prop.getProperty("testPlanId") + ":" + prop.getProperty("instanceId") + ":" +
+                        prop.getProperty("instanceIP");
                 userName = prop.getProperty("userName");
                 password = prop.getProperty("password");
             } else {


### PR DESCRIPTION
**Purpose**

Resolves #814 

**Goals**
This changes will enable downloading log files from the instances to the TestGrid environment.
All the files in the predefined log location for each test type will be downloaded.

**Approach**

The current implementation will use ssh access to the instance to download the logs. it is required the tinkerer Webapp to be hosted in the same environment as test grid for this approach to be successful.
A new testgrid.yaml property is introduced to indicate the location of the security key file (.pem file).
This property needs to be added to the job-config.properties file in the workspace

The AMIs also need to to have the agent pre-installed and should contain the
AGENT_READY value set.
Furthermore, the username of the instance needs to be also added as a TAG value.

Ex :
```
 Ubuntu ubuntu
CentOS centos
```

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
