### PR TITLE
Removing "depends on" property in EC2 instances of CF script

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -208,8 +208,6 @@ Resources:
   WSO2UnixInstance:
     Type: 'AWS::EC2::Instance'
     Condition: 'IsUnix'
-    DependsOn:
-      - WSO2DBInstance
     CreationPolicy:
       ResourceSignal:
         Count: '1'
@@ -303,8 +301,6 @@ Resources:
   WSO2WindowsInstance:
       Type: 'AWS::EC2::Instance'
       Condition: 'IsWindows'
-      DependsOn:
-        - WSO2DBInstance
       Properties:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop


### PR DESCRIPTION
**Purpose**
CloudFormation script for APIM-integration test is having `depends on` property for EC2 instances which pauses creation of EC2 instances until the DB-instance is created. 
But as per the current logic, creation of EC2 instances and creation of DB-instances are independent. Therefore we can remove 'depends on' property which will reduce stack creation time by making the resource creation parallel as per [AWS docs](https://aws.amazon.com/about-aws/whats-new/2013/08/12/aws-cloudformation-introduces-parallel-stack-creation-and-nested-stack-updates/).
Fixes #863
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Reduce TestGrid Job execution time.
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
Let CloudFormation resource creations to be parallel.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes