### PR TITLE
Improve latest test plans retrieving query

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
@@ -20,6 +20,7 @@
 package org.wso2.testgrid.common.config;
 
 
+import org.apache.commons.collections4.ListUtils;
 import org.wso2.testgrid.common.ConfigChangeSet;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestScenario;
@@ -55,7 +56,7 @@ public class ScenarioConfig implements Serializable {
     }
 
     public List<TestScenario> getScenarios() {
-        return scenarios;
+        return ListUtils.emptyIfNull(scenarios);
     }
 
     public void setScenarios(List<TestScenario> scenarios) {

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -28,8 +28,10 @@ import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.config.DeploymentConfig;
+import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.InfrastructureConfig.Provisioner;
 import org.wso2.testgrid.common.config.JobConfigFile;
+import org.wso2.testgrid.common.config.ScenarioConfig;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.config.TestgridYaml;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
@@ -636,15 +638,28 @@ public class GenerateTestPlanCommand implements Command {
      * @return True or False, based on the validity of the testgridYaml
      */
     private boolean validateTestgridYaml(TestgridYaml testgridYaml) {
-        Boolean isValisTestgridYaml = true;
-        if (testgridYaml.getInfrastructureConfig().getProvisioners().isEmpty()) {
-            logger.error("testgridYaml doesn't contain at least single infra provisioner, Invalid testgridYaml");
-            isValisTestgridYaml = false;
+        Boolean isValidTestgridYaml = true;
+        InfrastructureConfig infrastructureConfig = testgridYaml.getInfrastructureConfig();
+        ScenarioConfig scenarioConfig = testgridYaml.getScenarioConfig();
+        if (infrastructureConfig != null) {
+            if (infrastructureConfig.getProvisioners().isEmpty()) {
+                logger.error("testgrid.yaml doesn't contain at least single infra provisioner, Invalid testgrid.yaml");
+                isValidTestgridYaml = false;
+            }
+        } else {
+            logger.error("testgrid.yaml doesn't have defined the infra configuration, Invalid testgrid.yaml");
+            isValidTestgridYaml = false;
         }
-        if (testgridYaml.getScenarioConfig().getScenarios().isEmpty()) {
-            logger.error("testgridYaml doesn't contain at least single scenario, Invalid testgridYaml");
-            isValisTestgridYaml = false;
+        if (scenarioConfig != null) {
+            if (scenarioConfig.getScenarios().isEmpty()) {
+                logger.error("testgrid.yaml doesn't contain at least single scenario, Invalid testgrid.yaml");
+                isValidTestgridYaml = false;
+            }
+        } else {
+            logger.error("testgrid.yaml doesn't have defined the scenario configuration, Invalid testgrid.yaml");
+            isValidTestgridYaml = false;
         }
-        return isValisTestgridYaml;
+
+        return isValidTestgridYaml;
     }
 }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -183,7 +183,7 @@ public class GenerateTestPlanCommand implements Command {
             throws CommandExecutionException, TestGridDAOException {
         if (!validateTestgridYaml(testgridYaml)) {
             throw new CommandExecutionException(
-                    "Invalid tesgridYaml file is found,Please verify the content of the testgridYaml file");
+                    "Invalid tesgridYaml file is found. Please verify the content of the testgridYaml file");
         }
         populateDefaults(testgridYaml);
         Set<InfrastructureCombination> combinations = infrastructureCombinationsProvider.getCombinations(testgridYaml);
@@ -643,20 +643,20 @@ public class GenerateTestPlanCommand implements Command {
         ScenarioConfig scenarioConfig = testgridYaml.getScenarioConfig();
         if (infrastructureConfig != null) {
             if (infrastructureConfig.getProvisioners().isEmpty()) {
-                logger.error("testgrid.yaml doesn't contain at least single infra provisioner, Invalid testgrid.yaml");
+                logger.debug("testgrid.yaml doesn't contain at least single infra provisioner. Invalid testgrid.yaml");
                 isValidTestgridYaml = false;
             }
         } else {
-            logger.error("testgrid.yaml doesn't have defined the infra configuration, Invalid testgrid.yaml");
+            logger.debug("testgrid.yaml doesn't have defined the infra configuration. Invalid testgrid.yaml");
             isValidTestgridYaml = false;
         }
         if (scenarioConfig != null) {
             if (scenarioConfig.getScenarios().isEmpty()) {
-                logger.error("testgrid.yaml doesn't contain at least single scenario, Invalid testgrid.yaml");
+                logger.debug("testgrid.yaml doesn't contain at least single scenario. Invalid testgrid.yaml");
                 isValidTestgridYaml = false;
             }
         } else {
-            logger.error("testgrid.yaml doesn't have defined the scenario configuration, Invalid testgrid.yaml");
+            logger.debug("testgrid.yaml doesn't have defined the scenario configuration. Invalid testgrid.yaml");
             isValidTestgridYaml = false;
         }
 

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -638,28 +638,27 @@ public class GenerateTestPlanCommand implements Command {
      * @return True or False, based on the validity of the testgridYaml
      */
     private boolean validateTestgridYaml(TestgridYaml testgridYaml) {
-        Boolean isValidTestgridYaml = true;
         InfrastructureConfig infrastructureConfig = testgridYaml.getInfrastructureConfig();
         ScenarioConfig scenarioConfig = testgridYaml.getScenarioConfig();
         if (infrastructureConfig != null) {
             if (infrastructureConfig.getProvisioners().isEmpty()) {
                 logger.debug("testgrid.yaml doesn't contain at least single infra provisioner. Invalid testgrid.yaml");
-                isValidTestgridYaml = false;
+                return false;
             }
         } else {
             logger.debug("testgrid.yaml doesn't have defined the infra configuration. Invalid testgrid.yaml");
-            isValidTestgridYaml = false;
+            return false;
         }
         if (scenarioConfig != null) {
             if (scenarioConfig.getScenarios().isEmpty()) {
                 logger.debug("testgrid.yaml doesn't contain at least single scenario. Invalid testgrid.yaml");
-                isValidTestgridYaml = false;
+                return false;
             }
         } else {
             logger.debug("testgrid.yaml doesn't have defined the scenario configuration. Invalid testgrid.yaml");
-            isValidTestgridYaml = false;
+            return false;
         }
 
-        return isValidTestgridYaml;
+        return true;
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -197,8 +197,9 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
     public List<TestPlan> getLatestTestPlans(Product product) {
         String sql = "select tp.* from test_plan tp inner join (Select distinct infra_parameters, max(test_run_number) "
                 + "as test_run_number from test_plan where  DEPLOYMENTPATTERN_id in (select id from deployment_pattern "
-                + "where PRODUCT_id= ?) group by infra_parameters) as rn on tp.infra_parameters=rn.infra_parameters and"
-                + " tp.test_run_number=rn.test_run_number and tp.DEPLOYMENTPATTERN_id in "
+                + "where PRODUCT_id= ?) group by infra_parameters) as latest_test_run_nums on "
+                + "tp.infra_parameters=latest_test_run_nums.infra_parameters and "
+                + "tp.test_run_number=latest_test_run_nums.test_run_number and tp.DEPLOYMENTPATTERN_id in "
                 + "(select id from deployment_pattern where PRODUCT_id= ?);";
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
**Purpose**
The purpose of this PR is to modify the latest test plans retrieving query. 

**Goals**
When retrieving latest test plans for a given product, as per the current implementation, it is mainly considered the last modified timestamp of the test plan table and get the latest test plans. Since we stored the test plan number in the DB, it is more appropriate if we consider the maximum of the test plan number for an infra combination and a deployment pattern when we querying the latest test plans for a given product. Hence modified the query in this way. 

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
- JDK - ORACLE 1.8
- OS - UBUNTU 18.04
- DB- MySQL 5.7