### PR TITLE
Update displaying failure message of integration tests

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
@@ -70,6 +70,7 @@ public class TestNgResultsParser extends ResultParser {
     private static final String[] ARCHIVABLE_FILES = new String[] { "surefire-reports", "automation.log" };
     private static final Logger logger = LoggerFactory.getLogger(TestNgResultsParser.class);
     private static final String TEST_CASE = "testcase";
+    private static final String MESSAGE = "message";
     private static final String FAILED = "failure";
     private static final String SKIPPED = "skipped";
     private static final int ERROR_LINE_LIMIT = 2;
@@ -211,7 +212,7 @@ public class TestNgResultsParser extends ResultParser {
                 failureMessage = readFailureMessage(eventReader);
                 while (attributes.hasNext()) {
                     Attribute attribute = (Attribute) attributes.next();
-                    if (attribute.getName().getLocalPart().equals("message")) {
+                    if (MESSAGE.equals(attribute.getName().getLocalPart())) {
                         failureMessage = attribute.getValue();
                         break;
                     }

--- a/automation/src/test/resources/artifacts/surefire-reports/TEST-TestSuite.xml
+++ b/automation/src/test/resources/artifacts/surefire-reports/TEST-TestSuite.xml
@@ -71,7 +71,7 @@
 ]]></system-out>
     </testcase>
     <testcase name="destroy" classname="org.wso2.am.integration.tests.other.APIMANAGER3226APINameWithDifferentCaseTestCase" time="9.081">
-        <failure message="Unable to get API - echo. Error: Read timed out" type="org.wso2.am.integration.test.utils.APIManagerIntegrationTestException">org.wso2.am.integration.test.utils.APIManagerIntegrationTestException: Unable to get API - echo. Error: Read timed out
+        <failure type="org.wso2.am.integration.test.utils.APIManagerIntegrationTestException">org.wso2.am.integration.test.utils.APIManagerIntegrationTestException: Unable to get API - echo. Error: Read timed out
             at java.net.SocketInputStream.socketRead0(Native Method)
             at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
             at java.net.SocketInputStream.read(SocketInputStream.java:171)
@@ -115,8 +115,11 @@ INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2
 ]]></system-out>
     </testcase>
     <testcase name="destroy" classname="org.wso2.am.integration.tests.other.APIMANAGER3226APINameWithDifferentCaseTestCase" time="0.001">
-        <failure type="java.lang.NullPointerException:">java.lang.NullPointerException: null
-            at org.wso2.am.integration.tests.other.APIMANAGER3226APINameWithDifferentCaseTestCase.destroy(APIMANAGER3226APINameWithDifferentCaseTestCase.java:98)
+        <failure message="Access token response contains errors. expected:&lt;false&gt; but was:&lt;true&gt;" type="java.lang.AssertionError">java.lang.AssertionError: Access token response contains errors. expected:&lt;false&gt; but was:&lt;true&gt;
+            at org.testng.Assert.fail(Assert.java:89)
+            at org.testng.Assert.failNotEquals(Assert.java:489)
+            at org.testng.Assert.assertFalse(Assert.java:58)
+            at org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase.testAuthCodeGrantSendGetTokensPost(OAuth2IDTokenEncryptionTestCase.java:253)
         </failure>
         <system-out><![CDATA[INFO  [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - =================== On test skipped org.wso2.am.integration.tests.other.APIMANAGER3226APINameWithDifferentCaseTestCase.testValidateAddAPIsWithDifferentCase ===================
 ]]></system-out>


### PR DESCRIPTION
**Purpose**

Resolves #907 

**Goals**
Update the failure message content of both dashboard and the email report

**Approach**.
Read the message attribute from the TestSuite.xml file when possible and if there is no message attribute it will read the first two lines from the stack trace as the failure message

**Automation tests**
 - Unit tests 

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secret? yes

**Test environment**
ubuntu 14.04, Jdk8
 