### PR TITLE
Introduces a testng integration result parser

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
@@ -79,6 +79,21 @@ public class FunctionalTestResultParser extends ResultParser {
         super(testScenario, testLocation);
     }
 
+    /**
+     * Here, you pass the results, find out all the test cases that has
+     * executed. Then, these test cases are inserted into the db as child
+     * items of {@link TestScenario} via {@link #persistResults()}.
+     *
+     * Workflow:
+     * <ul><li>
+     *  1. build a test case for each httpSample or sample element found in JTL.
+     * </li><li>
+     *  2. set the failure state to true/false along with message
+     * </li><li>
+     *  3. Add the test case into the test scenario.
+     * </li></ul>
+     * @throws JTLResultParserException result parser error
+     */
     @Override
     public void parseResults() throws JTLResultParserException {
         boolean failureMsgElement = false;

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/ResultParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/ResultParser.java
@@ -50,6 +50,13 @@ public abstract class ResultParser {
      */
     public abstract void parseResults() throws ResultParserException;
 
+    /**
+     * Archive the results file for dashboard and reporting purposes.
+     * In here, the results file should be copied to the data-buckets folder.
+     *
+     * @throws ResultParserException failure during persisting.
+     * @see org.wso2.testgrid.common.util.DataBucketsHelper
+     */
     public abstract void persistResults() throws ResultParserException;
 }
 

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/ResultParserFactory.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/ResultParserFactory.java
@@ -46,6 +46,8 @@ public class ResultParserFactory {
             resultParser = new FunctionalTestResultParser(testScenario, testLocation);
         } else if (TestGridConstants.TEST_TYPE_PERFORMANCE.equals(testPlan.getScenarioConfig().getTestType())) {
             resultParser = new PerformanceTestCSVParser(testScenario, testLocation);
+        } else if (TestGridConstants.TEST_TYPE_INTEGRATION.equals(testPlan.getScenarioConfig().getTestType())) {
+            resultParser = new TestNgResultsParser(testScenario, testLocation);
         }
         return Optional.ofNullable(resultParser);
     }

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.testgrid.automation.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.automation.exception.ResultParserException;
+import org.wso2.testgrid.common.TestCase;
+import org.wso2.testgrid.common.TestScenario;
+import org.wso2.testgrid.common.util.DataBucketsHelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+/**
+ * Surefire reports parser implementation related to parsing testng integration
+ * test results.
+ *
+ * @since 1.0.0
+ */
+public class TestNgResultsParser extends ResultParser {
+
+    public static final String RESULTS_INPUT_FILE = "testng-results.xml";
+    private static final Logger logger = LoggerFactory.getLogger(TestNgResultsParser.class);
+    private static final String TOTAL = "total";
+    private static final String FAILED = "failed";
+    private static final String PASSED = "passed";
+    private static final String SKIPPED = "skipped";
+    private final XMLInputFactory factory = XMLInputFactory.newInstance();
+
+    /**
+     * This constructor is used to create a {@link TestNgResultsParser} object with the
+     * scenario details.
+     *
+     * @param testScenario TestScenario to be parsed
+     * @param testLocation location of the test artifacts
+     */
+    public TestNgResultsParser(TestScenario testScenario, String testLocation) {
+        super(testScenario, testLocation);
+    }
+
+    /**
+     * <pre>
+     * <testng-results skipped="2" failed="1" total="17" passed="14">
+     *  <reporter-output>
+     *  </reporter-output>
+     *  <suite name="apim-automation-tests-suite-1"
+     *          duration-ms="41210" started-at="2018-06-28T10:16:25Z" finished-at="2018-06-28T10:17:06Z">
+     *      <test name="apim-startup-tests" duration-ms="15825"
+     *          started-at="2018-06-28T10:16:50Z" finished-at="2018-06-28T10:17:06Z">
+     *      <class name="org.wso2.am.integration.tests.server.mgt.APIMgtServerStartupTestCase">
+     *      <test-method status="PASS" signature="setEnvironment()" name="setEnvironment" is-config="true"
+     *          duration-ms="98" started-at="2018-06-28T10:16:24Z" finished-at="2018-06-28T10:16:25Z">
+     *      </test-method>
+     *      <test-method status="PASS" signature="testVerifyLogs()" name="testVerifyLogs" duration-ms="600"
+     *          started-at="2018-06-28T10:16:50Z" description="verify server startup errors"
+     *          finished-at="2018-06-28T10:16:51Z">
+     *      </test-method>
+     *      <test-method status="PASS" signature="disconnectFromOSGiConsole()" name="disconnectFromOSGiConsole"
+     *          is-config="true" duration-ms="1" started-at="2018-06-28T10:17:01Z" finished-at="2018-06-28T10:17:01Z">
+     *      </test-method>
+     *      </class>
+     *   </suite>
+     *  </testng-results>
+     * </pre>
+     * <p>
+     * one test class == one testgrid testcase.
+     *
+     * @throws ResultParserException parsing error
+     */
+    @Override
+    public void parseResults() throws ResultParserException {
+        final Path dataBucket = DataBucketsHelper.getOutputLocation(testScenario.getTestPlan());
+        Set<Path> inputFiles = getResultInputFiles(dataBucket);
+
+        for (Path resultsFile : inputFiles) {
+            try (final InputStream stream = Files.newInputStream(resultsFile, StandardOpenOption.READ)) {
+                final XMLEventReader eventReader = XMLInputFactory.newInstance().createXMLEventReader(stream);
+
+                while (eventReader.hasNext()) {
+                    XMLEvent event = eventReader.nextEvent();
+                    if (event.getEventType() == XMLStreamConstants.START_ELEMENT) {
+                        StartElement startElement = event.asStartElement();
+                        if (startElement.getName().getLocalPart().equals("class")) {
+                            final String classNameStr = getClassName(startElement);
+                            final boolean failed = hasFailedTestMethods(eventReader);
+                            final TestCase testCase = buildTestCase(classNameStr, failed);
+                            testScenario.addTestCase(testCase);
+                        }
+                    }
+                }
+
+            } catch (IOException | XMLStreamException e) {
+                logger.error("Error while parsing testng-results.xml at " + resultsFile + " for " +
+                        testScenario.getName(), e);
+            }
+        }
+    }
+
+    private String getClassName(StartElement startElement) {
+        String classNameStr = "unknown";
+        final Iterator attributes = startElement.getAttributes();
+        while (attributes.hasNext()) {
+            Attribute att = (Attribute) attributes.next();
+            if (att.getName().getLocalPart().equals("name")) {
+                classNameStr = att.getValue();
+            }
+        }
+        return classNameStr;
+    }
+
+    /**
+     * Searches the child elements of class element for test-methods where
+     * status == !PASS.
+     *
+     * @param eventReader XMLEventReader
+     * @return true if all test-methods has PASS status, false otherwise.
+     * @throws XMLStreamException {@link XMLStreamException}
+     */
+    private boolean hasFailedTestMethods(XMLEventReader eventReader) throws XMLStreamException {
+        boolean hasFailedTestMethods = false;
+        while (eventReader.hasNext()) {
+            XMLEvent event = eventReader.nextEvent();
+            if (event.getEventType() == XMLStreamConstants.END_ELEMENT &&
+                    event.asEndElement().getName().getLocalPart().equals("class")) {
+                break;
+            }
+            if (event.getEventType() == XMLStreamConstants.START_ELEMENT) {
+                final StartElement element = event.asStartElement();
+                if (element.getName().getLocalPart().equals("test-method")) {
+                    Iterable<Attribute> testMethodAttrs = element::getAttributes; //todo
+                    hasFailedTestMethods = StreamSupport.stream(testMethodAttrs.spliterator(), false)
+                            .anyMatch(att -> att.getName().getLocalPart().equals("status")
+                                    && !att.getValue().equals("PASS"));
+                }
+            }
+        }
+        return hasFailedTestMethods;
+    }
+
+    private TestCase buildTestCase(String className, boolean failed) {
+        TestCase testCase = new TestCase();
+        testCase.setTestScenario(this.testScenario);
+        testCase.setName(className);
+        testCase.setSuccess(!failed);
+        return testCase;
+    }
+
+    private Set<Path> getResultInputFiles(Path dataBucket) {
+        try {
+            final Stream<Path> ls = Files.list(dataBucket);
+            final Set<Path> files = ls.collect(Collectors.toSet());
+            final Set<Path> inputFiles = new HashSet<>();
+            for (Path file : files) {
+                final Path fileName = file.getFileName();
+                if (Files.isDirectory(file)) {
+                    final Set<Path> anInputFilesList = getResultInputFiles(file);
+                    inputFiles.addAll(anInputFilesList);
+                } else if (RESULTS_INPUT_FILE.equals(fileName.toString())) {
+                    inputFiles.add(file);
+                }
+            }
+
+            return inputFiles;
+        } catch (IOException e) {
+            logger.error("Error while reading " + RESULTS_INPUT_FILE + " in " + dataBucket, e);
+            return Collections.emptySet();
+        }
+    }
+
+    @Override
+    public void persistResults() throws ResultParserException {
+        //TODO implement
+    }
+}
+

--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.testgrid.automation.executor;
+
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.testgrid.automation.exception.ParserInitializationException;
+import org.wso2.testgrid.automation.exception.ResultParserException;
+import org.wso2.testgrid.automation.parser.ResultParser;
+import org.wso2.testgrid.automation.parser.ResultParserFactory;
+import org.wso2.testgrid.automation.parser.TestNgResultsParser;
+import org.wso2.testgrid.common.DeploymentPattern;
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.TestScenario;
+import org.wso2.testgrid.common.config.ScenarioConfig;
+import org.wso2.testgrid.common.util.DataBucketsHelper;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+public class TestNgResultsParserTest {
+
+    private static final String TESTGRID_HOME = Paths.get("target", "testgrid-home").toString();
+
+    @BeforeMethod
+    public void init() {
+        System.setProperty(TestGridConstants.TESTGRID_HOME_SYSTEM_PROPERTY, TESTGRID_HOME);
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(description = "Test for testing the functional test parser instance")
+    public void testTestNgResultsParser() throws ResultParserException, ParserInitializationException, IOException {
+
+        // Set cloned test plan location.
+        ClassLoader classLoader = getClass().getClassLoader();
+        URL resource = classLoader.getResource("test-grid-is-resources");
+        Assert.assertNotNull(resource);
+        TestScenario testScenario = new TestScenario();
+        testScenario.setDir("scenarioDir");
+        TestPlan testPlan = new TestPlan();
+        testPlan.setJobName("wso2");
+        ScenarioConfig scenarioConfig = new ScenarioConfig();
+        scenarioConfig.setTestType(TestGridConstants.TEST_TYPE_INTEGRATION);
+        testPlan.setScenarioConfig(scenarioConfig);
+        testPlan.setScenarioTestsRepository("resources");
+        testScenario.setName("SolutionPattern22");
+        testScenario.setTestPlan(testPlan);
+        testPlan.setInfraParameters("{\"OS\": \"Ubuntu\"}");
+        DeploymentPattern deploymentPatternDBEntry = new DeploymentPattern();
+        deploymentPatternDBEntry.setName("deployment-pattern");
+        testPlan.setDeploymentPattern(deploymentPatternDBEntry);
+
+        final Path outputFile = DataBucketsHelper.getOutputLocation(testPlan)
+                .resolve(TestNgResultsParser.RESULTS_INPUT_FILE);
+        copyTestngResultsXml(outputFile);
+
+        Optional<ResultParser> parser = ResultParserFactory.getParser(testPlan, testScenario);
+        Assert.assertTrue(parser.isPresent());
+        Assert.assertTrue(parser.get() instanceof TestNgResultsParser);
+
+        parser.get().parseResults();
+        Assert.assertEquals(testScenario.getTestCases().size(), 5, "expected five test cases.");
+    }
+
+    private void copyTestngResultsXml(Path outputLocation) throws IOException {
+        Files.copy(Paths.get("src", "test", "resources", TestNgResultsParser.RESULTS_INPUT_FILE),
+                outputLocation, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+}

--- a/automation/src/test/resources/testng-results.xml
+++ b/automation/src/test/resources/testng-results.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testng-results skipped="6" failed="2" total="9" passed="1">
+    <reporter-output>
+    </reporter-output>
+    <suite name="ApiManager-features-test-suite" duration-ms="28490" started-at="2018-06-21T15:48:38Z" finished-at="2018-06-21T15:49:06Z">
+        <groups>
+            <group name="webapp">
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokeGETResource()" name="testInvokeGETResource" class="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTResourceBeforeAddingPOSTResource()" name="testInvokePOSTResourceBeforeAddingPOSTResource" class="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTAndGETResourceAfterAddingPOSTResource()" name="testInvokePOSTAndGETResourceAfterAddingPOSTResource" class="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTAndGetResourceAfterAddingURLPattern()" name="testInvokePOSTAndGetResourceAfterAddingURLPattern" class="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokeGETAndPOSTResourceAfterRemovePOSTResource()" name="testInvokeGETAndPOSTResourceAfterRemovePOSTResource" class="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.PluggableVersioningStrategyTestCase.testPluggableVersioningStratergy()" name="testPluggableVersioningStratergy" class="org.wso2.am.integration.tests.api.lifecycle.PluggableVersioningStrategyTestCase"/>
+            </group>
+            <group name="wso2.am">
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase.testAPIInvocationBeforeChangeTheEndPointURL()" name="testAPIInvocationBeforeChangeTheEndPointURL" class="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase.testEditEndPointURL()" name="testEditEndPointURL" class="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase"/>
+                <method signature="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase.testInvokeAPIAfterChangeAPIEndPointURLWithNewEndPointURL()" name="testInvokeAPIAfterChangeAPIEndPointURLWithNewEndPointURL" class="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase"/>
+            </group>
+        </groups>
+        <test name="apim-integration-tests-api-common" duration-ms="28490" started-at="2018-06-21T15:48:38Z" finished-at="2018-06-21T15:49:06Z">
+            <class name="org.wso2.am.integration.tests.other.AdvancedWebAppDeploymentConfig">
+                <test-method status="PASS" signature="deployWebApps()" name="deployWebApps" is-config="true" duration-ms="23621" started-at="2018-06-21T15:48:38Z" finished-at="2018-06-21T15:49:01Z">
+                </test-method>
+                <test-method status="PASS" signature="cleanUpArtifacts()" name="cleanUpArtifacts" is-config="true" duration-ms="704" started-at="2018-06-21T15:49:05Z" finished-at="2018-06-21T15:49:06Z">
+                </test-method>
+            </class>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase">
+                <test-method status="PASS" signature="initialize()" name="initialize" is-config="true" duration-ms="643" started-at="2018-06-21T15:49:01Z" finished-at="2018-06-21T15:49:02Z">
+                </test-method>
+                <test-method status="PASS" signature="testInvokeGETResource()" name="testInvokeGETResource"
+                             duration-ms="2183" started-at="2018-06-21T15:49:02Z"
+                             description="Test the invocation of GET resource"
+                             finished-at="2018-06-21T15:49:04Z">
+                </test-method>
+
+                <test-method status="FAIL" signature="testInvokePOSTResourceBeforeAddingPOSTResource()"
+                             name="testInvokePOSTResourceBeforeAddingPOSTResource" duration-ms="39" started-at="2018-06-21T15:49:04Z"
+                             description="Test the invocation of POST resource, before adding a POSt resource"
+                             depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokeGETResource" finished-at="2018-06-21T15:49:04Z">
+
+                    testcase: test name
+                    failureMessage:
+                    $sig - $description - status
+                    $sig - $description - status - exception message (cdata removed)
+
+                    <exception class="java.lang.AssertionError">
+                        <message>
+                            <![CDATA[API Context is not in error message Connection error (is server running at http://localhost:8780/1.0.0/api/customers/name/ ?): Server returned HTTP response code: 405 for URL: http://localhost:8780/1.0.0/api/customers/name/ expected:<false> but was:<true>]]>
+                        </message>
+                        <full-stacktrace>
+                            <![CDATA[java.lang.AssertionError: API Context is not in error message Connection error (is server running at http://localhost:8780/1.0.0/api/customers/name/ ?): Server returned HTTP response code: 405 for URL: http://localhost:8780/1.0.0/api/customers/name/ expected:<false> but was:<true>
+	at org.testng.Assert.fail(Assert.java:89)
+	at org.testng.Assert.failNotEquals(Assert.java:489)
+	at org.testng.Assert.assertFalse(Assert.java:58)
+	at org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTResourceBeforeAddingPOSTResource(AddEditRemoveRESTResourceTestCase.java:126)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:80)
+	at org.testng.internal.Invoker.invokeMethod(Invoker.java:673)
+	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:842)
+	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1166)
+	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
+	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
+	at org.testng.TestRunner.runWorkers(TestRunner.java:1178)
+	at org.testng.TestRunner.privateRun(TestRunner.java:757)
+	at org.testng.TestRunner.run(TestRunner.java:608)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:334)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:329)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:291)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:240)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1158)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1083)
+	at org.testng.TestNG.run(TestNG.java:999)
+	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
+	at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
+	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
+]]>
+                        </full-stacktrace>
+                    </exception>
+                </test-method>
+                <test-method status="SKIP" signature="testInvokeGETAndPOSTResourceAfterRemovePOSTResource()" name="testInvokeGETAndPOSTResourceAfterRemovePOSTResource" duration-ms="1" started-at="2018-06-21T15:49:04Z" description="Test the invocation of POST and GET resource, after Remove POST resource" depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTAndGetResourceAfterAddingURLPattern" finished-at="2018-06-21T15:49:04Z">
+                </test-method>
+                <test-method status="SKIP" signature="testInvokePOSTAndGETResourceAfterAddingPOSTResource()" name="testInvokePOSTAndGETResourceAfterAddingPOSTResource" duration-ms="0" started-at="2018-06-21T15:49:04Z" description="Test the invocation of POST and GET resource, after adding a POST resource" depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTResourceBeforeAddingPOSTResource" finished-at="2018-06-21T15:49:04Z">
+                </test-method>
+                <test-method status="SKIP" signature="testInvokePOSTAndGetResourceAfterAddingURLPattern()" name="testInvokePOSTAndGetResourceAfterAddingURLPattern" duration-ms="0" started-at="2018-06-21T15:49:04Z" description="Test the invocation of POST and GET resource, after adding a URL pattern" depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.AddEditRemoveRESTResourceTestCase.testInvokePOSTAndGETResourceAfterAddingPOSTResource" finished-at="2018-06-21T15:49:04Z">
+                </test-method>
+            </class>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase">
+                <test-method status="PASS" signature="initialize()" name="initialize" is-config="true" duration-ms="553" started-at="2018-06-21T15:49:05Z" finished-at="2018-06-21T15:49:05Z">
+                </test-method>
+                <test-method name="testInvokeAPIAfterChangeAPIEndPointURLWithNewEndPointURL" signature="testInvokeAPIAfterChangeAPIEndPointURLWithNewEndPointURL()" depends-on-groups="webapp" status="SKIP" duration-ms="0" finished-at="2018-06-21T15:49:05Z" started-at="2018-06-21T15:49:05Z" depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase.testEditEndPointURL" description="Test the invocation of API using new end point URL  after end point URL  change">
+                </test-method>
+                <test-method status="SKIP" signature="testAPIInvocationBeforeChangeTheEndPointURL()" name="testAPIInvocationBeforeChangeTheEndPointURL" duration-ms="0" depends-on-groups="webapp" started-at="2018-06-21T15:49:05Z" description="Test  invocation of API before change the  api end point URL." finished-at="2018-06-21T15:49:05Z">
+                </test-method>
+                <test-method name="testEditEndPointURL" signature="testEditEndPointURL()" depends-on-groups="webapp" status="SKIP" duration-ms="0" finished-at="2018-06-21T15:49:05Z" started-at="2018-06-21T15:49:05Z" depends-on-methods="org.wso2.am.integration.tests.api.lifecycle.ChangeAPIEndPointURLTestCase.testAPIInvocationBeforeChangeTheEndPointURL" description="Test changing of the API end point URL">
+                </test-method>
+            </class>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.PluggableVersioningStrategyTestCase">
+                <test-method status="PASS" signature="initialize()" name="initialize" is-config="true" duration-ms="621" started-at="2018-06-21T15:49:04Z" finished-at="2018-06-21T15:49:05Z">
+                </test-method>
+                <test-method status="FAIL" signature="testPluggableVersioningStratergy()" name="testPluggableVersioningStratergy" duration-ms="100" started-at="2018-06-21T15:49:05Z" description="This test method tests the pluggable versioning stratergy" finished-at="2018-06-21T15:49:05Z">
+                    <exception class="java.lang.AssertionError">
+                        <message>
+                            <![CDATA[Response Data not match for GET request. Expected value : <id>123</id><name>John</name></Customer> not contains in response data <?xml version="1.0" encoding="UTF-8" standalone="yes"?><Customer><id>123</id><name>John</name></Customer> expected:<false> but was:<true>]]>
+                        </message>
+                        <full-stacktrace>
+                            <![CDATA[java.lang.AssertionError: Response Data not match for GET request. Expected value : <id>123</id><name>John</name></Customer> not contains in response data <?xml version="1.0" encoding="UTF-8" standalone="yes"?><Customer><id>123</id><name>John</name></Customer> expected:<false> but was:<true>
+	at org.testng.Assert.fail(Assert.java:89)
+	at org.testng.Assert.failNotEquals(Assert.java:489)
+	at org.testng.Assert.assertFalse(Assert.java:58)
+	at org.wso2.am.integration.tests.api.lifecycle.PluggableVersioningStrategyTestCase.testPluggableVersioningStratergy(PluggableVersioningStrategyTestCase.java:76)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:80)
+	at org.testng.internal.Invoker.invokeMethod(Invoker.java:673)
+	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:842)
+	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1166)
+	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
+	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
+	at org.testng.TestRunner.runWorkers(TestRunner.java:1178)
+	at org.testng.TestRunner.privateRun(TestRunner.java:757)
+	at org.testng.TestRunner.run(TestRunner.java:608)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:334)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:329)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:291)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:240)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1158)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1083)
+	at org.testng.TestNG.run(TestNG.java:999)
+	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
+	at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
+	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
+	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
+]]>
+                        </full-stacktrace>
+                    </exception>
+                </test-method>
+            </class>
+        </test>
+    </suite>
+    <suite name="apim-automation-tests-suite-1" duration-ms="25782" started-at="2018-06-21T15:48:12Z" finished-at="2018-06-21T15:48:38Z">
+        <groups>
+        </groups>
+        <test name="apim-common-tests" duration-ms="25782" started-at="2018-06-21T15:48:12Z" finished-at="2018-06-21T15:48:38Z">
+            <class name="org.wso2.am.integration.tests.api.lifecycle.APIManagerConfigurationChangeTest">
+                <test-method status="PASS" signature="startDeployingWebAPPs()" name="startDeployingWebAPPs" is-config="true" duration-ms="25315" started-at="2018-06-21T15:48:12Z" finished-at="2018-06-21T15:48:37Z">
+                </test-method>
+                <test-method status="PASS" signature="unDeployWebApps()" name="unDeployWebApps" is-config="true" duration-ms="461" started-at="2018-06-21T15:48:37Z" finished-at="2018-06-21T15:48:38Z">
+                </test-method>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -382,6 +382,7 @@ public class TestPlanService {
         for (TestScenario testScenario : testScenarios) {
             List<TestCase> testCases = new ArrayList<>(testScenario.getTestCases());
 
+            // TODO: change backend design to store these info within the db to reduce UI latency.
             // Create scenario summary
             long totalSuccess = testCases.stream().filter(TestCase::isSuccess).count();
             long totalFailed = testCases.stream().filter(testCase -> !testCase.isSuccess()).count();


### PR DESCRIPTION
**Purpose**
We need to parse the testng output in order to figure out the test cases that has been run. 

Fixes #828

**Goals**
This is needed for build mail purpose, and for dashboard/report.

<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
Traverses data-buckets to find all `testng-results.xml` files. The they are read via a XMLEventReader.
Each test class is treated as a test case, and is inserted into the db.