### PR TITLE
Change integration-test log file path

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -446,22 +446,14 @@ public final class TestGridUtil {
     }
 
     /**
-     * Returns the path of the integration test log file.
+     * Returns the absolute path of the integration test log file.
      *
      * @param testPlan test-plan
-     * @param relative Whether the path need to be returned relative to testgrid.home or not
      * @return log file path
      */
-    public static String deriveTestIntegrationLogFilePath(TestPlan testPlan, Boolean relative)
+    public static String deriveTestIntegrationLogFilePath(TestPlan testPlan)
             throws TestGridException {
-        String productName = testPlan.getDeploymentPattern().getProduct().getName();
-        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
-        String dirPrefix = "";
-        if (!relative) {
-            dirPrefix = getTestGridHomePath();
-        }
-        return Paths.get(dirPrefix, TestGridConstants.TESTGRID_JOB_DIR, productName,
-                TestGridConstants.TESTGRID_BUILDS_DIR, testPlanDirName,
+        return Paths.get(DataBucketsHelper.getOutputLocation(testPlan).toString(),
                 TestGridConstants.TEST_INTEGRATION_LOG_FILE_NAME).toString();
     }
 

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
@@ -109,7 +109,7 @@ public class EmailReportProcessor {
         StringBuilder stringBuilder = new StringBuilder();
         Path filePath;
         try {
-            filePath = Paths.get(TestGridUtil.deriveTestIntegrationLogFilePath(testPlan, false));
+            filePath = Paths.get(TestGridUtil.deriveTestIntegrationLogFilePath(testPlan));
         } catch (TestGridException e) {
             throw new ReportingException("Error occurred while deriving integration-test log file path to get" +
                     " integration test results for test-plan with id " + testPlan.getId() + "of the product " +


### PR DESCRIPTION
**Purpose**
To change integration test log file path as to refer from data-bucket of the build.
Fixes #867

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes