### PR TITLE
Differentiate duplicate test cases by adding data provider suffix

### DIFF
--- a/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
+++ b/automation/src/main/java/org/wso2/testgrid/automation/parser/TestNgResultsParser.java
@@ -148,6 +148,31 @@ public class TestNgResultsParser extends ResultParser {
                         }
                     }
                 }
+                //start processing duplicate testcase names
+                List<TestCase> testCases = testScenario.getTestCases();
+                Set<TestCase> allCases = new HashSet<>();
+                //Get a list of duplicate test cases
+                List<TestCase> duplicates = testCases.stream()
+                        .filter(testCase -> !allCases.add(testCase))
+                        .collect(Collectors.toList());
+                List<TestCase> renamedTestCases = testCases
+                        .stream()
+                        .map(testCase -> {
+                            int suffix = 1;
+                            if (duplicates.contains(testCase)) {
+                                TestCase tempTestCase = new TestCase();
+                                tempTestCase.setName(testCase.getName());
+                                //add a suffix to the duplicate test case names
+                                while (testCases.contains(tempTestCase)) {
+                                    tempTestCase.setName(StringUtil
+                                            .concatStrings(testCase.getName(), "#data_provider_", suffix));
+                                    suffix++;
+                                }
+                                testCase.setName(tempTestCase.getName());
+                            }
+                            return testCase;
+                        }).collect(Collectors.toList());
+                testScenario.setTestCases(renamedTestCases);
                 logger.info(String.format("Found total of %s test cases. %s test cases has failed.", testScenario
                                 .getTestCases().size(),
                         testScenario.getTestCases().stream().filter(tc -> Status.FAIL.equals(tc.getStatus())).count()));

--- a/common/src/main/java/org/wso2/testgrid/common/TestCase.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestCase.java
@@ -154,4 +154,21 @@ public class TestCase extends AbstractUUIDEntity implements Serializable {
                 ", testScenario='", testScenario.getName(), "\'",
                 '}');
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !TestCase.class.isAssignableFrom(obj.getClass())) {
+            return false;
+        }
+        if (this == obj) {
+            return true;
+        }
+        TestCase testCase = (TestCase) obj;
+        return this.name.equals(testCase.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.name.hashCode();
+    }
 }


### PR DESCRIPTION

**Purpose**
Resolves #942 

**Goals**

The current test-suite.xml does not provide details about the data providers that execute the same test method multiple times. hence they are added to the database by the same name, This change will go through the test cases list and update these duplicate test cases by adding a data provider suffix with an index.


**Approach**

The test cases list will be checked for duplicates and each duplicate will be added a suffix to make them unique entry.
```

Classname#methodname    --> Classname#methodName#data_provider_1
Classname#methodname    --> Classname#methodName#data_provider_2
```
**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
OracleJDK8
ubuntu16.04