### PR TITLE
Change TestGrid structure to comply with Jenkins parallel pipeline execution

### DIFF
--- a/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
+++ b/automation/src/test/java/org/wso2/testgrid/automation/executor/TestNgResultsParserTest.java
@@ -76,6 +76,8 @@ public class TestNgResultsParserTest {
         deploymentPatternDBEntry.setName("deployment-pattern");
         deploymentPatternDBEntry.setProduct(product);
         testPlan.setDeploymentPattern(deploymentPatternDBEntry);
+        testPlan.setWorkspace(Paths.get(TESTGRID_HOME, TestGridConstants.TESTGRID_JOB_DIR,
+                product.getName()).toString());
         MockitoAnnotations.initMocks(this);
     }
 

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -80,4 +80,6 @@ public class TestGridConstants {
     public static final String SCENARIO_SCRIPT = "run-scenario.sh";
     public static final String AMAZON_S3_URL = "https://s3.amazonaws.com";
     public static final String AMAZON_S3_DEFAULT_BUCKET_NAME = "unknown";
+
+    public static final String KEY_FILE_LOCATION = "keyFileLocation";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -462,12 +462,31 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
         this.jobName = jobName;
     }
 
+    /**
+     * Return the workspace of the TestPlan.
+     * If the workspace is not set it will be derived as below;
+     *      1. Derived using the job-name
+     *      2. If job-name is not set, derive using product-name
+     *      3. If both (1) and (2) is not possible, consider job directory as "product-<random-number>"
+     *      (The random directory will be generated only one-time and will be used as its workspace from there onwards.)
+     */
     public String getWorkspace() {
-        if (workspace.contains("sample-product")) {
-            logger.warn("Testplan does not stick to a workspace directory. Hence a default value is referred as" +
-                    workspace);
+        if (StringUtil.isStringNullOrEmpty(workspace)) {
+            String jobDir = getJobName();
+            if (StringUtil.isStringNullOrEmpty(jobDir)) {
+                if (getDeploymentPattern() != null && getDeploymentPattern().getProduct() != null) {
+                    jobDir = getDeploymentPattern().getProduct().getName();
+                }
+                if (StringUtil.isStringNullOrEmpty(jobDir)) {
+                    jobDir = "product-" + StringUtil.generateRandomString(5);
+                }
+            }
+            this.setWorkspace(Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
+                    jobDir).toString());
+            logger.warn("Test-plan " + this.toString() + " does not stick to a workspace directory. " +
+                    "Hence the directory '" + workspace + "' is set as workspace and will be used from here onwards.");
         }
-        return workspace;
+            return workspace;
     }
 
     public void setWorkspace(String workspace) {

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -17,12 +17,16 @@
  */
 package org.wso2.testgrid.common;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.config.DeploymentConfig;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.ScenarioConfig;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 
 import java.io.Serializable;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -46,6 +50,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = TestPlan.TEST_PLAN_TABLE)
 public class TestPlan extends AbstractUUIDEntity implements Serializable, Cloneable {
+    private static final Logger logger = LoggerFactory.getLogger(TestPlan.class);
 
     /**
      * TestPlan table name.
@@ -117,6 +122,10 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
 
     @Transient
     private String keyFileLocation;
+
+    @Transient
+    private String workspace = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
+            "sample-product").toString();
 
     /**
      * Returns the status of the infrastructure.
@@ -451,6 +460,18 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
 
     public void setJobName(String jobName) {
         this.jobName = jobName;
+    }
+
+    public String getWorkspace() {
+        if (workspace.contains("sample-product")) {
+            logger.warn("Testplan does not stick to a workspace directory. Hence a default value is referred as" +
+                    workspace);
+        }
+        return workspace;
+    }
+
+    public void setWorkspace(String workspace) {
+        this.workspace = workspace;
     }
 
     /**

--- a/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
@@ -99,11 +99,8 @@ public class DataBucketsHelper {
      * @return Get the build outputs dir
      */
     public static Path getBuildOutputsDir(TestPlan testPlan) {
-        String productName = testPlan.getJobName();
-        productName = productName == null ? testPlan.getDeploymentPattern().getProduct().getName() : productName;
         String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
-        String testgridHome = TestGridUtil.getTestGridHomePath();
-        return Paths.get(testgridHome, TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants
+        return Paths.get(testPlan.getWorkspace(), TestGridConstants
                 .TESTGRID_BUILDS_DIR, testPlanDirName);
     }
 

--- a/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
@@ -22,7 +22,7 @@ public final class S3StorageUtil {
      * @param truncated whether the truncated log or the raw log file
      * @return log file path
      */
-    public static String deriveTestRunLogFilePath(TestPlan testPlan, Boolean truncated) {
+    public static String getS3LocationForTestRunLogFile(TestPlan testPlan, Boolean truncated) {
         String productName = testPlan.getDeploymentPattern().getProduct().getName();
         String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
         String fileName = truncated ?

--- a/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
@@ -1,0 +1,48 @@
+package org.wso2.testgrid.common.util;
+
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+
+import java.nio.file.Paths;
+
+/**
+ * This Util class holds the utility methods used to manage TestGrid S3 storage .
+ *
+ * @since 1.0.0
+ */
+public final class S3StorageUtil {
+
+    /**
+     * Returns the path of the test-run log file in S3 bucket.
+     * <p>
+     * /builds/#depl_name#_#infra-uuid#_#test-run-num#/test-run.log
+     *
+     * @param testPlan test-plan
+     * @param truncated whether the truncated log or the raw log file
+     * @return log file path
+     */
+    public static String deriveTestRunLogFilePath(TestPlan testPlan, Boolean truncated) {
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
+        String fileName = truncated ?
+                TestGridConstants.TRUNCATED_TESTRUN_LOG_FILE_NAME : TestGridConstants.TESTRUN_LOG_FILE_NAME;
+        return Paths.get(TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants.TESTGRID_BUILDS_DIR,
+                testPlanDirName, fileName).toString();
+    }
+
+    /**
+     * Generate the S3 bucket URL for the current environment.
+     * Ex. https://s3.amazonaws.com/bucket1
+     *
+     * @return the S3 bucket url of the environment
+     */
+    public static String getS3BucketURL() {
+        String s3BucketName = ConfigurationContext.getProperty(ConfigurationContext.
+                ConfigurationProperties.AWS_S3_BUCKET_NAME);
+        if (StringUtil.isStringNullOrEmpty(s3BucketName)) {
+            s3BucketName = TestGridConstants.AMAZON_S3_DEFAULT_BUCKET_NAME;
+        }
+        return String.join("/", TestGridConstants.AMAZON_S3_URL, s3BucketName);
+    }
+}

--- a/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
@@ -7,7 +7,7 @@ import org.wso2.testgrid.common.config.ConfigurationContext;
 import java.nio.file.Paths;
 
 /**
- * This Util class holds the utility methods used to manage TestGrid S3 storage .
+ * This Util class holds the utility methods used to manage TestGrid S3 storage.
  *
  * @since 1.0.0
  */

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.DeploymentPattern;
-import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
@@ -36,7 +35,6 @@ import org.wso2.testgrid.common.config.DeploymentConfig;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
-import org.wso2.testgrid.common.exception.TestGridException;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -108,48 +106,13 @@ public final class TestGridUtil {
     }
 
     /**
-     * Returns the directory location where the test-plans are stored.
+     * Returns the directory location where the test-plan requests are stored.
      *
-     * @return path of the test plans directory
+     * @return path of the test plan requests directory
      * @throws IOException thrown when error on calculating test plan artifacts directory
      */
-    public static Path getTestPlanDirectory() throws IOException {
+    public static Path getTestPlanRequestDirectory() throws IOException {
         return Paths.get(getTestGridHomePath(), "test-plans");
-    }
-
-    /**
-     * Returns the directory location where the test run artifacts resides relative to testgrid.home.
-     *
-     * @param testPlan test plan for getting the test run artifacts location
-     * @return path of the test run artifacts
-     * @throws TestGridException thrown when error on calculating test run artifacts directory
-     */
-    public static Path getTestRunWorkspace(TestPlan testPlan) throws TestGridException {
-        return getTestRunWorkspace(testPlan, true);
-    }
-
-    /**
-     * Returns the directory location where the test run artifacts resides.
-     *
-     * @param testPlan test plan for getting the test run artifacts location
-     * @param relative Whether the path need to be returned relative to testgrid.home or not.
-     * @return path of the test run artifacts
-     */
-    public static Path getTestRunWorkspace(TestPlan testPlan, boolean relative) {
-        DeploymentPattern deploymentPattern = testPlan.getDeploymentPattern();
-        Product product = deploymentPattern.getProduct();
-        int testRunNumber = testPlan.getTestRunNumber();
-
-        String productDir = product.getName();
-        String deploymentDir = deploymentPattern.getName();
-        String infraDir = getInfraParamUUID(testPlan.getInfraParameters());
-
-        String dirPrefix = "";
-        if (!relative) {
-            dirPrefix = getTestGridHomePath();
-        }
-
-        return Paths.get(dirPrefix, productDir, deploymentDir, infraDir, String.valueOf(testRunNumber));
     }
 
     /**
@@ -385,8 +348,7 @@ public final class TestGridUtil {
     }
 
     public static Path getTestScenarioArtifactPath(TestScenario testScenario) {
-        String productName = testScenario.getTestPlan().getDeploymentPattern().getProduct().getName();
-        return Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR, productName,
+        return Paths.get(testScenario.getTestPlan().getWorkspace(),
                 TestGridConstants.TESTGRID_BUILDS_DIR, deriveTestPlanDirName(testScenario.getTestPlan()),
                 testScenario.getDir());
     }
@@ -394,18 +356,17 @@ public final class TestGridUtil {
     /**
      * Returns the path of the test-run log file.
      * <p>
-     * TESTGRID_HOME/jobs/#name#/builds/#depl_name#_#infra-uuid#_#test-run-num#/test-run.log
+     * <TestPlan Workspace>/builds/#depl_name#_#infra-uuid#_#test-run-num#/test-run.log
      *
      * @param testPlan test-plan
      * @param truncated whether the truncated log or the raw log file
      * @return log file path
      */
     public static String deriveTestRunLogFilePath(TestPlan testPlan, Boolean truncated) {
-        String productName = testPlan.getDeploymentPattern().getProduct().getName();
         String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
         String fileName = truncated ?
                 TestGridConstants.TRUNCATED_TESTRUN_LOG_FILE_NAME : TestGridConstants.TESTRUN_LOG_FILE_NAME;
-        return Paths.get(TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants.TESTGRID_BUILDS_DIR,
+        return Paths.get(testPlan.getWorkspace(), TestGridConstants.TESTGRID_BUILDS_DIR,
                 testPlanDirName, fileName).toString();
     }
 
@@ -429,9 +390,8 @@ public final class TestGridUtil {
      * @return File download location path
      */
     public static String deriveLogDownloadLocation(TestPlan testPlan) {
-        String productName = testPlan.getDeploymentPattern().getProduct().getName();
         String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
-        return Paths.get(getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR, productName,
+        return Paths.get(testPlan.getWorkspace(),
                 TestGridConstants.TESTGRID_BUILDS_DIR, testPlanDirName).toString();
     }
 
@@ -486,21 +446,6 @@ public final class TestGridUtil {
         String testGridHost = ConfigurationContext.getProperty(ConfigurationContext.
                 ConfigurationProperties.TESTGRID_HOST);
         return String.join("/", testGridHost, productName);
-    }
-
-    /**
-     * Generate the S3 bucket URL for the current environment.
-     * Ex. https://s3.amazonaws.com/bucket1
-     *
-     * @return the S3 bucket url of the environment
-     */
-    public static String getS3BucketURL() {
-        String s3BucketName = ConfigurationContext.getProperty(ConfigurationContext.
-                ConfigurationProperties.AWS_S3_BUCKET_NAME);
-        if (StringUtil.isStringNullOrEmpty(s3BucketName)) {
-            s3BucketName = TestGridConstants.AMAZON_S3_DEFAULT_BUCKET_NAME;
-        }
-        return String.join("/", TestGridConstants.AMAZON_S3_URL, s3BucketName);
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
@@ -101,6 +101,7 @@ public class ScenarioExecutor {
             testScenario.setTestPlan(testPlan);
             testScenario.setStatus(Status.RUNNING);
             testScenario = persistTestScenario(testScenario);
+            testScenario.getTestPlan().setWorkspace(testPlan.getWorkspace());
 
             // Create run-scenario.sh file if it's missing.
             if (!Files.exists(Paths.get(

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -68,6 +68,7 @@ import org.wso2.testgrid.tinkerer.exception.TinkererOperationException;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -125,7 +126,6 @@ public class TestPlanExecutor {
         // Provision infrastructure
         InfrastructureProvisionResult infrastructureProvisionResult = provisionInfrastructure(infrastructureConfig,
                 testPlan);
-
         //setup product performance dashboard
         if (infrastructureProvisionResult.isSuccess()) {
             DashboardSetup dashboardSetup = new DashboardSetup(testPlan.getId());
@@ -536,10 +536,12 @@ public class TestPlanExecutor {
         final Path location = DataBucketsHelper.getInputLocation(testPlan)
                 .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE);
         final Properties jobProperties = testPlan.getJobProperties();
+        final String keyFileLocation = testPlan.getKeyFileLocation();
         final Properties infraParameters = testPlan.getInfrastructureConfig().getParameters();
         try (OutputStream os = Files.newOutputStream(location, CREATE, APPEND)) {
             jobProperties.store(os, null);
             infraParameters.store(os, null);
+            os.write((TestGridConstants.KEY_FILE_LOCATION + "=" + keyFileLocation).getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             logger.error("Error while persisting infra input params to " + location, e);
         }

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateEmailCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateEmailCommand.java
@@ -61,7 +61,6 @@ public class GenerateEmailCommand implements Command {
                     workspace);
             summarizedReportPath.ifPresent(p -> logger.info("Written the summarized email " +
                                                             "report body contents to: " + p));
-
             final Optional<Path> reportPath = testReportEngine.generateEmailReport(product, workspace);
             reportPath.ifPresent(p -> logger.info("Written the email report body contents to: " + p));
         } catch (ReportingException e) {

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -151,17 +151,17 @@ public class RunTestPlanCommand implements Command {
     private void resolvePaths(TestPlan testPlan) {
         //infra
         Path repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getInfrastructureRepository());
-        testPlan.setInfrastructureRepository(resolvePath(repoPath, testPlan));
+        testPlan.setInfrastructureRepository(resolvePath(repoPath));
         //deploy
         repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getDeploymentRepository());
-        testPlan.setDeploymentRepository(resolvePath(repoPath, testPlan));
+        testPlan.setDeploymentRepository(resolvePath(repoPath));
         //scenarios
         repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getScenarioTestsRepository());
-        testPlan.setScenarioTestsRepository(resolvePath(repoPath, testPlan));
+        testPlan.setScenarioTestsRepository(resolvePath(repoPath));
         //keyfile
         if (testPlan.getKeyFileLocation() != null) {
             repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getKeyFileLocation());
-            testPlan.setKeyFileLocation(resolvePath(repoPath, testPlan));
+            testPlan.setKeyFileLocation(resolvePath(repoPath));
         }
     }
 
@@ -170,16 +170,12 @@ public class RunTestPlanCommand implements Command {
      * the iobConfigYaml.
      *
      * @param path          The path to resolve
-     * @param testPlan the testPlan.yaml bean
      * @return the resolved path
      * @throws TestGridRuntimeException if the resolved path does not exist.
      */
-    private String resolvePath(Path path, TestPlan testPlan) {
+    private String resolvePath(Path path) {
         path = path.toAbsolutePath().normalize();
         if (!Files.exists(path)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("TestPlanFile: " + testPlan);
-            }
             throw new TestGridRuntimeException("Path '" + path.toString() + "' does not exist.");
         }
         return path.toString();

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -28,6 +28,7 @@ import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.exception.TestGridRuntimeException;
 import org.wso2.testgrid.common.util.FileUtil;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
@@ -67,6 +68,12 @@ public class RunTestPlanCommand implements Command {
             required = true)
     private String testPlanConfigLocation = "";
 
+    @Option(name = "--workspace",
+            usage = "Product workspace",
+            aliases = {"-w"},
+            required = true)
+    private String workspace = "";
+
     private ProductUOW productUOW;
     private DeploymentPatternUOW deploymentPatternUOW;
     private TestPlanUOW testPlanUOW;
@@ -79,15 +86,16 @@ public class RunTestPlanCommand implements Command {
         testPlanExecutor = new TestPlanExecutor();
     }
 
-    RunTestPlanCommand(String productName, String testPlanConfigLocation) {
+    RunTestPlanCommand(String productName, String testPlanConfigLocation, String workspace) {
         this.productName = productName;
         this.testPlanConfigLocation = testPlanConfigLocation;
+        this.workspace = workspace;
     }
 
     @Override
     public void execute() throws CommandExecutionException {
         try {
-            logger.debug("Input Arguments: \n" + "\tProduct name: " + productName);
+            logger.info("Input Arguments: \n" + "\tProduct name: " + productName);
 
             // Get test plan YAML file path location
             Product product = getProduct(productName);
@@ -101,6 +109,9 @@ public class RunTestPlanCommand implements Command {
 
             // Generate test plan from config
             TestPlan testPlan = FileUtil.readYamlFile(testPlanYAMLFilePath.get(), TestPlan.class);
+            testPlan.setWorkspace(workspace); // In future, the workspace will be kept in 'Context' and referred.
+
+            resolvePaths(testPlan);
             InfrastructureConfig infrastructureConfig = testPlan.getInfrastructureConfig();
 
             //Fetch persisted test plan from DB
@@ -131,6 +142,48 @@ public class RunTestPlanCommand implements Command {
         }
     }
 
+    /**
+     * This method will resolve the relative paths in the test-plan.yaml
+     * to absolute paths by taking into account factors such as the workingDir.
+     *
+     * @param testPlan The test-plan.yaml bean
+     */
+    private void resolvePaths(TestPlan testPlan) {
+        //infra
+        Path repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getInfrastructureRepository());
+        testPlan.setInfrastructureRepository(resolvePath(repoPath, testPlan));
+        //deploy
+        repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getDeploymentRepository());
+        testPlan.setDeploymentRepository(resolvePath(repoPath, testPlan));
+        //scenarios
+        repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getScenarioTestsRepository());
+        testPlan.setScenarioTestsRepository(resolvePath(repoPath, testPlan));
+        //keyfile
+        if (testPlan.getKeyFileLocation() != null) {
+            repoPath = Paths.get(testPlan.getWorkspace(), testPlan.getKeyFileLocation());
+            testPlan.setKeyFileLocation(resolvePath(repoPath, testPlan));
+        }
+    }
+
+    /**
+     * This method resolves the absolute path to a path mentioned in
+     * the iobConfigYaml.
+     *
+     * @param path          The path to resolve
+     * @param testPlan the testPlan.yaml bean
+     * @return the resolved path
+     * @throws TestGridRuntimeException if the resolved path does not exist.
+     */
+    private String resolvePath(Path path, TestPlan testPlan) {
+        path = path.toAbsolutePath().normalize();
+        if (!Files.exists(path)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("TestPlanFile: " + testPlan);
+            }
+            throw new TestGridRuntimeException("Path '" + path.toString() + "' does not exist.");
+        }
+        return path.toString();
+    }
     /**
      * Returns the product for the given parameters.
      *

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -167,7 +167,7 @@ public class RunTestPlanCommand implements Command {
 
     /**
      * This method resolves the absolute path to a path mentioned in
-     * the iobConfigYaml.
+     * the jobConfigYaml.
      *
      * @param path          The path to resolve
      * @return the resolved path
@@ -180,6 +180,7 @@ public class RunTestPlanCommand implements Command {
         }
         return path.toString();
     }
+
     /**
      * Returns the product for the given parameters.
      *

--- a/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
@@ -142,7 +142,8 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
         String repoPath = "./src/test/resources/workspace";
         expectedTestPlanContent = expectedTestPlanContent
                 .replaceAll(repoPath, Paths.get(repoPath).toAbsolutePath().normalize().toString());
-
+        expectedTestPlanContent = expectedTestPlanContent.replace("<workspace-to-be-added-at-runtime>",
+                testPlan.getWorkspace());
         Assert.assertEquals(generatedTestPlanContent, expectedTestPlanContent,
                 String.format("Generated test-plan is not correct: %n%s", generatedTestPlanContent));
     }

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -46,6 +46,7 @@ import org.wso2.testgrid.common.config.TestgridYaml;
 import org.wso2.testgrid.common.infrastructure.DefaultInfrastructureTypes;
 import org.wso2.testgrid.common.infrastructure.InfrastructureCombination;
 import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.common.util.DataBucketsHelper;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.core.ScenarioExecutor;
@@ -58,6 +59,8 @@ import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.dao.uow.TestScenarioUOW;
 import org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -107,14 +110,16 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     private TestPlanExecutor testPlanExecutor;
     private ScenarioExecutor scenarioExecutor;
     private String actualTestPlanFileLocation;
-
+    private String workspaceDir;
     @BeforeMethod
     public void init() throws Exception {
         final String randomStr = StringUtil.generateRandomString(5);
         String productName = "wso2-" + randomStr;
         actualTestPlanFileLocation = Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
                 productName, TestGridConstants.PRODUCT_TEST_PLANS_DIR, "test-plan-01.yaml").toString();
-        runTestPlanCommand = new RunTestPlanCommand(productName, actualTestPlanFileLocation);
+        workspaceDir = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
+                productName).toString();
+        runTestPlanCommand = new RunTestPlanCommand(productName, actualTestPlanFileLocation, workspaceDir);
         System.setProperty(TestGridConstants.TESTGRID_HOME_SYSTEM_PROPERTY, TESTGRID_HOME);
 
         this.product = new Product();
@@ -130,6 +135,11 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         testPlan.setDeploymentPattern(deploymentPattern);
         testPlan.setInfraParameters(infraParamsString);
         testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
+        testPlan.setScenarioTestsRepository(workspaceDir + "/workspace/scenarioTests");
+        testPlan.setInfrastructureRepository(workspaceDir + "/workspace/infrastructure");
+        testPlan.setDeploymentRepository(workspaceDir + "/workspace/deployment");
+        testPlan.setKeyFileLocation(workspaceDir + "/workspace/testkey.pem");
+        testPlan.setWorkspace(workspaceDir);
 
         when(testScenarioUOW.persistTestScenario(any(TestScenario.class))).thenAnswer(invocation -> invocation
                 .getArguments()[0]);
@@ -150,14 +160,14 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
 
         Path actualTestPlanPath = Paths.get(actualTestPlanFileLocation);
         assertTrue(Files.exists(actualTestPlanPath));
-
+        copyWorkspaceArtifacts();
         runTestPlanCommand.execute();
 
-        Path testRunDirectory = TestGridUtil.getTestRunWorkspace(testPlan, false);
+        Path testRunDirectory = DataBucketsHelper.getBuildOutputsDir(testPlan);
         assertTrue(Files.exists(testRunDirectory),
                 "The test-run dir does not exist: " + testRunDirectory.toString());
 
-        final Path infrastructurePath = testRunDirectory.resolve("my-infrastructure");
+        final Path infrastructurePath = Paths.get(testPlan.getInfrastructureRepository());
         assertTrue(Files.exists(infrastructurePath), "Infrastructure provision script failed to run. Dir does not "
                 + "exist: " + infrastructurePath.toString());
         final Path generatedDeploymentFile = infrastructurePath.resolve("my-deployment.txt");
@@ -165,6 +175,12 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
                 + "exist: " + generatedDeploymentFile);
         String content = new String(Files.readAllBytes(generatedDeploymentFile), StandardCharsets.UTF_8);
         Assert.assertEquals(content, "Deploy server1\n", "my-deployment.txt file does not contain expected content.");
+    }
+
+    private void copyWorkspaceArtifacts() throws IOException {
+        String resourceDir = "./src/test/resources/workspace";
+            FileUtils.copyDirectory(new File(resourceDir), new File(workspaceDir + "/workspace"));
+            logger.info("Copying necessary artifacts to workspace " + workspaceDir + "/workspace");
     }
 
     private void doMock() throws TestGridDAOException, TestAutomationException {

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -111,6 +111,7 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     private ScenarioExecutor scenarioExecutor;
     private String actualTestPlanFileLocation;
     private String workspaceDir;
+
     @BeforeMethod
     public void init() throws Exception {
         final String randomStr = StringUtil.generateRandomString(5);
@@ -180,8 +181,8 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     private void copyWorkspaceArtifacts() throws IOException {
         String resourceDir = Paths.get("./src", "test", "resources", "workspace").toString();
         String destinationDir = Paths.get(workspaceDir, "/workspace").toString();
-            FileUtils.copyDirectory(new File(resourceDir), new File(destinationDir));
-            logger.info("Copying necessary artifacts to directory: " + destinationDir);
+        FileUtils.copyDirectory(new File(resourceDir), new File(destinationDir));
+        logger.info("Copying necessary artifacts to directory: " + destinationDir);
     }
 
     private void doMock() throws TestGridDAOException, TestAutomationException {

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -135,10 +135,10 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         testPlan.setDeploymentPattern(deploymentPattern);
         testPlan.setInfraParameters(infraParamsString);
         testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
-        testPlan.setScenarioTestsRepository(workspaceDir + "/workspace/scenarioTests");
-        testPlan.setInfrastructureRepository(workspaceDir + "/workspace/infrastructure");
-        testPlan.setDeploymentRepository(workspaceDir + "/workspace/deployment");
-        testPlan.setKeyFileLocation(workspaceDir + "/workspace/testkey.pem");
+        testPlan.setScenarioTestsRepository(Paths.get(workspaceDir, "/workspace/scenarioTests").toString());
+        testPlan.setInfrastructureRepository(Paths.get(workspaceDir, "/workspace/infrastructure").toString());
+        testPlan.setDeploymentRepository(Paths.get(workspaceDir, "/workspace/deployment").toString());
+        testPlan.setKeyFileLocation(Paths.get(workspaceDir, "/workspace/testkey.pem").toString());
         testPlan.setWorkspace(workspaceDir);
 
         when(testScenarioUOW.persistTestScenario(any(TestScenario.class))).thenAnswer(invocation -> invocation
@@ -178,9 +178,10 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
     }
 
     private void copyWorkspaceArtifacts() throws IOException {
-        String resourceDir = "./src/test/resources/workspace";
-            FileUtils.copyDirectory(new File(resourceDir), new File(workspaceDir + "/workspace"));
-            logger.info("Copying necessary artifacts to workspace " + workspaceDir + "/workspace");
+        String resourceDir = Paths.get("./src", "test", "resources", "workspace").toString();
+        String destinationDir = Paths.get(workspaceDir, "/workspace").toString();
+            FileUtils.copyDirectory(new File(resourceDir), new File(destinationDir));
+            logger.info("Copying necessary artifacts to directory: " + destinationDir);
     }
 
     private void doMock() throws TestGridDAOException, TestAutomationException {

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -11,7 +11,7 @@ deploymentConfig:
       name: deploy-
       phase: CREATE
       type: SHELL
-deploymentRepository: ./src/test/resources/workspace/deployment
+deploymentRepository: workspace/deployment
 id: abc
 infrastructureConfig:
   containerOrchestrationEngine: None
@@ -35,10 +35,10 @@ infrastructureConfig:
       name: destroy-
       phase: DESTROY
       type: SHELL
-infrastructureRepository: ./src/test/resources/workspace/infrastructure
+infrastructureRepository: workspace/infrastructure
 jobProperties:
   PROPERTY1: value1
-keyFileLocation: ./src/test/resources/workspace/testkey.pem
+keyFileLocation: workspace/testkey.pem
 scenarioConfig:
   scenarios:
   - description: Test Scenario
@@ -48,7 +48,8 @@ scenarioConfig:
     testCases: [
       ]
   testType: FUNCTIONAL
-scenarioTestsRepository: ./src/test/resources/workspace/scenarioTests
+scenarioTestsRepository: workspace/scenarioTests
 testRunNumber: 1
 testScenarios: [
   ]
+workspace: <workspace-to-be-added-at-runtime>

--- a/core/src/test/resources/workspace/deployment/deploy.sh
+++ b/core/src/test/resources/workspace/deployment/deploy.sh
@@ -23,7 +23,8 @@ while [ "$1" != "" ]; do
     shift
 done
 
-INFRA=$WORKSPACE/my-infrastructure
+INFRA=$WORKSPACE/workspace/infrastructure
+echo $(pwd)
 if [ ! -d $INFRA ]; then
   echo 'Cannot proceed the deployment. infrastructure dir is empty: ' ${INFRA}
   exit 1;

--- a/core/src/test/resources/workspace/infrastructure/infra-provision.sh
+++ b/core/src/test/resources/workspace/infrastructure/infra-provision.sh
@@ -25,4 +25,3 @@ done
 
 echo 'PWD:' `pwd`
 echo 'We are in:' `uname`
-mkdir -p ${WORKSPACE}/my-infrastructure

--- a/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
+++ b/deployment/src/main/java/org/wso2/testgrid/deployment/deployers/ShellDeployer.java
@@ -44,7 +44,6 @@ import org.wso2.testgrid.deployment.DeploymentUtil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -160,9 +159,8 @@ public class ShellDeployer implements Deployer {
     }
 
     private Properties getInputParameters(TestPlan testPlan, Script deployment) {
-        Path workspace = TestGridUtil.getTestRunWorkspace(testPlan, false);
         final Properties inputParameters = deployment.getInputParameters();
-        inputParameters.setProperty(WORKSPACE, workspace.toString());
+        inputParameters.setProperty(WORKSPACE, testPlan.getWorkspace());
         return inputParameters;
     }
 

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/ShellScriptProvider.java
@@ -113,7 +113,7 @@ public class ShellScriptProvider implements InfrastructureProvider {
         try {
             Script createScript = getScriptToExecute(infrastructureConfig, Script.Phase.CREATE);
             Properties inputParameters = createScript.getInputParameters();
-            final String workspace = TestGridUtil.getTestRunWorkspace(testPlan, false).toString();
+            final String workspace = testPlan.getWorkspace();
             inputParameters.setProperty(WORKSPACE, workspace);
             // TODO: this is deprecated.
             inputParameters.setProperty(OUTPUT_DIR, DataBucketsHelper.getOutputLocation(testPlan).toString());

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -50,6 +50,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.InfrastructureProvisionResult;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.InfrastructureConfig;
@@ -155,7 +156,9 @@ public class AWSProviderTest extends PowerMockTestCase {
         String outputValue = "TestDNS";
         String patternName = "single-node";
         String matchedAmi = "123464";
-
+        String jobName = "wso2";
+        String workspaceDir = Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
+                jobName).toString();
         Map<String, String> map = new HashMap<>();
         map.put(AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID_VALUE);
         map.put(AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY_VALUE);
@@ -219,9 +222,10 @@ public class AWSProviderTest extends PowerMockTestCase {
                 .thenReturn(Collections.singletonList(Mockito.mock(AWSResourceLimit.class)));
 
         AWSProvider awsProvider = new AWSProvider();
-        testPlan.setJobName("wso2");
+        testPlan.setJobName(jobName);
         testPlan.setInfrastructureConfig(infrastructureConfig);
         testPlan.setInfrastructureRepository(resourcePath.getAbsolutePath());
+        testPlan.setWorkspace(workspaceDir);
         awsProvider.init(testPlan);
         InfrastructureProvisionResult provisionResult = awsProvider
                 .provision(testPlan);

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
@@ -37,7 +37,6 @@ import org.wso2.testgrid.reporting.surefire.SurefireReporter;
 import org.wso2.testgrid.reporting.surefire.TestResult;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -109,8 +108,7 @@ public class EmailReportProcessor {
 
             if ("?".equals(report.getTotalTests()) || "0".equals(report.getTotalTests())
                     || report.getTotalTests().isEmpty()) {
-                final Path reportPath = Paths.get(TestGridUtil.getTestGridHomePath())
-                        .relativize(TestGridUtil.getSurefireReportsDir(testPlan));
+                final Path reportPath = TestGridUtil.getSurefireReportsDir(testPlan);
                 logger.error("Integration-test log file does not exist at '" + reportPath
                         + "' for test-plan: " + testPlan);
             }

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -23,10 +23,12 @@ import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.common.util.FileUtil;
+import org.wso2.testgrid.common.util.S3StorageUtil;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
@@ -790,9 +792,7 @@ public class TestReportEngine {
         String htmlString = renderer.render(EMAIL_REPORT_MUSTACHE, perSummariesMap);
 
         // Write to HTML file
-        String relativeFilePath = TestGridUtil.deriveTestGridLogFilePath(product.getName(), TESTGRID_EMAIL_REPORT_NAME);
-        String testGridHome = TestGridUtil.getTestGridHomePath();
-        Path reportPath = Paths.get(testGridHome, relativeFilePath);
+        Path reportPath = Paths.get(workspace, TestGridConstants.TESTGRID_BUILDS_DIR, TESTGRID_EMAIL_REPORT_NAME);
         writeHTMLToFile(reportPath, htmlString);
         return Optional.of(reportPath);
     }
@@ -825,6 +825,7 @@ public class TestReportEngine {
                 Optional<TestPlan> testPlanById = testPlanUOW.getTestPlanById(testPlanYaml.getId());
                 if (testPlanById.isPresent()) {
                     TestPlan mergedTestPlan = TestGridUtil.mergeTestPlans(testPlanYaml, testPlanById.get(), false);
+                    mergedTestPlan.setWorkspace(workspace);
                     logger.info("Derived test plan dir in email phase : " +
                             TestGridUtil.deriveTestPlanDirName(mergedTestPlan));
                     testPlans.add(mergedTestPlan);
@@ -889,9 +890,9 @@ public class TestReportEngine {
 
         String productName = product.getName();
         final String dashboardURL = TestGridUtil.getDashboardURLFor(productName);
-        final String summaryChartURL = String.join("/", TestGridUtil.getS3BucketURL(),
+        final String summaryChartURL = String.join("/", S3StorageUtil.getS3BucketURL(),
                 "charts", productName, "summary.png");
-        final String historyChartURL = String.join("/", TestGridUtil.getS3BucketURL(),
+        final String historyChartURL = String.join("/", S3StorageUtil.getS3BucketURL(),
                 "charts", productName, "history.png");
 
         Renderable renderer = RenderableFactory.getRenderable(EMAIL_REPORT_MUSTACHE);
@@ -909,10 +910,8 @@ public class TestReportEngine {
         String htmlString = renderer.render(SUMMARIZED_EMAIL_REPORT_MUSTACHE, results);
 
         // Write to HTML file
-        String relativeFilePath = TestGridUtil
-                .deriveTestGridLogFilePath(product.getName(), TESTGRID_SUMMARIZED_EMAIL_REPORT_NAME);
-        String testGridHome = TestGridUtil.getTestGridHomePath();
-        Path reportPath = Paths.get(testGridHome, relativeFilePath);
+        Path reportPath = Paths.get(workspace, TestGridConstants.TESTGRID_BUILDS_DIR,
+                TESTGRID_SUMMARIZED_EMAIL_REPORT_NAME);
         writeHTMLToFile(reportPath, htmlString);
         Path reportParentPath = reportPath.getParent();
 

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/BaseClass.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/BaseClass.java
@@ -111,12 +111,10 @@ public class BaseClass {
         productDir = Paths.get(TESTGRID_HOME).resolve("jobs").resolve(productName);
         Files.createDirectories(productDir);
 
-
     }
 
     protected Path getTestPlansPath() {
-        return Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
-                product.getName(), TestGridConstants.PRODUCT_TEST_PLANS_DIR);
+        return Paths.get(productDir.toString(), TestGridConstants.PRODUCT_TEST_PLANS_DIR);
     }
 
     /**
@@ -148,11 +146,12 @@ public class BaseClass {
                 + "\"DBEngineVersion\":\"5.7\",\"DBEngine\":\"mysql\"}");
         testPlan.setStatus(Status.FAIL);
         testPlan.setId(testPlanId);
-
+        testPlan.setWorkspace(productDir.toString());
         InfrastructureConfig infraConfig = new InfrastructureConfig();
         Properties p = new Properties();
         p.setProperty("DBEngine", "mysql");
         p.setProperty("DBEngineVersion", "5.7");
+
         p.setProperty("OS", "CentOS");
         p.setProperty("JDK", "ORACLE_JDK8");
         infraConfig.setParameters(p);
@@ -360,7 +359,7 @@ public class BaseClass {
             TestPlan testPlan = new TestPlan();
             testPlan.setStatus(ts.getStatus());
             testPlan.setId(i + "");
-
+            testPlan.setWorkspace(productDir.toString());
             InfrastructureConfig infraConfig = new InfrastructureConfig();
             Properties props = new Properties();
             for (InfrastructureParameter infrastructureParameter : infrastructureCombination.getParameters()) {

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -29,6 +29,7 @@ import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.exception.TestGridException;
+import org.wso2.testgrid.common.util.S3StorageUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
@@ -169,8 +170,7 @@ public class TestPlanService {
                         .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
             }
             TestPlan testPlan = optionalTestPlan.get();
-
-            String logFileDir = TestGridUtil.deriveTestRunLogFilePath(testPlan, truncate);
+            String logFileDir = S3StorageUtil.deriveTestRunLogFilePath(testPlan, truncate);
             String bucketKey = Paths
                     .get(AWS_BUCKET_ARTIFACT_DIR, logFileDir).toString();
             // In future when TestGrid is deployed in multiple regions, builds may run in different regions.
@@ -221,7 +221,7 @@ public class TestPlanService {
             }
             TestPlan testPlan = optionalTestPlan.get();
 
-            String logFileDir = TestGridUtil.deriveTestRunLogFilePath(testPlan, true);
+            String logFileDir = S3StorageUtil.deriveTestRunLogFilePath(testPlan, true);
             String bucketKey = Paths
                     .get(AWS_BUCKET_ARTIFACT_DIR, logFileDir).toString();
             // In future when TestGrid is deployed in multiple regions, builds may run in different regions.
@@ -382,7 +382,7 @@ public class TestPlanService {
      *                           3.If the YAML file already exists.
      */
     private void persistAsYamlFile(TestPlanRequest testPlanRequest) throws TestGridException, IOException {
-        java.nio.file.Path path = TestGridUtil.getTestPlanDirectory().resolve(testPlanRequest.getTestPlanName());
+        java.nio.file.Path path = TestGridUtil.getTestPlanRequestDirectory().resolve(testPlanRequest.getTestPlanName());
 
         if (!Files.exists(path)) {
             try {

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -170,7 +170,7 @@ public class TestPlanService {
                         .entity(new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
             }
             TestPlan testPlan = optionalTestPlan.get();
-            String logFileDir = S3StorageUtil.deriveTestRunLogFilePath(testPlan, truncate);
+            String logFileDir = S3StorageUtil.getS3LocationForTestRunLogFile(testPlan, truncate);
             String bucketKey = Paths
                     .get(AWS_BUCKET_ARTIFACT_DIR, logFileDir).toString();
             // In future when TestGrid is deployed in multiple regions, builds may run in different regions.
@@ -221,7 +221,7 @@ public class TestPlanService {
             }
             TestPlan testPlan = optionalTestPlan.get();
 
-            String logFileDir = S3StorageUtil.deriveTestRunLogFilePath(testPlan, true);
+            String logFileDir = S3StorageUtil.getS3LocationForTestRunLogFile(testPlan, true);
             String bucketKey = Paths
                     .get(AWS_BUCKET_ARTIFACT_DIR, logFileDir).toString();
             // In future when TestGrid is deployed in multiple regions, builds may run in different regions.


### PR DESCRIPTION
**Purpose**
Fixes #971 

<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Goals**
Spread parallel execution into multiple slaves.
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**
**Isolate the parallel block working directories, so that each block run its own**
With this PR, the jobs will run as;
Sample directory;

_Node1_
```
testgridhome -> jobs ->  wso2is-intg -> workspace  (workspace used by generate-testplan command)
                                     -> 2 -> workspace   (workspaces used to run parallel block)
                                     -> 3 -> workspace
                                     -> 4 -> workspace    
                                     -> 5 -> workspace
```
_Node2_
```
testgridhome -> jobs ->  wso2is-intg -> 6 -> workspace   (workspaces used to run parallel block)
                                      -> 7 -> workspace
                                      -> 8 -> workspace
                                      -> 9 -> workspace
                                      -> 10 -> workspace
                                      -> 11 -> workspace
```

The PR include necessary changes to existing Job execution flow in order to make it self-contained.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
