### PR TITLE
Change storage of redux-persist module

### DIFF
--- a/web/src/main/react-dashboard/src/App.js
+++ b/web/src/main/react-dashboard/src/App.js
@@ -36,7 +36,7 @@ import {Provider} from 'react-redux';
 import testGrid from './reducers/testGrid.js';
 import {persistStore, persistCombineReducers} from 'redux-persist';
 import {PersistGate} from 'redux-persist/es/integration/react';
-import storage from 'redux-persist/es/storage';
+import storage from 'redux-persist/lib/storage/session';
 import Drawer from 'material-ui/Drawer';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';


### PR DESCRIPTION
**Purpose**

Resolves #914 

**Goals**
Proper navigation of the dashboard when direct URLs are used.

**Approach**

Updated the current redux-persist storage option from local storage to session storage, to solve the
caching issue caused by direct URL links. the session storage ensures that the state is not maintained
after the browser tab is closed and the session is destroyed.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes