### PR TITLE
Modify is_success field in the test_case table

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/FunctionalTestResultParser.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.automation.exception.JTLResultParserException;
 import org.wso2.testgrid.automation.exception.ResultParserException;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestScenario;
@@ -196,7 +197,13 @@ public class FunctionalTestResultParser extends ResultParser {
             if (TEST_NAME_ATTRIBUTE.equals(attribute.getName().getLocalPart())) {
                 testCase.setName(attribute.getValue());
             } else if (TEST_SUCCESS_ATTRIBUTE.equals(attribute.getName().getLocalPart())) {
-                testCase.setSuccess(Boolean.valueOf(attribute.getValue()));
+                if (Boolean.valueOf(attribute.getValue())) {
+                    testCase.setSuccess(Status.SUCCESS);
+                } else if (!Boolean.valueOf(attribute.getValue())) {
+                    testCase.setSuccess(Status.FAIL);
+                } else {
+                    testCase.setSuccess(Status.SKIP);
+                }
             }
         }
         return testCase;

--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
@@ -69,11 +69,9 @@ public class TestNgResultsParser extends ResultParser {
     public static final String RESULTS_TEST_SUITE_FILE = "TEST-TestSuite.xml";
     private static final String[] ARCHIVABLE_FILES = new String[] { "surefire-reports", "automation.log" };
     private static final Logger logger = LoggerFactory.getLogger(TestNgResultsParser.class);
-    private static final String TOTAL = "total";
-    private static final String FAILED = "failed";
-    private static final String PASSED = "passed";
+    private static final String TEST_CASE = "testcase";
+    private static final String FAILED = "failure";
     private static final String SKIPPED = "skipped";
-    private final XMLInputFactory factory = XMLInputFactory.newInstance();
 
     /**
      * This constructor is used to create a {@link TestNgResultsParser} object with the
@@ -193,23 +191,22 @@ public class TestNgResultsParser extends ResultParser {
         List<TestCase> testCases = new ArrayList<>();
         while (eventReader.hasNext()) {
             XMLEvent event = eventReader.nextEvent();
-            if (event.getEventType() == XMLStreamConstants.END_ELEMENT &&
-                    event.asEndElement().getName().getLocalPart().equals("testcase")) {
-                TestCase testCase = buildTestCase(classNameStr, Boolean.TRUE, "");
+            if (event.getEventType() == XMLStreamConstants.END_ELEMENT && TEST_CASE
+                    .equals(event.asEndElement().getName().getLocalPart())) {
+                TestCase testCase = buildTestCase(classNameStr, Status.SUCCESS, "");
                 testCases.add(testCase);
                 break;
             }
-            if (event.getEventType() == XMLStreamConstants.START_ELEMENT &&
-                    event.asStartElement().getName().getLocalPart().equals("skipped")) {
-                //TODO add new state SKIPPED in the testcase/TestGrid and set to that state
-                TestCase testCase = buildTestCase(classNameStr, Boolean.FALSE, "Test Skipped");
+            if (event.getEventType() == XMLStreamConstants.START_ELEMENT && SKIPPED
+                    .equals(event.asStartElement().getName().getLocalPart())) {
+                TestCase testCase = buildTestCase(classNameStr, Status.SKIP, "Test Skipped");
                 testCases.add(testCase);
                 break;
             }
-            if (event.getEventType() == XMLStreamConstants.START_ELEMENT &&
-                    event.asStartElement().getName().getLocalPart().equals("failure")) {
+            if (event.getEventType() == XMLStreamConstants.START_ELEMENT && FAILED
+                    .equals(event.asStartElement().getName().getLocalPart())) {
                 String failureMessage = readFailureMessage(eventReader);
-                TestCase testCase = buildTestCase(classNameStr, Boolean.FALSE, failureMessage);
+                TestCase testCase = buildTestCase(classNameStr, Status.FAIL, failureMessage);
                 testCases.add(testCase);
                 break;
             }
@@ -217,7 +214,6 @@ public class TestNgResultsParser extends ResultParser {
         return testCases;
     }
 
-<<<<<<< HEAD
     /**
      * Reads the text content data inside the <failure></failure> element and builds the
      * error message.
@@ -237,44 +233,6 @@ public class TestNgResultsParser extends ResultParser {
             }
         }
         return builder.toString();
-=======
-    private TestCase readTestMethod(String classNameStr, StartElement element) {
-        final Iterator attrs = element.getAttributes();
-        Status status = null;  // null means 'SKIP' for now. true/false for PASS/FAIL.
-        String name = "unknown";
-        String description = "";
-        while (attrs.hasNext()) {
-            final Attribute attr = (Attribute) attrs.next();
-            if ("status".equals(attr.getName().getLocalPart())) {
-                switch (attr.getValue()) {
-                case "PASS":
-                    status = Status.SUCCESS;
-                    break;
-                case "FAIL":
-                    status = Status.FAIL;
-                    break;
-                default:
-                    status = Status.SKIP; //handle the skipped case
-                    description += " :: " + attr.getValue();
-                    break;
-                }
-            }
-            if ("name".equals(attr.getName().getLocalPart())) {
-                name = attr.getValue();
-            }
-            if ("description".equals(attr.getName().getLocalPart())) {
-                description = description.isEmpty() ? attr.getValue() : attr.getValue() + description;
-            }
-        }
-        if (status == null) { // it's a skipped test!
-            // TODO we need to properly handle Skipped test cases.
-            name = name + " :: SKIPPED!";
-            status = Status.SKIP;
-        }
-        //todo capture failure message
-        return buildTestCase(classNameStr + "." + name, status, description);
-
->>>>>>> Modify is_success field in the test_case table
     }
 
     private TestCase buildTestCase(String className, Status isSuccess, String failureMessage) {

--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
@@ -97,13 +97,15 @@ public class TestNgResultsParserTest {
 
         parser.get().parseResults();
         Assert.assertEquals(testScenario.getTestCases().size(), 9, "generated test cases does not match.");
-        final long successTestCases = testScenario.getTestCases().stream().filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
-        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
+        final long successTestCases = testScenario.getTestCases().stream()
+                .filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
+        final long failureTestCases = testScenario.getTestCases().stream()
+                .filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
         final long skipTestCases = testScenario.getTestCases().stream()
                 .filter(tc -> Status.SKIP.equals(tc.getStatus())).count();
         Assert.assertEquals(successTestCases, 6, "success test cases does not match.");
-        Assert.assertEquals(failureTestCases, 3, "failure test cases does not match.");
-        Assert.assertEquals(skipTestCases, 5, "skip test cases does not match.");
+        Assert.assertEquals(failureTestCases, 2, "failure test cases does not match.");
+        Assert.assertEquals(skipTestCases, 1, "skip test cases does not match.");
     }
 
     @Test
@@ -121,10 +123,12 @@ public class TestNgResultsParserTest {
         parser.get().parseResults();
         parser.get().archiveResults();
         Assert.assertEquals(testScenario.getTestCases().size(), 9, "generated test cases does not match.");
-        final long successTestCases = testScenario.getTestCases().stream().filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
-        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
+        final long successTestCases = testScenario.getTestCases().stream()
+                .filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
+        final long failureTestCases = testScenario.getTestCases().stream()
+                .filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
         Assert.assertEquals(successTestCases, 6, "success test cases does not match.");
-        Assert.assertEquals(failureTestCases, 3, "failure test cases does not match.");
+        Assert.assertEquals(failureTestCases, 2, "failure test cases does not match.");
     }
 
     private void copyTestngResultsXml(Path outputLocation) throws IOException {

--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
@@ -31,7 +31,7 @@ import org.wso2.testgrid.automation.parser.ResultParserFactory;
 import org.wso2.testgrid.automation.parser.TestNgResultsParser;
 import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Product;
-import org.wso2.testgrid.common.TestCase;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
@@ -97,11 +97,13 @@ public class TestNgResultsParserTest {
 
         parser.get().parseResults();
         Assert.assertEquals(testScenario.getTestCases().size(), 9, "generated test cases does not match.");
-        final long successTestCases = testScenario.getTestCases().stream().filter(TestCase::isSuccess).count();
-        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> !tc.isSuccess()).count();
+        final long successTestCases = testScenario.getTestCases().stream().filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
+        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
+        final long skipTestCases = testScenario.getTestCases().stream()
+                .filter(tc -> Status.SKIP.equals(tc.getStatus())).count();
         Assert.assertEquals(successTestCases, 6, "success test cases does not match.");
         Assert.assertEquals(failureTestCases, 3, "failure test cases does not match.");
-
+        Assert.assertEquals(skipTestCases, 5, "skip test cases does not match.");
     }
 
     @Test
@@ -119,11 +121,10 @@ public class TestNgResultsParserTest {
         parser.get().parseResults();
         parser.get().archiveResults();
         Assert.assertEquals(testScenario.getTestCases().size(), 9, "generated test cases does not match.");
-        final long successTestCases = testScenario.getTestCases().stream().filter(TestCase::isSuccess).count();
-        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> !tc.isSuccess()).count();
+        final long successTestCases = testScenario.getTestCases().stream().filter(tc -> Status.SUCCESS.equals(tc.getStatus())).count();
+        final long failureTestCases = testScenario.getTestCases().stream().filter(tc -> Status.FAIL.equals(tc.getStatus())).count();
         Assert.assertEquals(successTestCases, 6, "success test cases does not match.");
         Assert.assertEquals(failureTestCases, 3, "failure test cases does not match.");
-
     }
 
     private void copyTestngResultsXml(Path outputLocation) throws IOException {

--- a/common/src/main/java/org/wso2/testgrid/common/Status.java
+++ b/common/src/main/java/org/wso2/testgrid/common/Status.java
@@ -57,7 +57,12 @@ public enum Status {
     /**
      * Entity execution is incomplete.
      */
-    INCOMPLETE("INCOMPLETE");
+    INCOMPLETE("INCOMPLETE"),
+
+    /**
+     * Entity execution is skipped.
+     */
+    SKIP("SKIP");
 
     private final String status;
 

--- a/common/src/main/java/org/wso2/testgrid/common/TestCase.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestCase.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
@@ -46,7 +48,7 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
      * Column names of the table.
      */
     public static final String NAME_COLUMN = "name";
-    public static final String IS_SUCCESS_COLUMN = "isSuccess";
+    public static final String IS_SUCCESS_COLUMN = "status";
     public static final String FAILURE_MESSAGE_COLUMN = "failureMessage";
     public static final String TEST_SCENARIO_COLUMN = "testScenario";
 
@@ -55,8 +57,9 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
     @Column(name = "test_name", nullable = false)
     private String name;
 
-    @Column(name = "is_success", nullable = false)
-    private boolean isSuccess;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    private Status status;
 
     @Column(name = "failure_message", length = 20000)
     private String failureMessage;
@@ -88,8 +91,8 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
      *
      * @return {@code true} if the test case is successful, {@code false} otherwise
      */
-    public boolean isSuccess() {
-        return isSuccess;
+    public Status getStatus() {
+        return status;
     }
 
     /**
@@ -97,8 +100,8 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
      *
      * @param success whether the test is successful or failed
      */
-    public void setSuccess(boolean success) {
-        isSuccess = success;
+    public void setSuccess(Status success) {
+        status = success;
     }
 
     /**
@@ -143,7 +146,7 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
         return StringUtil.concatStrings("TestCase{",
                 "id='", id,
                 ", name='", name, "\'",
-                ", isSuccess='", isSuccess, "\'",
+                ", status='", status, "\'",
                 ", failureMessage='", failureMessage, "\'",
                 ", testScenario='", testScenario.getName(), "\'",
                 '}');

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -632,11 +632,11 @@ public class TestPlanExecutor {
     private void persistTestScenario(TestScenario testScenario) throws TestPlanExecutorException {
         //Persist test scenario
         try {
-            if (testScenario.getTestCases().size() == 0) {
+            if (testScenario.getTestCases().isEmpty()) {
                 testScenario.setStatus(Status.ERROR);
             } else {
                 for (TestCase testCase : testScenario.getTestCases()) {
-                    if (!testCase.isSuccess()) {
+                    if (Status.FAIL.equals(testCase.getStatus())) {
                         testScenario.setStatus(Status.FAIL);
                         break;
                     } else {
@@ -730,7 +730,7 @@ public class TestPlanExecutor {
                 .filter(ts -> ts.getStatus() != Status.SUCCESS)
                 .map(TestScenario::getTestCases)
                 .flatMap(Collection::stream)
-                .filter(tc -> !tc.isSuccess())
+                .filter(tc -> Status.FAIL.equals(tc.getStatus()))
                 .forEachOrdered(
                         tc -> {
                             failedTestCaseCount.incrementAndGet();
@@ -792,4 +792,3 @@ public class TestPlanExecutor {
     }
 
 }
-

--- a/core/src/test/java/org/wso2/testgrid/core/TestPlanExecutorTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/TestPlanExecutorTest.java
@@ -74,21 +74,21 @@ public class TestPlanExecutorTest {
         s2.setStatus(Status.FAIL);
 
         TestCase tc = new TestCase();
-        tc.setSuccess(true);
+        tc.setSuccess(Status.SUCCESS);
         tc.setFailureMessage("success");
         tc.setName("Sample Testcase 01");
         tc.setTestScenario(s);
         s.addTestCase(tc);
 
         tc = new TestCase();
-        tc.setSuccess(false);
+        tc.setSuccess(Status.FAIL);
         tc.setFailureMessage("fail");
         tc.setName("Sample Testcase 02");
         tc.setTestScenario(s2);
         s2.addTestCase(tc);
 
         tc = new TestCase();
-        tc.setSuccess(false);
+        tc.setSuccess(Status.FAIL);
         tc.setFailureMessage("fail");
         tc.setName("Sample Testcase 03");
         tc.setTestScenario(s2);

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
@@ -278,7 +279,7 @@ public class TestReportEngine {
 
         // Fail list
         List<ReportElement> failList = distinctElements.stream()
-                .filter(reportElement -> !reportElement.isTestSuccess())
+                .filter(ReportElement::isTestFail)
                 .collect(Collectors.toList());
 
         // Success list
@@ -321,7 +322,7 @@ public class TestReportEngine {
 
         // Fail list
         List<ReportElement> failList = distinctElements.stream()
-                .filter(reportElement -> !reportElement.isTestSuccess())
+                .filter(ReportElement::isTestFail)
                 .collect(Collectors.toList());
 
         // Success list
@@ -365,7 +366,7 @@ public class TestReportEngine {
 
         // Fail list
         List<ReportElement> failList = distinctElements.stream()
-                .filter(reportElement -> !reportElement.isTestSuccess())
+                .filter(ReportElement::isTestFail)
                 .collect(Collectors.toList());
 
         // Success list
@@ -542,7 +543,7 @@ public class TestReportEngine {
      */
     private List<ReportElement> filterSuccessReportElements(List<ReportElement> reportElements) {
         return reportElements.stream()
-                .filter(reportElement -> !reportElement.isTestSuccess())
+                .filter(ReportElement::isTestFail)
                 .collect(Collectors.toList());
     }
 
@@ -704,14 +705,13 @@ public class TestReportEngine {
         // Test case can be null if the infra fails.
         if (testCase != null) {
             reportElement.setTestCase(testCase.getName());
-            reportElement.setTestSuccess(testCase.isSuccess());
-
-            if (!testCase.isSuccess()) {
+            reportElement.setTestSuccess(testCase.getStatus());
+            if (Status.FAIL.equals(testCase.getStatus())) {
                 reportElement.setTestCaseFailureMessage(testCase.getFailureMessage());
             }
         } else {
             reportElement.setTestCase("");
-            reportElement.setTestSuccess(false);
+            reportElement.setTestSuccess(Status.FAIL);
         }
         return reportElement;
     }

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/model/ReportElement.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/model/ReportElement.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.testgrid.reporting.model;
 
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.reporting.AxisColumn;
 
 /**
@@ -34,7 +35,7 @@ public class ReportElement {
     private String scenarioDescription;
     private String testCase;
     private String testCaseFailureMessage;
-    private boolean isTestSuccess;
+    private Status isTestSuccess;
 
     /**
      * Constructs an instance of {@link ReportElement} for the given parameters.
@@ -143,7 +144,16 @@ public class ReportElement {
      * @return {@code true} if the test case is successful, {@code false} otherwise
      */
     public boolean isTestSuccess() {
-        return isTestSuccess;
+        return Status.SUCCESS.equals(isTestSuccess);
+    }
+
+    /**
+     * Returns whether the test case is successful or not.
+     *
+     * @return {@code true} if the test case is successful, {@code false} otherwise
+     */
+    public boolean isTestFail() {
+        return Status.FAIL.equals(isTestSuccess);
     }
 
     /**
@@ -151,7 +161,7 @@ public class ReportElement {
      *
      * @param testSuccess whether the test case is successful or not.
      */
-    public void setTestSuccess(boolean testSuccess) {
+    public void setTestSuccess(Status testSuccess) {
         isTestSuccess = testSuccess;
     }
 

--- a/reporting/src/main/resources/templates/report_element.mustache
+++ b/reporting/src/main/resources/templates/report_element.mustache
@@ -3,12 +3,12 @@
         <!-- Status -->
         <td>
             <center>
-                {{#isTestSuccess}}
+                {{#status}}
                     <i class="fas fa-check-circle"></i>
-                {{/isTestSuccess}}
-                {{^isTestSuccess}}
+                {{/status}}
+                {{^status}}
                     <i class="fas fa-times-circle"></i>
-                {{/isTestSuccess}}
+                {{/status}}
             </center>
         </td>
 
@@ -24,28 +24,28 @@
 
         <!-- Scenario -->
         {{^isGroupByScenario}}
-            {{#isTestSuccess}}
+            {{#status}}
                 <td class="successText">{{scenarioDescription}}</td>
-            {{/isTestSuccess}}
-            {{^isTestSuccess}}
+            {{/status}}
+            {{^status}}
                 <td class="errorText">{{scenarioDescription}}</td>
-            {{/isTestSuccess}}
+            {{/status}}
         {{/isGroupByScenario}}
 
         <!-- Test case -->
-        {{#isTestSuccess}}
+        {{#status}}
             <td class="successText">{{testCase}}</td>
-        {{/isTestSuccess}}
-        {{^isTestSuccess}}
+        {{/status}}
+        {{^status}}
             <td class="errorText">{{testCase}}</td>
-        {{/isTestSuccess}}
+        {{/status}}
 
         <!-- Failure message -->
-        {{#isTestSuccess}}
+        {{#status}}
             <td class="successText"></td>
-        {{/isTestSuccess}}
-        {{^isTestSuccess}}
+        {{/status}}
+        {{^status}}
             <td class="errorText">{{testCaseFailureMessage}}</td>
-        {{/isTestSuccess}}
+        {{/status}}
     </tr>
 {{/parsedReportElements}}

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
@@ -112,21 +112,21 @@ public class TestReportEngineTest {
         s2.setStatus(Status.FAIL);
 
         TestCase tc = new TestCase();
-        tc.setSuccess(true);
+        tc.setSuccess(Status.SUCCESS);
         tc.setFailureMessage("success");
         tc.setName("Sample Testcase 01");
         tc.setTestScenario(s);
         s.addTestCase(tc);
 
         tc = new TestCase();
-        tc.setSuccess(false);
+        tc.setSuccess(Status.FAIL);
         tc.setFailureMessage("fail");
         tc.setName("Sample Testcase 02");
         tc.setTestScenario(s2);
         s2.addTestCase(tc);
 
         tc = new TestCase();
-        tc.setSuccess(false);
+        tc.setSuccess(Status.FAIL);
         tc.setFailureMessage("fail");
         tc.setName("Sample Testcase 03");
         tc.setTestScenario(s2);

--- a/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
@@ -213,7 +213,7 @@ class APIUtil {
         if (testCase != null) {
             testCaseBean.setId(testCase.getId());
             testCaseBean.setName(testCase.getName());
-            testCaseBean.setSuccess(testCase.isSuccess());
+            testCaseBean.setStatus(testCase.getStatus());
             testCaseBean.setModifiedTimestamp(testCase.getModifiedTimestamp());
             testCaseBean.setCreatedTimestamp(testCase.getCreatedTimestamp());
             testCaseBean.setErrorMsg(testCase.getFailureMessage());

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -21,6 +21,7 @@ package org.wso2.testgrid.web.api;
 import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
@@ -428,18 +429,19 @@ public class TestPlanService {
 
             // TODO: change backend design to store these info within the db to reduce UI latency.
             // Create scenario summary
-            long totalSuccess = testCases.stream().filter(TestCase::isSuccess).count();
-            long totalFailed = testCases.stream().filter(testCase -> !testCase.isSuccess()).count();
+            long totalSuccess = testCases.stream().filter(testCase -> Status.SUCCESS.equals(testCase.getStatus()))
+                    .count();
+            long totalFailed = testCases.stream().filter(testCase -> Status.FAIL.equals(testCase.getStatus())).count();
             ScenarioSummary scenarioSummary = new ScenarioSummary(testScenario.getDescription(),
-                    testScenario.getConfigChangeSetName() , testScenario.getConfigChangeSetDescription(), totalSuccess,
+                    testScenario.getConfigChangeSetName(), testScenario.getConfigChangeSetDescription(), totalSuccess,
                     totalFailed, testScenario.getStatus(), testScenario.getName());
             scenarioSummaries.add(scenarioSummary);
 
             // Create test case entries for failed tests
             List<TestCaseEntry> failedTestCaseEntries = testCases.stream()
-                    .filter(testCase -> !testCase.isSuccess())
+                    .filter(testCase -> Status.FAIL.equals(testCase.getStatus()))
                     .map(testCase -> new TestCaseEntry(testCase.getName(), testCase.getFailureMessage(),
-                            testCase.isSuccess())
+                            testCase.getStatus())
                     )
                     .collect(Collectors.toList());
             scenarioTestCaseEntries.add(new ScenarioTestCaseEntry(

--- a/web/src/main/java/org/wso2/testgrid/web/bean/TestCase.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/TestCase.java
@@ -18,6 +18,8 @@
 
 package org.wso2.testgrid.web.bean;
 
+import org.wso2.testgrid.common.Status;
+
 import java.sql.Timestamp;
 import java.util.Date;
 
@@ -31,7 +33,7 @@ public class TestCase {
     private String errorMsg;
     private Timestamp createdTimestamp;
     private Timestamp modifiedTimestamp;
-    private boolean isSuccess;
+    private Status status;
 
     /**
      * Returns the id of the test-case.
@@ -112,21 +114,21 @@ public class TestCase {
     }
 
     /**
-     * Returns the isSuccess of the test-case.
+     * Returns the status of the test-case.
      *
      * @return {@code true} if the test is success, {@code false} otherwise
      */
-    public boolean isSuccess() {
-        return isSuccess;
+    public Status getStatus() {
+        return status;
     }
 
     /**
-     * Sets the isSuccess of the test-case.
+     * Sets the status of the test-case.
      *
-     * @param success test-case isSuccess
+     * @param status test-case getStatus
      */
-    public void setSuccess(boolean success) {
-        this.isSuccess = success;
+    public void setStatus(Status status) {
+        this.status = status;
     }
 
     /**

--- a/web/src/main/java/org/wso2/testgrid/web/bean/TestCaseEntry.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/TestCaseEntry.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.testgrid.web.bean;
 
+import org.wso2.testgrid.common.Status;
+
 /**
  * Bean class for managing information related to test case.
  *
@@ -26,19 +28,19 @@ public class TestCaseEntry {
 
     private final String testCase;
     private final String failureMessage;
-    private final boolean isTestSuccess;
+    private final Status status;
 
     /**
      * Constructs an instance of {@link TestCaseEntry}
      *
      * @param testCase       test case name
      * @param failureMessage test case failure message
-     * @param isTestSuccess  whether the test case is successful or not
+     * @param status  whether the test case is successful or not
      */
-    public TestCaseEntry(String testCase, String failureMessage, boolean isTestSuccess) {
+    public TestCaseEntry(String testCase, String failureMessage, Status status) {
         this.testCase = testCase;
         this.failureMessage = failureMessage;
-        this.isTestSuccess = isTestSuccess;
+        this.status = status;
     }
 
     /**
@@ -60,12 +62,12 @@ public class TestCaseEntry {
     }
 
     /**
-     * Returns whether the test case is successful or not.
+     * Returns status of the test case.
      *
-     * @return {@code true} if the test case is success, {@code false} otherwise
+     * @return 'SUCCESS' if the test case is success,return 'FALSE' if the test case is failed,otherwise returns 'SKIP'
      */
-    public boolean isTestSuccess() {
-        return isTestSuccess;
+    public Status getTestStatus() {
+        return status;
     }
 
     @Override
@@ -73,7 +75,7 @@ public class TestCaseEntry {
         return "TestCaseEntry{" +
                "testCase='" + testCase + '\'' +
                ", failureMessage='" + failureMessage + '\'' +
-               ", isTestSuccess='" + isTestSuccess + '\'' +
+               ", status='" + status + '\'' +
                '}';
     }
 }


### PR DESCRIPTION
**Purpose**
The purpose of this PR is to modify is_success field in the test_case table.

**Goals**
In current TG implementation, it stores the status of the test case as boolean (i.e. True or False). But when we consider integration test there could be some skipped test cases because of failure of a dependent test case. Hence storing the status of those test cases as Failure is incorrect. Therefore modified the data type of the field and according to that code source also modified. In the new implementation maintain status column as varchar. Further, 'SUCCESS', 'FAIL' and 'SKIP' statuses are maintained.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Migrations**
After doing this change you have to modify TG database as well. You can find migration script in below.
```mysql
USE testgriddb;
ALTER TABLE test_case MODIFY is_success VARCHAR(50) NOT NULL;
UPDATE test_case SET is_success = 'SUCCESS' WHERE is_success='1';
UPDATE test_case SET is_success = 'FAIL' WHERE is_success='0';
ALTER TABLE test_case CHANGE `is_success` `status` varchar(50);
``` 
**Test environment**
- JDK - ORACLE 1.8
- OS -UBUNTU 18.04
- DB - MySQL 5.7