### PR TITLE
Email report: identify test cases that fail due to involvement of two or more infras

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
@@ -140,8 +140,10 @@ public class TestNgResultsParser extends ResultParser {
                         if (startElement.getName().getLocalPart().equals("testcase")) {
                             final String classNameStr = getClassName(startElement);
                             List<TestCase> testCases = getTestCasesFor(classNameStr, eventReader);
-                            logger.info(String.format("Found %s test cases in class '%s'", testCases.size(),
-                                    classNameStr));
+                            if (logger.isDebugEnabled()) {
+                                logger.debug(String.format("Found %s test cases in class '%s'", testCases.size(),
+                                        classNameStr));
+                            }
                             testCases.stream().forEachOrdered(tc -> testScenario.addTestCase(tc));
                         }
                     }

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -412,9 +412,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
         return StringUtil.concatStrings("TestPlan{",
                 "id='", id, "\'",
                 ", status='", status, "\'",
+                ", infraParams='", infraParameters, "\'",
                 ", testRunNumber='", testRunNumber, "\'",
                 ", deploymentPattern='", deploymentPattern, "\'",
-                ", infraCombination='", infraParameters, "\'",
                 '}');
     }
 

--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureParameter.java
@@ -19,13 +19,23 @@
 
 package org.wso2.testgrid.common.infrastructure;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.AbstractUUIDEntity;
+import org.wso2.testgrid.common.TestGridError;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -45,8 +55,9 @@ import javax.persistence.UniqueConstraint;
         }
 )
 public class InfrastructureParameter extends AbstractUUIDEntity implements
-        Serializable, Comparable<InfrastructureParameter> {
+        Serializable, Comparable<InfrastructureParameter>, Cloneable {
 
+    private static final Logger logger = LoggerFactory.getLogger(InfrastructureParameter.class);
     public static final String INFRASTRUCTURE_PARAMETER_NAME_COLUMN = "name";
 
     /**
@@ -71,6 +82,14 @@ public class InfrastructureParameter extends AbstractUUIDEntity implements
 
     @Column(name = "ready_for_testgrid")
     private boolean readyForTestGrid;
+
+    /**
+     * This is processed format of the {@link #properties} field.
+     * This does not have a setter method since it can be calculated via the {@link #properties} field.
+     *
+     */
+    @Transient
+    private List<InfrastructureParameter> subInfrastructureParameters = null;
 
     public InfrastructureParameter(String name, String type, String properties, boolean readyForTestGrid) {
         this.name = name;
@@ -123,6 +142,40 @@ public class InfrastructureParameter extends AbstractUUIDEntity implements
 
     public void setReadyForTestGrid(boolean readyForTestGrid) {
         this.readyForTestGrid = readyForTestGrid;
+    }
+
+    /**
+     * Processes the {@link #properties} field, and generate a list of sub infrastructure parameters.
+     *
+     * @return list of sub infra parameters
+     */
+    public List<InfrastructureParameter> getProcessedSubInfrastructureParameters() {
+        if (subInfrastructureParameters == null) {
+            subInfrastructureParameters = new ArrayList<>();
+            try {
+                Properties properties = new Properties();
+                properties.load(new StringReader(this.getProperties()));
+
+                for (Map.Entry entry : properties.entrySet()) {
+                    String name = (String) entry.getValue();
+                    String type = (String) entry.getKey();
+                    String regex = "[\\w,-\\.@:]*";
+                    if (type.isEmpty() || !type.matches(regex)
+                            || name.isEmpty() || !name.matches(regex)) {
+                        continue;
+                    }
+                    InfrastructureParameter infraParameter = new InfrastructureParameter();
+                    infraParameter.setName(name);
+                    infraParameter.setType(type);
+                    infraParameter.setReadyForTestGrid(true);
+                    infraParameter.setProperties(this.getProperties());
+                    subInfrastructureParameters.add(infraParameter);
+                }
+            } catch (IOException e) {
+                logger.warn("Error while loading the infrastructure parameter's properties string for: " + this);
+            }
+        }
+        return subInfrastructureParameters;
     }
 
     @Override
@@ -188,4 +241,59 @@ public class InfrastructureParameter extends AbstractUUIDEntity implements
         return result;
     }
 
+    @Override
+    public InfrastructureParameter clone() {
+        try {
+            final InfrastructureParameter clone = (InfrastructureParameter) super.clone();
+            clone.name = this.name;
+            clone.type = this.type;
+            clone.readyForTestGrid = this.readyForTestGrid;
+            clone.properties = this.properties;
+            clone.subInfrastructureParameters = this.subInfrastructureParameters;
+            return clone;
+
+        } catch (CloneNotSupportedException e) {
+            throw new TestGridError("Since the super class of this object is java.lang.Object that supports cloning, "
+                    + "this failure condition should never happen unless a serious system error occurred.", e);
+        }
+    }
+
+    @Transient
+    private boolean transformed = false;
+    /**
+     *
+     * TODO: This is a temporary method until we fix the infrastructure_parameter table
+     * to contain uniquely distinguishable 'name' column.
+     * Right now, even the type=name pair is also taken as a infrastructure value.
+     * This is not a good design.
+     *
+     */
+    public synchronized void transform() {
+        if (transformed) {
+            return;
+        }
+        final String newName = getProcessedInfraParamName();
+        final InfrastructureParameter clone = this.clone();
+        clone.subInfrastructureParameters = null;
+        this.subInfrastructureParameters.add(clone);
+        this.name = newName;
+        this.transformed = true;
+    }
+
+
+    /**
+     * The @{@link InfrastructureParameter#getName()} is supposed to provide a fully-qualified name
+     * that can uniquely identify an infra. But that's not the case right now.
+     *
+     * Following is a working around to provide better display output.
+     *
+     */
+    private String getProcessedInfraParamName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getName());
+        for (InfrastructureParameter subParam : this.getProcessedSubInfrastructureParameters()) {
+            sb.append(" - ").append(subParam.getName());
+        }
+        return sb.toString();
+    }
 }

--- a/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/FileUtil.java
@@ -234,12 +234,12 @@ public class FileUtil {
         }
         try (Stream<Path> stream = Files.list(source).filter(Files::isRegularFile)) {
             List<Path> paths = stream.sorted().collect(Collectors.toList());
+            logger.info("Test plans found at " + paths);
             for (Path path : paths) {
                 if (!path.toFile().exists()) {
                     throw new IOException(
                             "Test Plan File doesn't exist. File path is " + path.toAbsolutePath().toString());
                 }
-                logger.info("A test plan file found at " + path.toAbsolutePath().toString());
                 TestPlan testPlanYaml = org.wso2.testgrid.common.util.FileUtil
                         .readYamlFile(path.toAbsolutePath().toString(), TestPlan.class);
                 testPlanIds.add(testPlanYaml.getId());

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -148,6 +148,36 @@ public final class TestGridUtil {
     }
 
     /**
+     * Parse the infra param string of {@link TestPlan#getInfraParameters()} into a map of key-value pairs.
+     *
+     * @param infraParams the {@link TestPlan#getInfraParameters()}
+     * @return Map of key-value pair where key == infra type, and value == infra value.
+     */
+    public static Map<String, String> parseInfraParametersString(String infraParams) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(infraParams, new TypeReference<Map<String, String>>() {
+            });
+        } catch (IOException e) {
+            logger.error("Error while parsing infra parameters", e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * transform the properties object into a json string.
+     *
+     */
+    public static String convertToJsonString(Properties properties) {
+        try {
+            return new ObjectMapper().writeValueAsString(properties);
+        } catch (JsonProcessingException e) {
+            logger.error("Error while transforming to json string", e);
+            return null;
+        }
+    }
+
+    /**
      * Returns a UUID specific to the infra parameters.
      *
      * @param infraParams infra parameters to get the UUID
@@ -235,6 +265,40 @@ public final class TestGridUtil {
             throw new CommandExecutionException(StringUtil
                     .concatStrings("Error in preparing a JSON object from the given test plan infra " +
                             "parameters: ", testPlan.getInfrastructureConfig().getParameters()), e);
+        }
+    }
+
+
+    /**
+     * Copies non existing properties from a persisted test plan to a test plan object generated from the config.
+     *
+     * @param testPlanConfig    an instance of test plan which is generated from the config
+     * @param testPlanPersisted an instance of test plan which is persisted in the db
+     * @return an instance of {@link TestPlan} with merged properties
+     */
+    public static TestPlan mergeTestPlans(TestPlan testPlanConfig, TestPlan testPlanPersisted, boolean
+            addToConfigYaml) {
+        //todo: addToConfigYaml param is required because our current merging logic is incomplete.
+        if (addToConfigYaml) {
+            testPlanConfig.setInfraParameters(testPlanPersisted.getInfraParameters());
+            testPlanConfig.setDeploymentPattern(testPlanPersisted.getDeploymentPattern());
+            testPlanConfig.setTestScenarios(testPlanPersisted.getTestScenarios());
+            return testPlanConfig;
+        } else {
+            testPlanPersisted.setDeployerType(testPlanConfig.getDeployerType());
+            testPlanPersisted.setInfrastructureConfig(testPlanConfig.getInfrastructureConfig());
+            testPlanPersisted.setDeploymentConfig(testPlanConfig.getDeploymentConfig());
+            testPlanPersisted.setScenarioConfig(testPlanConfig.getScenarioConfig());
+            testPlanPersisted.setJobName(testPlanConfig.getJobName());
+            testPlanPersisted.setInfrastructureRepository(testPlanConfig.getInfrastructureRepository());
+            testPlanPersisted.setDeploymentRepository(testPlanConfig.getDeploymentRepository());
+            testPlanPersisted.setScenarioTestsRepository(testPlanConfig.getScenarioTestsRepository());
+            testPlanPersisted.setJobProperties(testPlanConfig.getJobProperties());
+            testPlanPersisted.setConfigChangeSetRepository(testPlanConfig.getConfigChangeSetRepository());
+            testPlanPersisted.setConfigChangeSetBranchName(testPlanConfig.getConfigChangeSetBranchName());
+            testPlanPersisted.setResultFormat(testPlanConfig.getResultFormat());
+            testPlanPersisted.setKeyFileLocation(testPlanConfig.getKeyFileLocation());
+            return testPlanPersisted;
         }
     }
 

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -195,8 +195,9 @@ public class TestPlanExecutor {
             ReportGenerator reportGenerator = ReportGeneratorFactory.getReportGenerator(testPlan);
             reportGenerator.generateReport();
         } catch (ReportGeneratorNotFoundException e) {
-            logger.error("Error occurred while finding a report generator " +
-                    " for TestPlan of " + testPlan.getDeploymentPattern().getProduct().getName(), e);
+            logger.error("Could not find a report generator " +
+                    " for TestPlan of " + testPlan.getDeploymentPattern().getProduct().getName() +
+                    ". Test type: " + testPlan.getScenarioConfig().getTestType());
         } catch (ReportGeneratorInitializingException e) {
             logger.error("Error while initializing the report generators  " +
                     "for TestPlan of " + testPlan.getDeploymentPattern().getProduct().getName(), e);

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -107,7 +107,7 @@ public class RunTestPlanCommand implements Command {
             Optional<TestPlan> testPlanEntity = testPlanUOW.getTestPlanById(testPlan.getId());
             if (testPlanEntity.isPresent()) {
                 //Merge properties from persisted test plan to test plan config
-                testPlan = this.mergeTestPlans(testPlan, testPlanEntity.get());
+                testPlan = TestGridUtil.mergeTestPlans(testPlan, testPlanEntity.get(), true);
 
                 // Test plan status should be changed to running and persisted
                 testPlan.setStatus(Status.RUNNING);
@@ -129,20 +129,6 @@ public class RunTestPlanCommand implements Command {
         } catch (TestGridDAOException e) {
             throw new CommandExecutionException("Error in obtaining persisted TestPlan from database.", e);
         }
-    }
-
-    /**
-     * Copies non existing properties from a persisted test plan to a test plan object generated from the config.
-     *
-     * @param testPlanConfig    an instance of test plan which is generated from the config
-     * @param testPlanPersisted an instance of test plan which is persisted in the db
-     * @return an instance of {@link TestPlan} with merged properties
-     */
-    private TestPlan mergeTestPlans(TestPlan testPlanConfig, TestPlan testPlanPersisted) {
-        testPlanConfig.setInfraParameters(testPlanPersisted.getInfraParameters());
-        testPlanConfig.setDeploymentPattern(testPlanPersisted.getDeploymentPattern());
-        testPlanConfig.setTestScenarios(testPlanPersisted.getTestScenarios());
-        return testPlanConfig;
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProvider.java
+++ b/core/src/main/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProvider.java
@@ -28,14 +28,10 @@ import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.InfrastructureParameterUOW;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -111,28 +107,10 @@ public class InfrastructureCombinationsProvider {
      */
     private void addSubpropertiesAsInfrastructureParameters(InfrastructureCombination combination,
             InfrastructureParameter origInfraParameter) {
-        try {
-            Properties properties = new Properties();
-            properties.load(new StringReader(origInfraParameter.getProperties()));
-
-            for (Map.Entry entry : properties.entrySet()) {
-                String name = (String) entry.getValue();
-                String type = (String) entry.getKey();
-                String regex = "[\\w,-\\.@:]*";
-                if (type.isEmpty() || !type.matches(regex)
-                        || name.isEmpty() || !name.matches(regex)) {
-                    continue;
-                }
-                InfrastructureParameter infraParameter = new InfrastructureParameter();
-                infraParameter.setName(name);
-                infraParameter.setType(type);
-                infraParameter.setReadyForTestGrid(true);
-                infraParameter.setProperties(origInfraParameter.getProperties());
-                combination.addParameter(infraParameter);
-            }
-        } catch (IOException e) {
-            logger.warn(
-                    "Error while loading the infrastructure parameter's properties string for: " + origInfraParameter);
+        final List<InfrastructureParameter> subInfraParams = origInfraParameter
+                .getProcessedSubInfrastructureParameters();
+        for (InfrastructureParameter subParam : subInfraParams) {
+            combination.addParameter(subParam);
         }
     }
 

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/GraphDataProvider.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/GraphDataProvider.java
@@ -64,6 +64,10 @@ public class GraphDataProvider {
         this.testPlanUOW = new TestPlanUOW();
     }
 
+    public GraphDataProvider(TestPlanUOW testPlanUOW) {
+        this.testPlanUOW = testPlanUOW;
+    }
+
     /**
      * Provides the test failure summary for a given build job. Test Plan ids of the build job is retrieved by reading
      * testgrid yaml files which contains in the current workspace.

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/model/email/InfraCombination.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/model/email/InfraCombination.java
@@ -19,7 +19,7 @@
 package org.wso2.testgrid.reporting.model.email;
 
 /**
- * This defines s single infra combination.
+ * This defines a single infra combination.
  *
  * @since 1.0.0
  */

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureBuildStatus.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureBuildStatus.java
@@ -18,6 +18,8 @@
 
 package org.wso2.testgrid.reporting.summary;
 
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +31,7 @@ import java.util.List;
  */
 public class InfrastructureBuildStatus {
 
-    private List<String> successInfra = new ArrayList<>();
+    private List<InfrastructureParameter> successInfra = new ArrayList<>();
 
     /**
      * The list of failed infras. If the given test case fails only
@@ -37,18 +39,18 @@ public class InfrastructureBuildStatus {
      * "associated infras". So, those are added together.
      *
      */
-    private List<List<String>> failedInfra = new ArrayList<>();
-    private List<String> unknownInfra = new ArrayList<>();
+    private List<List<InfrastructureParameter>> failedInfra = new ArrayList<>();
+    private List<InfrastructureParameter> unknownInfra = new ArrayList<>();
 
-    public List<String> getSuccessInfra() {
+    public List<InfrastructureParameter> getSuccessInfra() {
         return successInfra;
     }
 
-    public void addSuccessInfra(String successInfra) {
+    public void addSuccessInfra(InfrastructureParameter successInfra) {
         this.successInfra.add(successInfra);
     }
 
-    public List<List<String>> getFailedInfra() {
+    public List<List<InfrastructureParameter>> getFailedInfra() {
         return failedInfra;
     }
 
@@ -63,9 +65,9 @@ public class InfrastructureBuildStatus {
      *
      * @return unassociated failed infra
      */
-    public List<String> getUnassociatedFailedInfra() {
-        List<String> unassociatedFailedInfra = new ArrayList<>();
-        for (List<String> failedInfraCombination : failedInfra) {
+    public List<InfrastructureParameter> getUnassociatedFailedInfra() {
+        List<InfrastructureParameter> unassociatedFailedInfra = new ArrayList<>();
+        for (List<InfrastructureParameter> failedInfraCombination : failedInfra) {
             if (failedInfraCombination.size() == 1) {
                 unassociatedFailedInfra.add(failedInfraCombination.get(0));
             }
@@ -80,22 +82,23 @@ public class InfrastructureBuildStatus {
      *
      * @param failedAssociatedInfras associated infras that are failing.
      */
-    public void addFailedInfra(String... failedAssociatedInfras) {
+    public void addFailedInfra(InfrastructureParameter... failedAssociatedInfras) {
         this.failedInfra.add(Arrays.asList(failedAssociatedInfras));
     }
 
-    public List<String> getUnknownInfra() {
+    public List<InfrastructureParameter> getUnknownInfra() {
         return unknownInfra;
     }
 
-    public void addUnknownInfra(String unknownInfra) {
+    public void addUnknownInfra(InfrastructureParameter unknownInfra) {
         this.unknownInfra.add(unknownInfra);
     }
 
     @Override
     public String toString() {
-        return "success=" + successInfra +
+        return "{success=" + successInfra +
                 ", failed=" + failedInfra +
-                ", unknown=" + unknownInfra;
+                ", unknown=" + unknownInfra +
+                '}';
     }
 }

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureBuildStatus.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureBuildStatus.java
@@ -65,7 +65,7 @@ public class InfrastructureBuildStatus {
      *
      * @return unassociated failed infra
      */
-    public List<InfrastructureParameter> getUnassociatedFailedInfra() {
+    public List<InfrastructureParameter> retrieveUnassociatedFailedInfra() {
         List<InfrastructureParameter> unassociatedFailedInfra = new ArrayList<>();
         for (List<InfrastructureParameter> failedInfraCombination : failedInfra) {
             if (failedInfraCombination.size() == 1) {

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporter.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporter.java
@@ -24,23 +24,24 @@ import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
 
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * This generates the infrastructure summary report table that shows
  * the success/failure of each test-case in a given infrastructure.
- *
+ * <p>
  * Sample summary report may look like below:
- *
- *      CentOS      Windows      MySQL
+ * <p>
+ * CentOS      Windows      MySQL
  * T1     fail      success       fail
  * T2   success     success     success
- *
  */
 public class InfrastructureSummaryReporter {
 
@@ -56,24 +57,12 @@ public class InfrastructureSummaryReporter {
     public Map<String, InfrastructureBuildStatus> getSummaryTable(List<TestPlan> testPlans) {
         Map<String, InfrastructureBuildStatus> testCaseInfraBuildStatusMap = new HashMap<>();
         // Mapping between test-case to infrastructure-score-map
-        Map<String, InfrastructureScoreMap> testCaseInfraScores = getTCAndInfraScoreMap(
-                testPlans);
+        TestCaseInfrastructureScoreTable testCaseInfraScores = getTCAndInfraScoreMap(testPlans);
 
-        for (Map.Entry<String, InfrastructureScoreMap> testCaseEntry : testCaseInfraScores.entrySet()) {
+        for (Map.Entry<String, InfrastructureScores> testCaseEntry : testCaseInfraScores.get().entrySet()) {
             String testCase = testCaseEntry.getKey();
-            InfrastructureScoreMap infraScoreMap = testCaseEntry.getValue();
-            // first pass
-            for (String infra : infraScoreMap.infraScores.keySet()) {
-                final Score score = infraScoreMap.infraScores.get(infra);
-                InfrastructureBuildStatus infraBuildStatus = getInfraBuildStatusFrom(testCaseInfraBuildStatusMap,
-                        testCase);
-                if (score.success == 0 && score.failed > 0) {
-                    infraBuildStatus.addFailedInfra(infra);
-                } else if (score.failed == 0 && score.success > 0) {
-                    infraBuildStatus.addSuccessInfra(infra);
-                }
-                testCaseInfraBuildStatusMap.put(testCase, infraBuildStatus);
-            }
+            InfrastructureScores infraScoreMap = testCaseEntry.getValue();
+            calculateInfraStatusOf(testCase, testPlans, testCaseInfraBuildStatusMap, infraScoreMap);
         }
 
         if (logger.isDebugEnabled()) {
@@ -84,15 +73,100 @@ public class InfrastructureSummaryReporter {
     }
 
     /**
+     * Calculate the infrastructure success/failure status of the given test case.
+     *
+     * @param testCase the test case
+     * @param testPlans test plans that contain test cases
+     * @param testCaseInfraBuildStatusMap the result map
+     * @param infraScores the success and failure counts of each infrastructure for the given test case.
+     */
+    private void calculateInfraStatusOf(String testCase, List<TestPlan> testPlans,
+            Map<String, InfrastructureBuildStatus> testCaseInfraBuildStatusMap,
+            InfrastructureScores infraScores) {
+        boolean allSuccessInfrasFound = false;
+        InfrastructureBuildStatus infraBuildStatus = getInfraBuildStatusFrom(testCaseInfraBuildStatusMap, testCase);
+        if (logger.isDebugEnabled()) {
+            logger.debug("The testCaseInfraBuildStatusMap: " + testCaseInfraBuildStatusMap);
+            logger.debug("The infra score map: " + infraScores);
+        }
+        for (Map.Entry<InfrastructureParameter, Score> infraEntry : infraScores.getScores().entrySet()) {
+            final InfrastructureParameter infra = infraEntry.getKey();
+            final Score score = infraEntry.getValue();
+            if (score.success == 0 && score.failed > 0) {
+                handleBuildStatusOfFailedInfra(infra, infraScores, infraBuildStatus);
+            } else if (score.failed == 0 && score.success > 0) {
+                infraBuildStatus.addSuccessInfra(infra);
+                allSuccessInfrasFound = true;
+            }
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.info("The testCaseInfraBuildStatusMap: " + testCaseInfraBuildStatusMap);
+        }
+
+        if (allSuccessInfrasFound) {
+            List<TestPlan> testPlansWithoutAllSuccessInfra = testPlans.stream()
+                    .filter(tp -> infraBuildStatus.getSuccessInfra().stream()
+                            .noneMatch(ip -> tp.getInfraParameters().contains("\"" + ip.getName() + "\"")))
+                    .collect(Collectors.toList());
+            if (testPlansWithoutAllSuccessInfra.isEmpty()) {
+                return;
+            }
+
+            final TestCaseInfrastructureScoreTable tcAndInfraScoreMap = getTCAndInfraScoreMap(
+                    testPlansWithoutAllSuccessInfra); //todo no need to re-calc scores of all test cases
+            calculateInfraStatusOf(testCase, testPlansWithoutAllSuccessInfra, testCaseInfraBuildStatusMap,
+                    tcAndInfraScoreMap.get(testCase));
+        }
+
+    }
+
+    /**
+     * handle the infra build status of a given test case for a failed infra.
+     * The test case must have been failed in all the test plans that contain this infra.
+     *
+     * @param infra the infrastructure that has failure
+     * @param infraScores the infra scores of a given test case
+     * @param infraBuildStatus infrastructure build status that needs to be populated.
+     */
+    private void handleBuildStatusOfFailedInfra(InfrastructureParameter infra, InfrastructureScores infraScores,
+            InfrastructureBuildStatus infraBuildStatus) {
+        String infraCategory = infra.getType();
+        //check if rest of the infras in the same category are success
+        boolean allOtherInfraInCurrentCatFailed = true;
+        boolean allOtherInfraInCurrentCatSuccess = true;
+        for (Map.Entry<InfrastructureParameter, Score> scoreEntry : infraScores.getScores().entrySet()) {
+            if (scoreEntry.getKey().getType().equals(infraCategory) && !scoreEntry.getKey().getName()
+                    .equals(infra.getName())) {
+                if (scoreEntry.getValue().success > 0) {
+                    allOtherInfraInCurrentCatFailed = false;
+                } else if (scoreEntry.getValue().failed > 0) {
+                    allOtherInfraInCurrentCatSuccess = false;
+                }
+            }
+        }
+
+        if (allOtherInfraInCurrentCatSuccess) {
+            infraBuildStatus.addFailedInfra(infra);
+            //add all the infras in all the categories
+            // todo: what if there's a failure in an infra in another category?
+            infraScores.getScores().entrySet().stream().filter(e -> !e.getKey().getName().equals(infra
+                    .getName())).forEach(e -> infraBuildStatus.addSuccessInfra(e.getKey()));
+        } else if (allOtherInfraInCurrentCatFailed) {
+            infraScores.getScores().entrySet().stream().filter(e -> !e.getKey().getName().equals(infra
+                    .getName())).forEach(e -> infraBuildStatus.addUnknownInfra(e.getKey()));
+        }
+    }
+
+    /**
      * Get the {@link InfrastructureBuildStatus} from the testCaseInfrastructureBuildStatusMap
      * for the given testCase. If the key does not exist, then add the testCase with an empty
      * {@link InfrastructureBuildStatus}, and return.
      * <p>
      *
      * @param testCaseInfrastructureBuildStatusMap the mapping between testcase vs infrastructure
-     * @param testCase given testcase
+     * @param testCase                             given testcase
      * @return the existing @{@link InfrastructureBuildStatus} if one exists. Or an empty one.
-     *
      */
     private InfrastructureBuildStatus getInfraBuildStatusFrom(
             Map<String, InfrastructureBuildStatus> testCaseInfrastructureBuildStatusMap, String testCase) {
@@ -105,59 +179,54 @@ public class InfrastructureSummaryReporter {
     }
 
     /**
-     * To determine the success/failure status of each test case in a given infrastructure, we provide
+     * To determine the success/failure status of each test case in a given infrastructure, we set
      * scores.
      *
      * @param testPlans the test plans
      * @return the scores
      */
-    private Map<String, InfrastructureScoreMap> getTCAndInfraScoreMap(
-            List<TestPlan> testPlans) {
+    private TestCaseInfrastructureScoreTable getTCAndInfraScoreMap(List<TestPlan> testPlans) {
         //map between test-case and its infrastructure-scores
-        Map<String, InfrastructureScoreMap> testCaseInfrastructureScores = new HashMap<>();
+        TestCaseInfrastructureScoreTable tcInfraScoreTable = new TestCaseInfrastructureScoreTable();
         for (TestPlan testPlan : testPlans) {
             final Properties infraParams = testPlan.getInfrastructureConfig().getParameters();
             //for each test case, T1
             for (TestScenario testScenario : testPlan.getTestScenarios()) {
                 for (TestCase testCase : testScenario.getTestCases()) {
-                    InfrastructureScoreMap scoreMap = testCaseInfrastructureScores.get(testCase.getName());
-                    if (scoreMap == null) {
-                        scoreMap = new InfrastructureScoreMap();
-                        testCaseInfrastructureScores.put(testCase.getName(), scoreMap);
-                    }
-                    addScore(infraParams, testCase.getStatus() == Status.SUCCESS, scoreMap);
+                    final InfrastructureScores infraScoreMap = tcInfraScoreTable.get(testCase.getName());
+                    addScores(infraParams, testCase, infraScoreMap);
                 }
             }
         }
         if (logger.isDebugEnabled()) {
-            logger.debug("Summary report generation: Infrastructure scores: " + testCaseInfrastructureScores);
+            logger.debug("Summary report generation: Infrastructure scores: " + tcInfraScoreTable);
         }
-        return testCaseInfrastructureScores;
+        return tcInfraScoreTable;
     }
 
     /**
      * Calculate the scores in each infra for a given test-case of a given test-plan.
      *
-     * @param infraParams the infra params
-     * @param isTestCaseSuccess given test case's success/failure status.
-     * @param scoreMap          The infrastructures and their scores for a given test case
+     * @param tc            given test case.
+     * @param infraParams   the infra params
+     * @param infraScoreMap The infrastructures and their scores for a given test case
      */
-    private void addScore(Properties infraParams, boolean isTestCaseSuccess, InfrastructureScoreMap scoreMap) {
+    private void addScores(Properties infraParams, TestCase tc, InfrastructureScores infraScoreMap) {
         @SuppressWarnings("unchecked")
         final Enumeration<String> infraIt = (Enumeration<String>) infraParams.propertyNames();
         while (infraIt.hasMoreElements()) {
-            final String infraParam = infraParams.getProperty(infraIt.nextElement());
-            Score score = scoreMap.infraScores.get(infraParam);
-            if (score == null) {
-                score = new Score();
-                scoreMap.infraScores.put(infraParam, score);
-            }
-
-            if (isTestCaseSuccess) {
+            final String infraType = infraIt.nextElement();
+            final String infraName = infraParams.getProperty(infraType);
+            InfrastructureParameter infraParam = new InfrastructureParameter(infraName, infraType, "", true);
+            Score score = infraScoreMap.getScore(infraParam);
+            if (tc.getStatus() == Status.SUCCESS) {
                 score.success++;
-            } else {
+            } else if (tc.getStatus() == Status.FAIL) {
                 score.failed++;
+            } else {
+                logger.warn("This test status, " + tc.getStatus() + ", is unaccounted for: " + tc);
             }
+            //todo take care of other test statuses
 
         }
     }
@@ -165,21 +234,54 @@ public class InfrastructureSummaryReporter {
     /**
      * Bean class that keep the score of each infra for a given test case.
      */
-    public static class InfrastructureScoreMap {
-        /**
-         * infra to score mapping.
-         */
-        Map<String, Score> infraScores = new HashMap<>();
+    public static class TestCaseInfrastructureScoreTable {
+        Map<String, InfrastructureScores> tcInfraScores = new HashMap<>();
+
+        public InfrastructureScores add(String tc, InfrastructureParameter infra, Score score) {
+            return tcInfraScores.computeIfAbsent(tc, k -> new InfrastructureScores());
+        }
+
+        public InfrastructureScores get(String tc) {
+            return tcInfraScores.computeIfAbsent(tc, atc -> new InfrastructureScores());
+        }
+
+        public Map<String, InfrastructureScores> get() {
+            return tcInfraScores;
+        }
 
         @Override
         public String toString() {
-            return "InfrastructureScoreMap=" + infraScores;
+            return "TestCaseInfrastructureScoreTable=" + tcInfraScores;
+        }
+    }
+
+    /**
+     * Contains the infra to score mapping.
+     */
+    public static class InfrastructureScores {
+        Map<InfrastructureParameter, Score> scores = new HashMap<>();
+
+        public Map<InfrastructureParameter, Score> getScores() {
+            return scores;
+        }
+
+        public Score getScore(InfrastructureParameter infraParam) {
+            return scores.computeIfAbsent(infraParam, ip -> new Score());
+        }
+
+        public void putScore(InfrastructureParameter infraParam, Score score) {
+            scores.put(infraParam, score);
+        }
+
+        @Override
+        public String toString() {
+            return "InfrastructureScores{" + scores +
+                    '}';
         }
     }
 
     /**
      * Success and failure scores of a given test case on a given infrastructure.
-     *
      */
     public static class Score {
         private int success = 0;

--- a/reporting/src/main/resources/templates/email_report.mustache
+++ b/reporting/src/main/resources/templates/email_report.mustache
@@ -64,6 +64,14 @@
             border-left: none;
         }
 
+        table[class="MainContainer"], td[class="cell"] {
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        table.testcaseInfraSummaryTable {
+            table-layout: auto;
+        }
         /*
         Titles
          */
@@ -134,16 +142,16 @@
             <div><em>{{{gitBuildDetails}}}</em></div>
             <br/>
 
-            <!-- Start of test-case-vs-infrastructure success/failure summary table. -->
-            <div class="consoleLog">
-                <span>Test failure summary:</span><br/>
-                <span>
-                <table class="reportTable">
+        <!-- Start of test-case-vs-infrastructure success/failure summary table. -->
+        <div class="consoleLog">
+            <span>Failing test cases and infrastructures:</span><br/>
+            <span>
+                <table class="reportTable testcaseInfraSummaryTable">
                     <thead>
                     <tr>
                         <th>Test case:</th>
-                        <th colspan="???">Fails on:</th>
-                        <th colspan="????">Passes on:</th>
+                        <th>Fails on:</th>
+                        <th>Passes on:</th>
                     </tr>
                     </thead>
                     <tbody>

--- a/reporting/src/main/resources/templates/email_report.mustache
+++ b/reporting/src/main/resources/templates/email_report.mustache
@@ -99,7 +99,7 @@
         }
 
         .failure {
-            background-color: red;
+            background-color: orangered;
         }
 
         .error {

--- a/reporting/src/main/resources/templates/summarized_email_report.mustache
+++ b/reporting/src/main/resources/templates/summarized_email_report.mustache
@@ -73,6 +73,9 @@
         		height:auto !important;
         	}
 
+        table.testcaseInfraSummaryTable {
+            table-layout: auto;
+        }
         /*
         Titles
          */
@@ -109,7 +112,9 @@
         }
 
         .failure {
-            background-color: orangered;
+            color: black;
+            font-weight: bold;
+            background: repeating-radial-gradient(circle, yellow, #ffd840);
         }
 
         .error {
@@ -145,6 +150,7 @@
             </table>
             <br/>
             <div><em>{{{gitBuildDetails}}}</em></div>
+            <div>Tested Infrastructures: <br/> <em>{{{testedInfrastructures}}}</em></div>
             <br/>
             <span class="testResultSubTitle" align="center">Test Result Summary</span>
             <p/><p/>
@@ -161,15 +167,14 @@
             <br/>
 
         <!-- Start of test-case-vs-infrastructure success/failure summary table. -->
+        <span class="testResultSubTitle" align="center">Test cases vs suspected culprits (beta)</span><p/>
         <div class="consoleLog">
-            <span>Failing test cases and infrastructures:</span><br/>
             <span>
-                <table class="reportTable">
+                <table class="reportTable testcaseInfraSummaryTable">
                     <thead>
                     <tr>
-                        <th>Test case:</th>
-                        <th>Fails on:</th>
-                        <th>Passes on:</th>
+                        <th>Test case</th>
+                        <th>Suspected Infrastructure Culprits</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -189,18 +194,18 @@
                                     {{/failedInfra}}
                                 </tr>
                                 </table>
-                                </td>
-                                <td>
-                                    <table>
-                                    <tr>
-                                        {{#successInfra}}
-                                            <td class="success">
-                                                {{.}}
-                                            </td>
-                                        {{/successInfra}}
-                                    </tr>
-                                    </table>
-                                </td>
+                                <!--</td>-->
+                                <!--<td>-->
+                                    <!--<table>-->
+                                    <!--<tr>-->
+                                        <!--{{#successInfra}}-->
+                                            <!--<td class="success">-->
+                                                <!--{{.}}-->
+                                            <!--</td>-->
+                                        <!--{{/successInfra}}-->
+                                    <!--</tr>-->
+                                    <!--</table>-->
+                                <!--</td>-->
                             {{/value}}
                         </tr>
                     {{/testCaseInfraSummaryTable}}

--- a/reporting/src/main/resources/templates/summarized_email_report.mustache
+++ b/reporting/src/main/resources/templates/summarized_email_report.mustache
@@ -109,11 +109,15 @@
         }
 
         .failure {
-            background-color: #fbce50;
+            background-color: orangered;
         }
 
         .error {
-            background-color: #DD0000;
+            background-color: darkred;
+        }
+
+        .success {
+            background-color: limegreen;
         }
 
     </style>
@@ -155,6 +159,60 @@
                 </tr>
             </table>
             <br/>
+
+        <!-- Start of test-case-vs-infrastructure success/failure summary table. -->
+        <div class="consoleLog">
+            <span>Failing test cases and infrastructures:</span><br/>
+            <span>
+                <table class="reportTable">
+                    <thead>
+                    <tr>
+                        <th>Test case:</th>
+                        <th>Fails on:</th>
+                        <th>Passes on:</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {{#testCaseInfraSummaryTable}}
+                        <tr>
+                            <td>{{key}}</td>
+                            {{#value}}
+                                <td>
+                                <table>
+                                <tr>
+                                    {{#failedInfra}}
+                                        {{#.}}
+                                            <td class="failure">
+                                                {{.}}
+                                            </td>
+                                        {{/.}}
+                                    {{/failedInfra}}
+                                </tr>
+                                </table>
+                                </td>
+                                <td>
+                                    <table>
+                                    <tr>
+                                        {{#successInfra}}
+                                            <td class="success">
+                                                {{.}}
+                                            </td>
+                                        {{/successInfra}}
+                                    </tr>
+                                    </table>
+                                </td>
+                            {{/value}}
+                        </tr>
+                    {{/testCaseInfraSummaryTable}}
+                    {{^testCaseInfraSummaryTable}}
+                        <tr><td>no information available.</td></tr>
+                    {{/testCaseInfraSummaryTable}}
+                    </tbody>
+                </table>
+                </span>
+        </div>
+        <br/>
+
             <span class="testResultSubTitle">Testcase Failure Summary Table</span>
             <p/><p/>
           <table class="reportTable">

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
@@ -31,7 +31,9 @@ import org.wso2.testgrid.common.TestPlan;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -59,9 +61,11 @@ public class TestReportEngineTest extends BaseClass {
                     return Optional.of(testPlans.get(Integer.valueOf(testPlanId)));
                 });
         when(testPlanUOW.getCurrentStatus(product)).thenReturn(Status.FAIL);
+        when(testPlanUOW.getTestExecutionSummary(any())).thenReturn(testPlans.stream().map(tp -> tp.getStatus()
+                .toString()).collect(Collectors.toList()));
 
         final TestReportEngine testReportEngine = new TestReportEngine(testPlanUOW,
-                new EmailReportProcessor(testPlanUOW));
+                new EmailReportProcessor(testPlanUOW), new GraphDataProvider(testPlanUOW));
         final Optional<Path> path = testReportEngine.generateEmailReport(product, productDir.toString());
         Assert.assertTrue(path.isPresent(), "Email report generation has failed. File path is empty.");
         logger.info("email report file: " + path.get());

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/TestReportEngineTest.java
@@ -65,9 +65,21 @@ public class TestReportEngineTest extends BaseClass {
                 .toString()).collect(Collectors.toList()));
 
         final TestReportEngine testReportEngine = new TestReportEngine(testPlanUOW,
-                new EmailReportProcessor(testPlanUOW), new GraphDataProvider(testPlanUOW));
-        final Optional<Path> path = testReportEngine.generateEmailReport(product, productDir.toString());
+                new EmailReportProcessor(testPlanUOW, infrastructureParameterUOW), new GraphDataProvider(testPlanUOW));
+        Optional<Path> path = testReportEngine.generateEmailReport(product, productDir.toString());
         Assert.assertTrue(path.isPresent(), "Email report generation has failed. File path is empty.");
         logger.info("email report file: " + path.get());
+
+        if (testNum.equals("02")) {
+            //We can only handle maximum of one data provider for chart generation code.
+            //TODO: this was done because one JVM can only call JAVAFX Platform.exit() once.
+            // See @ChartGenerator#stopApplication
+
+            path = testReportEngine.generateSummarizedEmailReport(product, productDir.toString());
+            Assert.assertTrue(path.isPresent(), "Email report generation has failed. File path is empty.");
+            logger.info("v2 email report file: " + path.get());
+
+        }
+
     }
 }

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
@@ -45,16 +45,17 @@ public class InfrastructureSummaryReporterTest extends BaseClass {
     public void testGetSummaryTable(String testPlanInputsNum) throws Exception {
 
         List<TestPlan> testPlans = getTestPlansFor(testPlanInputsNum);
-        final InfrastructureSummaryReporter summaryReporter = new InfrastructureSummaryReporter();
+        final InfrastructureSummaryReporter summaryReporter = new InfrastructureSummaryReporter(
+                infrastructureParameterUOW);
         final Map<String, InfrastructureBuildStatus> summaryTable = summaryReporter.getSummaryTable(testPlans);
 
         if (testPlanInputsNum.equals("02")) {
-            Assert.assertEquals(summaryTable.size(), 3);
+            Assert.assertEquals(summaryTable.size(), 4);
             final InfrastructureBuildStatus buildStatus = summaryTable.values().iterator().next();
             Assert.assertEquals(buildStatus.getUnknownInfra().size(), 0, "Summary with unknown status found. " +
                     buildStatus.getUnknownInfra());
             final List<List<InfrastructureParameter>> failedInfra01 = buildStatus.getFailedInfra();
-            final List<InfrastructureParameter> unassociatedFailedInfra = buildStatus.getUnassociatedFailedInfra();
+            final List<InfrastructureParameter> unassociatedFailedInfra = buildStatus.retrieveUnassociatedFailedInfra();
 
             Assert.assertEquals(unassociatedFailedInfra.size(), buildStatus.getFailedInfra().size(), "All failed infra "
                     + "should be unassociated infras.");

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
@@ -23,12 +23,14 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
 import org.wso2.testgrid.reporting.BaseClass;
 
 import java.util.List;
 import java.util.Map;
 
 /**
+ *  Tests @{@link InfrastructureSummaryReporter}.
  *
  */
 public class InfrastructureSummaryReporterTest extends BaseClass {
@@ -47,26 +49,25 @@ public class InfrastructureSummaryReporterTest extends BaseClass {
         final Map<String, InfrastructureBuildStatus> summaryTable = summaryReporter.getSummaryTable(testPlans);
 
         if (testPlanInputsNum.equals("02")) {
-            Assert.assertEquals(summaryTable.size(), 1);
+            Assert.assertEquals(summaryTable.size(), 3);
             final InfrastructureBuildStatus buildStatus = summaryTable.values().iterator().next();
             Assert.assertEquals(buildStatus.getUnknownInfra().size(), 0, "Summary with unknown status found. " +
                     buildStatus.getUnknownInfra());
-            final List<List<String>> failedInfra01 = buildStatus.getFailedInfra();
-            final List<String> unassociatedFailedInfra = buildStatus.getUnassociatedFailedInfra();
+            final List<List<InfrastructureParameter>> failedInfra01 = buildStatus.getFailedInfra();
+            final List<InfrastructureParameter> unassociatedFailedInfra = buildStatus.getUnassociatedFailedInfra();
 
             Assert.assertEquals(unassociatedFailedInfra.size(), buildStatus.getFailedInfra().size(), "All failed infra "
                     + "should be unassociated infras.");
             Assert.assertEquals(buildStatus.getFailedInfra().size(), 1);
             Assert.assertEquals(unassociatedFailedInfra.size(), 1);
-            Assert.assertEquals(unassociatedFailedInfra.get(0), "CentOS", "Cummary table's "
+            Assert.assertEquals(unassociatedFailedInfra.get(0).getName(), "CentOS", "Summary table's "
                     + "failed infra result validation failed.");
 
-            //        Assert.assertEquals(buildStatus.getSuccessInfra().size(), 6);
-
-            final List<String> failedAssociatedInfras = failedInfra01.get(0);
+            final List<InfrastructureParameter> failedAssociatedInfras = failedInfra01.get(0);
             Assert.assertEquals(failedAssociatedInfras.size(), 1);
-            String failedInfra = failedAssociatedInfras.get(0);
-            Assert.assertEquals(failedInfra, "CentOS", "Could not detect the actual reason for test failures.");
+            InfrastructureParameter failedInfra = failedAssociatedInfras.get(0);
+            Assert.assertEquals(failedInfra.getName(), "CentOS",
+                    "Could not detect the actual reason for test failures.");
 
         }
     }


### PR DESCRIPTION

**Purpose**
Using statistical analysis of builds of the test plans in the current iteration, we should try to determine the exact failing infrastructure that lead to test failures/errors. This is much useful than showing lists of failing infrastructure combinations.

Fixes #919 

<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Better presentation of testgrid results.