### PR TITLE
Add surefire sub-directory to integration-log file path

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -71,6 +71,7 @@ public final class TestGridUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGridUtil.class);
     private static final String UNDERSCORE = "_";
+    private static final String SUREFIRE_REPORTS_DIR = "surefire-reports";
 
     /**
      * Use {@link org.wso2.testgrid.common.ShellExecutor#executeCommand(String)} instead.
@@ -453,7 +454,7 @@ public final class TestGridUtil {
      */
     public static String deriveTestIntegrationLogFilePath(TestPlan testPlan)
             throws TestGridException {
-        return Paths.get(DataBucketsHelper.getOutputLocation(testPlan).toString(),
+        return Paths.get(DataBucketsHelper.getOutputLocation(testPlan).toString(), SUREFIRE_REPORTS_DIR,
                 TestGridConstants.TEST_INTEGRATION_LOG_FILE_NAME).toString();
     }
 


### PR DESCRIPTION
**Purpose**
Add surefire sub-directory to integration-log file path
ex:

><TESTGRID_HOME>/jobs/wso2xy-intg/builds/integration-tests_123456789101112131415161718/data-bucket/**surefire-reports**/

  
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes