### PR TITLE
Support to run generic test scripts in testgrid for intg tests

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/TestEngine.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/TestEngine.java
@@ -37,7 +37,13 @@ public enum TestEngine {
     /**
      * Defines the Selenium TestEngine.
      */
-    SELENIUM("selenium");
+    SELENIUM("selenium"),
+
+    /**
+     * Defines tests run via shell.
+     *
+     */
+    DEFAULT("default");
 
     private final String testEngine;
 

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
@@ -27,6 +27,7 @@ import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.util.DataBucketsHelper;
 import org.wso2.testgrid.common.util.EnvironmentUtil;
 import org.wso2.testgrid.common.util.StringUtil;
 
@@ -74,7 +75,11 @@ public class JMeterExecutor extends TestExecutor {
             for (Host host : deploymentCreationResult.getHosts()) {
                 environment.put(host.getLabel(), host.getIp());
             }
-            int exitCode = shellExecutor.executeCommand("bash " + script, environment);
+            String testInputsLoc = DataBucketsHelper.getTestInputLocation(testScenario.getTestPlan())
+                    .toAbsolutePath().toString();
+            final String command = "bash " + script + " --input-dir " + testInputsLoc;
+            logger.info("Execute: " + command);
+            int exitCode = shellExecutor.executeCommand(command, environment);
             if (exitCode > 0) {
                 logger.error(StringUtil.concatStrings("Error occurred while executing the test: ", testName, ", at: ",
                         testScenario.getDir(), ". Script exited with a status code of ", exitCode));

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
@@ -37,11 +37,14 @@ import java.util.Map;
 /**
  * Responsible for performing the tasks related to execution of single JMeter solution.
  *
+ * @deprecated succeeded by {@link ShellTestExecutor}.
+ * We do not need test tool specific executors at this moment.
+ *
  * @since 1.0.0
  */
 public class JMeterExecutor extends TestExecutor {
 
-    private static final Logger logger = LoggerFactory.getLogger(JMeterExecutor.class);
+    private static final Logger logger = LoggerFactory.getLogger(ShellTestExecutor.class);
     public static final String JMETER_HOME = "JMETER_HOME";
     private String testLocation;
     private String testName;
@@ -60,7 +63,7 @@ public class JMeterExecutor extends TestExecutor {
         try {
             String jmeterHome = EnvironmentUtil.getSystemVariableValue(JMETER_HOME);
             if (jmeterHome == null) {
-                logger.error(JMETER_HOME + " environment variable is not set. JMeter test execution may fail.");
+                logger.warn(JMETER_HOME + " environment variable is not set. JMeter test executions may fail.");
             } else {
                 logger.info(JMETER_HOME + ": " + jmeterHome);
             }

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/JMeterExecutor.java
@@ -75,7 +75,7 @@ public class JMeterExecutor extends TestExecutor {
             for (Host host : deploymentCreationResult.getHosts()) {
                 environment.put(host.getLabel(), host.getIp());
             }
-            String testInputsLoc = DataBucketsHelper.getTestInputLocation(testScenario.getTestPlan())
+            String testInputsLoc = DataBucketsHelper.getInputLocation(testScenario.getTestPlan())
                     .toAbsolutePath().toString();
             final String command = "bash " + script + " --input-dir " + testInputsLoc;
             logger.info("Execute: " + command);

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/ShellTestExecutor.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/ShellTestExecutor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.testgrid.automation.executor;
+
+import org.wso2.testgrid.automation.TestAutomationException;
+import org.wso2.testgrid.common.DeploymentCreationResult;
+import org.wso2.testgrid.common.TestScenario;
+
+/**
+ * Responsible for performing the tasks related to execution of single test scenario.
+ *
+ * This will eventually replace the {@link JMeterExecutor}.
+ *
+ * @since 1.0.0
+ */
+public class ShellTestExecutor extends JMeterExecutor {
+
+    @Override
+    public void init(String testLocation, String testName, TestScenario testScenario) throws TestAutomationException {
+        super.init(testLocation, testName, testScenario);
+    }
+
+    @Override
+    public void execute(String script, DeploymentCreationResult deploymentCreationResult)
+            throws TestAutomationException {
+        super.execute(script, deploymentCreationResult);
+    }
+
+}

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutorFactory.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutorFactory.java
@@ -20,8 +20,6 @@ package org.wso2.testgrid.automation.executor;
 
 import org.wso2.testgrid.automation.TestAutomationException;
 import org.wso2.testgrid.automation.TestEngine;
-import org.wso2.testgrid.common.ShellExecutor;
-import org.wso2.testgrid.common.util.StringUtil;
 
 /**
  * Factory class to return the specific test executor for the test type.
@@ -38,12 +36,12 @@ public class TestExecutorFactory {
      */
     public static TestExecutor getTestExecutor(TestEngine testType) throws TestAutomationException {
         switch (testType) {
-            case JMETER:
-                return new ShellTestExecutor();
-            case TESTNG:
-                return new TestNgExecutor();
-            default:
-                return new ShellTestExecutor();
+        case JMETER:
+            return new ShellTestExecutor();
+        case TESTNG:
+            return new TestNgExecutor();
+        default:
+            return new ShellTestExecutor();
         }
     }
 }

--- a/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutorFactory.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/executor/TestExecutorFactory.java
@@ -20,6 +20,7 @@ package org.wso2.testgrid.automation.executor;
 
 import org.wso2.testgrid.automation.TestAutomationException;
 import org.wso2.testgrid.automation.TestEngine;
+import org.wso2.testgrid.common.ShellExecutor;
 import org.wso2.testgrid.common.util.StringUtil;
 
 /**
@@ -38,12 +39,11 @@ public class TestExecutorFactory {
     public static TestExecutor getTestExecutor(TestEngine testType) throws TestAutomationException {
         switch (testType) {
             case JMETER:
-                return new JMeterExecutor();
+                return new ShellTestExecutor();
             case TESTNG:
                 return new TestNgExecutor();
             default:
-                throw new TestAutomationException(StringUtil.concatStrings("Test executor for test type ",
-                        testType, " not implemented."));
+                return new ShellTestExecutor();
         }
     }
 }

--- a/automation/src/main/java/org/wso2/testgrid/automation/reader/JMeterTestReader.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/reader/JMeterTestReader.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.automation.Test;
 import org.wso2.testgrid.automation.TestAutomationException;
 import org.wso2.testgrid.automation.TestEngine;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestScenario;
 
 import java.io.File;
@@ -41,10 +42,6 @@ public class JMeterTestReader implements TestReader {
 
     private static final Logger logger = LoggerFactory.getLogger(JMeterTestReader.class);
     private static final String JMETER_TEST_PATH = "jmeter";
-    private static final String SHELL_SUFFIX = ".sh";
-    private static final String PRE_STRING = "pre-scenario-steps";
-    private static final String POST_STRING = "post-scenario-steps";
-    private static final String SCENARIO_SCRIPT = "run-scenario.sh";
 
     /**
      * This method goes through the file structure and create an object model of the tests.
@@ -55,7 +52,7 @@ public class JMeterTestReader implements TestReader {
      */
     private List<Test> processTestStructure(File file, TestScenario scenario) throws TestAutomationException {
         List<Test> testsList = new ArrayList<>();
-        Path scenarioScriptLocation = Paths.get(file.getAbsolutePath(), SCENARIO_SCRIPT);
+        Path scenarioScriptLocation = Paths.get(file.getAbsolutePath(), TestGridConstants.SCENARIO_SCRIPT);
         if (Files.exists(scenarioScriptLocation) && !Files.isDirectory(scenarioScriptLocation)) {
             File tests = new File(Paths.get(file.getAbsolutePath(), JMETER_TEST_PATH).toString());
             if (tests.exists()) {
@@ -65,20 +62,22 @@ public class JMeterTestReader implements TestReader {
                 Test test = new Test(scenario.getName(), TestEngine.JMETER, scriptList, scenario);
 
                 scripts.stream()
-                        .filter(x -> x.endsWith(SHELL_SUFFIX) && x.contains(PRE_STRING))
+                        .filter(x -> x.endsWith(TestGridConstants.SHELL_SUFFIX) && x.contains(
+                                TestGridConstants.PRE_STRING))
                         .map(x -> Paths.get(tests.getAbsolutePath(), x).toString())
                         .findFirst()
                         .ifPresent(test::setPreScenarioScript);
 
                 scripts.stream()
-                        .filter(x -> x.endsWith(SHELL_SUFFIX) && x.contains(POST_STRING))
+                        .filter(x -> x.endsWith(TestGridConstants.SHELL_SUFFIX) && x.contains(
+                                TestGridConstants.POST_STRING))
                         .map(x -> Paths.get(tests.getAbsolutePath(), x).toString())
                         .findFirst()
                         .ifPresent(test::setPostScenarioScript);
                 testsList.add(test);
             }
         } else {
-            logger.error("Scenario script file (" + SCENARIO_SCRIPT + ") was not found in " + file.getAbsolutePath());
+            logger.error("Scenario script file (" + TestGridConstants.SCENARIO_SCRIPT + ") was not found in " + file.getAbsolutePath());
         }
         return testsList;
     }

--- a/automation/src/main/java/org/wso2/testgrid/automation/reader/JMeterTestReader.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/reader/JMeterTestReader.java
@@ -77,7 +77,8 @@ public class JMeterTestReader implements TestReader {
                 testsList.add(test);
             }
         } else {
-            logger.error("Scenario script file (" + TestGridConstants.SCENARIO_SCRIPT + ") was not found in " + file.getAbsolutePath());
+            logger.error("Scenario script file (" + TestGridConstants.SCENARIO_SCRIPT + ") was not found in " + file
+                    .getAbsolutePath());
         }
         return testsList;
     }

--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/JMeterExecutorTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/JMeterExecutorTest.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
- * Test class to test the functionality of the {@link JMeterExecutor} class.
+ * Test class to test the functionality of the {@link ShellTestExecutor} class.
  *
  * @since 1.0.0
  */

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -39,6 +39,7 @@ public class TestGridConstants {
     public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";
     public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String TESTGRID_COMPRESSED_FILE_EXT = ".zip";
+
     public static final String TESTRUN_LOG_FILE_NAME = "test-run.log";
     public static final String TEST_INTEGRATION_LOG_FILE_NAME = "TestSuite.txt";
     public static final String TESTGRID_BUILDS_DIR = "builds";
@@ -70,4 +71,9 @@ public class TestGridConstants {
     public static final String TEST_PLANS_URI = "test-plans";
     public static final String HTML_LINE_SEPARATOR = "<br/>";
     public static final String TESTGRID_EMAIL_REPORT_NAME = "EmailReport.html";
+
+    public static final String SHELL_SUFFIX = ".sh";
+    public static final String PRE_STRING = "pre-scenario-steps";
+    public static final String POST_STRING = "post-scenario-steps";
+    public static final String SCENARIO_SCRIPT = "run-scenario.sh";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -19,7 +19,6 @@ package org.wso2.testgrid.common;
 
 import org.wso2.testgrid.common.config.DeploymentConfig;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
-import org.wso2.testgrid.common.config.JobConfigFile;
 import org.wso2.testgrid.common.config.ScenarioConfig;
 import org.wso2.testgrid.common.util.StringUtil;
 
@@ -93,6 +92,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     private ScenarioConfig scenarioConfig = new ScenarioConfig();
 
     @Transient
+    private String jobName;
+
+    @Transient
     private String infrastructureRepository;
 
     @Transient
@@ -102,7 +104,7 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     private String scenarioTestsRepository;
 
     @Transient
-    private Properties inputProperties = new Properties();
+    private Properties jobProperties = new Properties();
 
     @Transient
     private ResultFormat resultFormat;
@@ -309,20 +311,21 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     /**
      * Get the list of build properties associated with this test plan.
      * The build properties are currently contain properties received via
-     * {@link JobConfigFile#getProperties()}.
+     * {@link org.wso2.testgrid.common.config.JobConfigFile#getProperties()}.
      *
      * @return build proprties
      */
-    public Properties getInputProperties() {
-        return inputProperties;
+    public Properties getJobProperties() {
+        return jobProperties;
     }
 
     /**
-     * See {@link #getInputProperties()}
-     * @param inputProperties build properties
+     * See {@link #getJobProperties()}
+     *
+     * @param jobProperties build properties
      */
-    public void setInputProperties(Properties inputProperties) {
-        this.inputProperties = inputProperties;
+    public void setJobProperties(Properties jobProperties) {
+        this.jobProperties = jobProperties;
     }
 
     /**
@@ -402,6 +405,14 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
                     + "this failure condition should never happen unless a serious system error occurred.", e);
         }
 
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
     }
 
     /**

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -19,12 +19,14 @@ package org.wso2.testgrid.common;
 
 import org.wso2.testgrid.common.config.DeploymentConfig;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
+import org.wso2.testgrid.common.config.JobConfigFile;
 import org.wso2.testgrid.common.config.ScenarioConfig;
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -98,6 +100,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
 
     @Transient
     private String scenarioTestsRepository;
+
+    @Transient
+    private Properties inputProperties = new Properties();
 
     @Transient
     private ResultFormat resultFormat;
@@ -299,6 +304,25 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
      */
     public void setDeploymentRepository(String deploymentRepository) {
         this.deploymentRepository = deploymentRepository;
+    }
+
+    /**
+     * Get the list of build properties associated with this test plan.
+     * The build properties are currently contain properties received via
+     * {@link JobConfigFile#getProperties()}.
+     *
+     * @return build proprties
+     */
+    public Properties getInputProperties() {
+        return inputProperties;
+    }
+
+    /**
+     * See {@link #getInputProperties()}
+     * @param inputProperties build properties
+     */
+    public void setInputProperties(Properties inputProperties) {
+        this.inputProperties = inputProperties;
     }
 
     /**

--- a/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
@@ -21,6 +21,8 @@ package org.wso2.testgrid.common.config;
 
 import org.wso2.testgrid.common.util.StringUtil;
 
+import java.util.Properties;
+
 /**
  * Describes the job configuration of a given product.
  * <p>
@@ -34,6 +36,7 @@ public class JobConfigFile {
     private String deploymentRepository;
     private String scenarioTestsRepository;
     private String keyFileLocation;
+    private Properties properties;
 
     /**
      * @see #isRelativePaths()
@@ -155,6 +158,25 @@ public class JobConfigFile {
 
     public void setKeyFileLocation(String keyFileLocation) {
         this.keyFileLocation = keyFileLocation;
+    }
+
+    /**
+     * Get a list of dynamic properties added to the job-config.yaml.
+     * An example include the product dist download location.
+     *
+     * @return list of properties
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    /**
+     * @see #getProperties()
+     *
+     * @param properties properties to set.
+     */
+    public void setProperties(Properties properties) {
+        this.properties = properties;
     }
 
     @Override

--- a/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/JobConfigFile.java
@@ -32,6 +32,7 @@ import java.util.Properties;
  */
 public class JobConfigFile {
 
+    private String jobName;
     private String infrastructureRepository;
     private String deploymentRepository;
     private String scenarioTestsRepository;
@@ -189,5 +190,13 @@ public class JobConfigFile {
                 ", testgridYamlLocation='" + testgridYamlLocation + '\'' +
                 ", testgridKeyFileLocation='" + keyFileLocation + '\'' +
                 '}';
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
     }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
@@ -99,7 +99,8 @@ public class DataBucketsHelper {
      * @return Get the build outputs dir
      */
     private static Path getBuildOutputsDir(TestPlan testPlan) {
-        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        String productName = testPlan.getJobName();
+        productName = productName == null ? testPlan.getDeploymentPattern().getProduct().getName() : productName;
         String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
         String testgridHome = TestGridUtil.getTestGridHomePath();
         return Paths.get(testgridHome, TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants

--- a/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.testgrid.common.util;
+
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DataBucketsHelper {
+
+    public static final String INFRA_INPUT_DIR = "infra-inputs";
+    public static final String INFRA_OUTPUT_DIR = "infra-outputs";
+    public static final String DEPL_OUTPUT_DIR = "deploy-outputs";
+    public static final String TEST_OUTPUT_DIR = "test-outputs";
+
+    /**
+     * Returns the path of infrastructure outputs (infra-outputs).
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/infra-outputs
+     * ex.~/.testgrid/jobs/wso2am/builds/two-node-depl_b158e122-78f8-11e8-adc0-fa7ae01bbebc_10/infra-outputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's outputs are stored
+     */
+    public static Path getInfrastructureOutputLocation(TestPlan testPlan) {
+        return getBuildOutputsDir(testPlan).resolve(INFRA_OUTPUT_DIR);
+    }
+
+    /**
+     * Returns the path of infrastructure outputs (infra-outputs).
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/deploy-outputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's outputs are stored
+     */
+    public static Path getDeploymentOutputLocation(TestPlan testPlan) {
+        return getBuildOutputsDir(testPlan).resolve(DEPL_OUTPUT_DIR);
+    }
+
+    /**
+     * Returns the path of infrastructure outputs (infra-outputs).
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/test-outputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's outputs are stored
+     */
+    public static Path getTestOutputLocation(TestPlan testPlan) {
+        return getBuildOutputsDir(testPlan).resolve(TEST_OUTPUT_DIR);
+    }
+
+    /**
+     * Returns the path of infrastructure inputs (infra-inputs).
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/infra-inputs
+     * ex.~/.testgrid/jobs/wso2am/builds/two-node-depl_b158e122-78f8-11e8-adc0-fa7ae01bbebc_10/infra-inputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's inputs are stored
+     */
+    public static Path getInfrastructureInputLocation(TestPlan testPlan) {
+        return getBuildOutputsDir(testPlan).resolve(INFRA_INPUT_DIR);
+    }
+
+    /**
+     * Returns the path of depl inputs (infra-outputs).
+     * In reality, deployment-inputs-location == infrastructure-outputs-location
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/infra-outputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's inputs are stored
+     */
+    public static Path getDeploymentInputLocation(TestPlan testPlan) {
+        return getInfrastructureOutputLocation(testPlan);
+    }
+
+    /**
+     * Returns the path of test inputs (depl-outputs).
+     * In reality, test-inputs-location == depl-outputs-location
+     * <p>
+     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/depl-outputs
+     *
+     * @param testPlan test-plan
+     * @return The dir location where this step's inputs are stored
+     */
+    public static Path getTestInputLocation(TestPlan testPlan) {
+        return getDeploymentOutputLocation(testPlan);
+    }
+
+    /**
+     * Get the build outputs dir
+     *
+     * @param testPlan testplan
+     * @return Get the build outputs dir
+     */
+    private static Path getBuildOutputsDir(TestPlan testPlan) {
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
+        return Paths.get(TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants.TESTGRID_BUILDS_DIR,
+                testPlanDirName);
+    }
+
+}

--- a/common/src/main/java/org/wso2/testgrid/common/util/StringUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/StringUtil.java
@@ -85,4 +85,29 @@ public class StringUtil {
         }
     }
 
+    /**
+     * Get time for summary logging purposes.
+     *
+     * @param timeDifferenceMilliseconds the time taken to run the test plan
+     * @return human readable elapsed time
+     */
+    public static String getHumanReadableTimeDiff(long timeDifferenceMilliseconds) {
+        long diffSeconds = timeDifferenceMilliseconds / 1000;
+        long diffMinutes = timeDifferenceMilliseconds / (60 * 1000);
+        long diffHours = timeDifferenceMilliseconds / (60 * 60 * 1000);
+        long diffDays = timeDifferenceMilliseconds / (60 * 60 * 1000 * 24);
+
+        if (diffSeconds < 1) {
+            return "less than a second";
+        } else if (diffMinutes < 1) {
+            return diffSeconds + " seconds";
+        } else if (diffHours < 1) {
+            return diffMinutes + " minutes" + " " + (diffSeconds % 60) + " seconds";
+        } else if (diffDays < 1) {
+            return diffHours + " hours" + " " + (diffMinutes % 60) + " minutes";
+        } else {
+            return diffDays + " days" + " " + (diffHours % 24) + " hours";
+        }
+
+    }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
@@ -208,8 +208,10 @@ public class ScenarioExecutor {
                         .filter(p -> Files.isDirectory(p)).collect(Collectors.toSet());
 
                 for (Path testDirectory : testDirectories) {
+                    final Path fileName = testDirectory.getFileName();
+                    assert fileName != null;
                     Optional<TestReader> testReader = TestReaderFactory
-                            .getTestReader(testDirectory.getFileName().toString());
+                            .getTestReader(fileName.toString());
                     if (testReader.isPresent()) {
                         List<Test> tests = testReader.get().readTests(testLocation, testScenario);
                         testList.addAll(tests);

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -599,7 +599,7 @@ public class TestPlanExecutor {
         logger.info("TEST RUN " + testPlan.getStatus());
         printSeparator(LINE_LENGTH);
 
-        logger.info("Total Time: " + getHumanReadableTimeDiff(totalTime));
+        logger.info("Total Time: " + StringUtil.getHumanReadableTimeDiff(totalTime));
         logger.info("Finished at: " + new Date());
         printSeparator(LINE_LENGTH);
     }

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -458,10 +458,10 @@ public class TestPlanExecutor {
     private void persistInfraInputs(TestPlan testPlan) {
         final Path location = DataBucketsHelper.getInputLocation(testPlan)
                 .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE);
-        final Properties inputProperties = testPlan.getInputProperties();
+        final Properties jobProperties = testPlan.getJobProperties();
         final Properties infraParameters = testPlan.getInfrastructureConfig().getParameters();
         try (OutputStream os = Files.newOutputStream(location, CREATE, APPEND)) {
-            inputProperties.store(os, null);
+            jobProperties.store(os, null);
             infraParameters.store(os, null);
         } catch (IOException e) {
             logger.error("Error while persisting infra input params to " + location, e);
@@ -675,31 +675,6 @@ public class TestPlanExecutor {
      */
     private static void printSeparator(int length) {
         logger.info(StringUtils.repeat("-", length));
-    }
-
-    /**
-     * Get time for summary logging purposes.
-     *
-     * @param timeDifferenceMilliseconds the time taken to run the test plan
-     * @return human readable elapsed time
-     */
-    private static String getHumanReadableTimeDiff(long timeDifferenceMilliseconds) {
-        long diffSeconds = timeDifferenceMilliseconds / 1000;
-        long diffMinutes = timeDifferenceMilliseconds / (60 * 1000);
-        long diffHours = timeDifferenceMilliseconds / (60 * 60 * 1000);
-        long diffDays = timeDifferenceMilliseconds / (60 * 60 * 1000 * 24);
-
-        if (diffSeconds < 1) {
-            return "less than a second";
-        } else if (diffMinutes < 1) {
-            return diffSeconds + " seconds";
-        } else if (diffHours < 1) {
-            return diffMinutes + " minutes" + " " + (diffSeconds % 60) + " seconds";
-        } else if (diffDays < 1) {
-            return diffHours + " hours" + " " + (diffMinutes % 60) + " minutes";
-        } else {
-            return diffDays + " days" + " " + (diffHours % 24) + " hours";
-        }
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -391,10 +391,11 @@ public class GenerateTestPlanCommand implements Command {
      * @param jobConfigFile jobConfigFile
      */
     private void insertJobConfigFilePropertiesTo(TestgridYaml testgridYaml, JobConfigFile jobConfigFile) {
+        testgridYaml.setJobName(jobConfigFile.getJobName());
         testgridYaml.setInfrastructureRepository(jobConfigFile.getInfrastructureRepository());
         testgridYaml.setDeploymentRepository(jobConfigFile.getDeploymentRepository());
         testgridYaml.setScenarioTestsRepository(jobConfigFile.getScenarioTestsRepository());
-        testgridYaml.setInputProperties(jobConfigFile.getProperties());
+        testgridYaml.setJobProperties(jobConfigFile.getProperties());
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -373,19 +373,28 @@ public class GenerateTestPlanCommand implements Command {
         }
 
         Representer representer = new Representer();
-
-        // Skip missing properties in testgrid.yaml
-        representer.getPropertyUtils().setSkipMissingProperties(true);
+        representer.getPropertyUtils().setSkipMissingProperties(true); // Skip missing properties in testgrid.yaml
         TestgridYaml testgridYaml = new Yaml(new Constructor(TestgridYaml.class), representer)
                 .loadAs(testgridYamlContent, TestgridYaml.class);
-        testgridYaml.setInfrastructureRepository(jobConfigFile.getInfrastructureRepository());
-        testgridYaml.setDeploymentRepository(jobConfigFile.getDeploymentRepository());
-        testgridYaml.setScenarioTestsRepository(jobConfigFile.getScenarioTestsRepository());
+        insertJobConfigFilePropertiesTo(testgridYaml, jobConfigFile);
 
         if (logger.isDebugEnabled()) {
             logger.debug("The testgrid.yaml content for this product build: " + testgridYamlContent);
         }
         return testgridYaml;
+    }
+
+    /**
+     * Reads the @{@link JobConfigFile} and add its content into {@link TestgridYaml}.
+     *
+     * @param testgridYaml testgridYaml
+     * @param jobConfigFile jobConfigFile
+     */
+    private void insertJobConfigFilePropertiesTo(TestgridYaml testgridYaml, JobConfigFile jobConfigFile) {
+        testgridYaml.setInfrastructureRepository(jobConfigFile.getInfrastructureRepository());
+        testgridYaml.setDeploymentRepository(jobConfigFile.getDeploymentRepository());
+        testgridYaml.setScenarioTestsRepository(jobConfigFile.getScenarioTestsRepository());
+        testgridYaml.setInputProperties(jobConfigFile.getProperties());
     }
 
     /**

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -35,7 +35,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.testgrid.automation.TestAutomationException;
-import org.wso2.testgrid.automation.executor.JMeterExecutor;
 import org.wso2.testgrid.automation.executor.ShellTestExecutor;
 import org.wso2.testgrid.automation.executor.TestExecutorFactory;
 import org.wso2.testgrid.common.DeploymentPattern;
@@ -77,7 +76,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 
 @PrepareForTest({ StringUtil.class, TestExecutorFactory.class })
-@PowerMockIgnore({ "javax.management.*", "javax.script.*", "org.apache.logging.log4j.*"})
+@PowerMockIgnore({ "javax.management.*", "javax.script.*", "org.apache.logging.log4j.*" })
 public class RunTestPlanCommandTest extends PowerMockTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(RunTestPlanCommandTest.class);

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.testgrid.automation.TestAutomationException;
 import org.wso2.testgrid.automation.executor.JMeterExecutor;
+import org.wso2.testgrid.automation.executor.ShellTestExecutor;
 import org.wso2.testgrid.automation.executor.TestExecutorFactory;
 import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Product;
@@ -171,7 +172,7 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         PowerMockito.spy(StringUtil.class);
         when(StringUtil.generateRandomString(anyInt())).thenReturn("");
         PowerMockito.mockStatic(TestExecutorFactory.class);
-        when(TestExecutorFactory.getTestExecutor(any())).thenReturn(new JMeterExecutor());
+        when(TestExecutorFactory.getTestExecutor(any())).thenReturn(new ShellTestExecutor());
 
         InfrastructureParameter param = new InfrastructureParameter("ubuntu_16.04", DefaultInfrastructureTypes
                 .OPERATING_SYSTEM, "{}", true);

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -36,6 +36,8 @@ infrastructureConfig:
       phase: DESTROY
       type: SHELL
 infrastructureRepository: ./src/test/resources/workspace/infrastructure
+jobProperties: {
+  }
 keyFileLocation: ./src/test/resources/workspace/testkey.pem
 scenarioConfig:
   scenarios:

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -45,6 +45,7 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
@@ -103,8 +104,12 @@ public class AWSProviderTest extends PowerMockTestCase {
 
         ScenarioConfig scenarioConfig = new ScenarioConfig();
         scenarioConfig.setScripts(scripts);
+        DeploymentPattern deploymentPatternDBEntry = new DeploymentPattern();
+        deploymentPatternDBEntry.setName("deployment-pattern");
+        testPlan.setDeploymentPattern(deploymentPatternDBEntry);
         testPlan.setScenarioConfig(scenarioConfig);
         testPlan.setScenarioTestsRepository(scenarioRepo);
+        testPlan.setInfraParameters("{\"OS\": \"Ubuntu\"}");
     }
 
     @Test(description = "This test case tests creation of AWSProvider object when AWS credentials are " +
@@ -184,6 +189,7 @@ public class AWSProviderTest extends PowerMockTestCase {
 
         AWSProvider awsProvider = new AWSProvider();
         awsProvider.init(testPlan);
+        testPlan.setJobName("wso2");
         testPlan.setInfrastructureConfig(infrastructureConfig);
         testPlan.setInfrastructureRepository(resourcePath.getAbsolutePath());
         InfrastructureProvisionResult provisionResult = awsProvider

--- a/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.1.0-LTS/Jenkinsfile
@@ -63,7 +63,8 @@ pipeline {
                 }
 
                 sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                 echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}
@@ -140,7 +141,7 @@ pipeline {
             sh """
 	    cd ${TESTGRID_HOME}/testgrid-dist/${TESTGRID_NAME}
             ./testgrid finalize-run-testplan \
-            --product ${PRODUCT --workspace ${PWD}}
+            --product ${PRODUCT} --workspace ${PWD}
             """
 
            sh """

--- a/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2apim-2.2.0-LTS/Jenkinsfile
@@ -68,7 +68,8 @@ pipeline {
                     """
 
                     sh """
-                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                    echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                     echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                     echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                     echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2ei-6.1.1-LTS/Jenkinsfile
@@ -61,7 +61,8 @@ pipeline {
                 }
 
                 sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                 echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.3.0-LTS/Jenkinsfile
@@ -61,7 +61,8 @@ pipeline {
                 }
 
                 sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                 echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is-5.5.0-LTS/Jenkinsfile
@@ -61,7 +61,8 @@ pipeline {
                 }
 
                 sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                 echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.0LTS/Jenkinsfile
@@ -61,7 +61,8 @@ pipeline {
                 }
 
                 sh """
-                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                 echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                 echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
+++ b/jenkins/pipelines/test-jobs/wso2is5.4.1LTS/Jenkinsfile
@@ -60,7 +60,8 @@ pipeline {
                     }
 
                     sh """
-                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' > ${JOB_CONFIG_YAML_PATH}
+                    echo 'jobName: ${PRODUCT}' >> ${JOB_CONFIG_YAML_PATH}
+                    echo 'infrastructureRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >>${JOB_CONFIG_YAML_PATH}
                     echo 'deploymentRepository: ${INFRA_LOCATION}/cloudformation-templates/pattern-1/' >> ${JOB_CONFIG_YAML_PATH}
                     echo 'scenarioTestsRepository: ${SCENARIOS_LOCATION}' >> ${JOB_CONFIG_YAML_PATH}
                     echo 'testgridYamlLocation: ${INFRA_CONFIGS_LOCATION}/single-node-infra.yaml' >> ${JOB_CONFIG_YAML_PATH}

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -455,13 +455,6 @@ public class TestPlanService {
             return Response.serverError()
                     .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
                             .setDescription(e.getMessage()).build()).build();
-        } catch (TestGridException e) {
-            String msg = "Error occurred when deriving test run artifacts directory (Test Plan id:"  + testPlanId
-                    + ", Scenario directory: " + scenarioDir + ")";
-            logger.error(msg, e);
-            return Response.serverError()
-                    .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg)
-                            .setDescription(e.getMessage()).build()).build();
         } catch (ArtifactReaderException e) {
             String msg = "Error occurred when reading the artifact in " + archiveFileDir;
             logger.error(msg, e);


### PR DESCRIPTION
**Purpose**
Testgrid need to be able to run product integration tests. For that purpose, we are going to get the testgrid to have,

1. a proper data-passing mechanism through the testgrid's test-plan pipeline (infra -> deploy -> tests), 
2. Support for running generic test scripts in contrast to being jmeter specific. (Deprecated JmeterTestExecutor!)
3. Provide job's properties as input arguments to scripts testgrid execute.