### PR TITLE
Parameterize maven version in cf scripts for integration tests

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -124,6 +124,10 @@ Parameters:
     AllowedValues:
       - OPEN_JDK8
       - ORACLE_JDK8
+  MavenVersion:
+    Type: String
+    Default: '3.3.9'
+    Description: Enter required Maven version.
   CustomUserData:
    Type: String
    Default: "echo"
@@ -266,9 +270,9 @@ Resources:
 
           setup_java_env
           echo "Installing Apache Maven"
-          wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-          tar -xvzf apache-maven-3.3.9-bin.tar.gz
-          ln -fs apache-maven-3.3.9 maven
+          wget https://archive.apache.org/dist/maven/maven-3/${MavenVersion}/binaries/apache-maven-${MavenVersion}-bin.tar.gz
+          tar -xvzf apache-maven-${MavenVersion}-bin.tar.gz
+          ln -fs apache-maven-${MavenVersion} maven
           echo 'export MAVEN_OPTS="-Xmx2048m -Xms256m"' >> /etc/environment
           echo 'export M3_HOME=/opt/wso2/workspace/maven' >> /etc/environment
           echo PATH=/opt/wso2/workspace/maven/bin/:$PATH >> /etc/environment
@@ -317,9 +321,18 @@ Resources:
         UserData:
           !Base64
           'Fn::Sub': |
-            <script>
-            setx -m JAVA_HOME "%${JDK}%"
-            </script>
+            <powershell>
+            [Environment]::SetEnvironmentVariable("JAVA_HOME", "$Env:${JDK}", "Machine")
+
+            wget https://archive.apache.org/dist/maven/maven-3/${MavenVersion}/binaries/apache-maven-${MavenVersion}-bin.zip -OutFile "maven.zip"
+            Expand-Archive maven.zip -DestinationPath c:\\testgrid\\workspace
+
+            [Environment]::SetEnvironmentVariable("M2_HOME", "c:\\testgrid\\workspace\\apache-maven-${MavenVersion}", "Machine")
+            [Environment]::SetEnvironmentVariable("MAVEN_HOME", "c:\\testgrid\\workspace\\apache-maven-${MavenVersion}", "Machine")
+
+            $Old_Path=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path).Path
+            Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value ($Old_Path += ';c:\\testgrid\\workspace\\apache-maven-${MavenVersion}\\bin') -Verbose -PassThru|fl
+            </powershell>
             <persist>true</persist>
         SecurityGroups:
           - !Ref WSO2InstanceSecurityGroup


### PR DESCRIPTION
**Purpose**
Contains changes related to parameterizing the maven version to get compatible version to run integration tests.
Resolves #974

**Goals**
Build integration test modules successfully.

**Approach**
Parameterized the maven version in the cf script with a default value.
The maven version should be provided as an optional input parameter to the CFN in the testgrid.yaml as below. 
MavenVersion: 3.5.4

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes