### PR TITLE
Change output.properties file location as to refer from data-bucket

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -474,21 +474,15 @@ public final class TestGridUtil {
     }
 
     /**
-     * Returns the path of the integration test log file.
+     * Returns the path of the scenario outputs property file.
+     * This property file is received from the instance where tests have been executed.
      *
      * @param testPlan test-plan
      * @return log file path
      */
-    public static String deriveScenarioOutputPropertyFilePath(TestPlan testPlan, Boolean relative)
+    public static String deriveScenarioOutputPropertyFilePath(TestPlan testPlan)
             throws TestGridException {
-        String productName = testPlan.getDeploymentPattern().getProduct().getName();
-        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
-        String dirPrefix = "";
-        if (!relative) {
-            dirPrefix = getTestGridHomePath();
-        }
-        return Paths.get(dirPrefix, TestGridConstants.TESTGRID_JOB_DIR, productName,
-                TestGridConstants.TESTGRID_BUILDS_DIR, testPlanDirName,
+        return Paths.get(DataBucketsHelper.getOutputLocation(testPlan).toString(),
                 TestGridConstants.TESTGRID_SCENARIO_OUTPUT_PROPERTY_FILE).toString();
     }
     /**

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
@@ -173,7 +173,7 @@ public class EmailReportProcessor {
         String outputPropertyFilePath = null;
         try {
             outputPropertyFilePath =
-                    TestGridUtil.deriveScenarioOutputPropertyFilePath(testPlan, false);
+                    TestGridUtil.deriveScenarioOutputPropertyFilePath(testPlan);
             PropertyFileReader propertyFileReader = new PropertyFileReader();
             String gitRevision = propertyFileReader.
                     getProperty(PropertyFileReader.BuildOutputProperties.GIT_REVISION, outputPropertyFilePath);


### PR DESCRIPTION
**Purpose**
With the introduction of data-buckets, the output.property file have to be referred from that directory.
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes