### PR TITLE
Make Grafana product performance dashboard support SSL

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
@@ -18,7 +18,6 @@
 
 package org.wso2.testgrid.common;
 
-
 import org.apache.http.entity.ContentType;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;

--- a/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
@@ -18,11 +18,8 @@
 
 package org.wso2.testgrid.common;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
+
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.json.simple.JSONObject;
@@ -31,8 +28,19 @@ import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.util.StringUtil;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.io.DataOutputStream;
+import java.net.URL;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import static org.apache.http.protocol.HTTP.USER_AGENT;
 
 /**
  * This class create a database in influxDB and a Data Source in
@@ -40,8 +48,8 @@ import java.io.UnsupportedEncodingException;
 public class DashboardSetup {
 
     private static final Logger logger = LoggerFactory.getLogger(DashboardSetup.class);
-    private String restUrl = "http://" +
-            ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.PERFORMANCE_DASHBOARD_URL);
+    private String restUrl =
+            ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_URL);
     private String username =
             ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_USER);
     private String password =
@@ -60,7 +68,7 @@ public class DashboardSetup {
     public void initDashboard() {
         // create influxDB database according to tp_id
         try {
-            InfluxDB influxDB = InfluxDBFactory.connect(restUrl + ":8086", username, password);
+            InfluxDB influxDB = InfluxDBFactory.connect("http://" + restUrl + ":8086", username, password);
             String dbName = testplanID;
             influxDB.createDatabase(dbName);
             influxDB.close();
@@ -69,9 +77,9 @@ public class DashboardSetup {
         } catch (IllegalArgumentException e) {
             logger.error(StringUtil.concatStrings("INFLUXDB_USER and INFLUXDB_PASS cannot be empty: \n", e));
         }
+
         // add a new data source to grafana
-        HttpPost httpPost = createConnectivity(restUrl, apikey);
-        executeReq(getDataSource(testplanID), httpPost);
+        addGrafanaDataSource();
 
     }
 
@@ -86,7 +94,8 @@ public class DashboardSetup {
         JSONObject user = new JSONObject();
         user.put("name", name);
         user.put("type", "influxdb");
-        user.put("url", "http://localhost:8086");
+        user.put("url", "http://" + ConfigurationContext.getProperty(ConfigurationContext.
+                ConfigurationProperties.GRAFANA_DATASOURCE) + ":8086");
         user.put("access", "proxy");
         user.put("basicAuth", false);
         user.put("password", ConfigurationContext.getProperty(ConfigurationContext.
@@ -99,50 +108,68 @@ public class DashboardSetup {
     }
 
     /**
-     * This method will create the header of the POST request
-     * @param restUrl url of the grafana server
-     * @param apikey APIkey of the grafana server
-     * @return return a http post request
+     * This method will create a grafana datasource according to TestPlanID
      */
-    private HttpPost createConnectivity(String restUrl, String apikey) {
-        HttpPost post = new HttpPost(restUrl + ":3000/api/datasources/");
-        post.setHeader("AUTHORIZATION", apikey);
-        post.setHeader("Content-Type", ContentType.APPLICATION_JSON.toString());
-        post.setHeader("Accept", ContentType.APPLICATION_JSON.toString());
-        return post;
-    }
+    public void addGrafanaDataSource() {
 
-    /**
-     * This command will handle the posting http request to REST  api
-     * @param jsonData json string of the data source
-     * @param httpPost post request with authentication
-     */
-    private void executeReq(String jsonData, HttpPost httpPost) {
+        DataOutputStream wr = null;
         try {
-            executeHttpRequest(jsonData, httpPost);
-        } catch (UnsupportedEncodingException e) {
-            logger.error(StringUtil.concatStrings("error while encoding grafana http api url : ", e));
-        } catch (IOException e) {
-            logger.error(StringUtil.concatStrings("ioException occured while sending http request : ", e));
+            String url = "https://" + ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties
+                    .GRAFANA_DATASOURCE) + ":3000/api/datasources/";
+
+            HostnameVerifier allHostsValid = (hostname, session) -> true;
+            HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+
+            URL obj = new URL(url);
+            HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+            //add reuqest header
+            con.setRequestMethod("POST");
+            con.setRequestProperty("User-Agent", USER_AGENT);
+            con.setRequestProperty("Content-Type", ContentType.APPLICATION_JSON.toString());
+            con.setRequestProperty("Accept", ContentType.APPLICATION_JSON.toString());
+            con.setRequestProperty("Authorization", apikey);
+            SSLSocketFactory sslSocketFactory = createSslSocketFactory();
+            con.setSSLSocketFactory(sslSocketFactory);
+            String urlParameters = getDataSource(testplanID);
+            con.setDoOutput(true);
+            //logger.info("garafana COnnection: " + con.toString());
+            wr = new DataOutputStream(con.getOutputStream());
+            wr.writeBytes(urlParameters);
+            wr.flush();
+            int responseCode = con.getResponseCode();
+            if (responseCode == 200) {
+                logger.info("grafana Data Source created for testplan " + testplanID);
+            } else {
+                logger.error(StringUtil.concatStrings("failed to create grafana Data testplan ", testplanID,
+                        " Response Code ", responseCode));
+            }
+        } catch (SSLHandshakeException e) {
+            logger.error("Please set a valid truststore key file" + e.toString());
         } catch (Exception e) {
-            logger.error(StringUtil.concatStrings("Exception occured while sending http request : ", e));
+            logger.error("Error while creating Grafana data source" + e.toString());
         } finally {
-            httpPost.releaseConnection();
+            if (wr != null) {
+                try {
+                    wr.close();
+                } catch (Exception e) {
+                    logger.error("Couldn't close the output stream");
+                }
+            }
         }
     }
 
-    /**
-     * This method will execute the post request
-     * @param jsonData json string of the data source
-     * @param httpPost post request with authentication
-     * @throws UnsupportedEncodingException thown when an error with api key
-     * @throws IOException thrown when error in connection
-     */
-    private void executeHttpRequest(String jsonData,  HttpPost httpPost)  throws UnsupportedEncodingException,
-            IOException {
-        httpPost.setEntity(new StringEntity(jsonData));
-        HttpClient client = HttpClientBuilder.create().build();
-        client.execute(httpPost);
+    private static SSLSocketFactory createSslSocketFactory() throws Exception {
+        TrustManager[] byPassTrustManagers = new TrustManager[] { new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            }
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+        } };
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, byPassTrustManagers, new SecureRandom());
+        return sslContext.getSocketFactory();
     }
-
 }

--- a/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
@@ -43,7 +43,7 @@ import javax.net.ssl.X509TrustManager;
 import static org.apache.http.protocol.HTTP.USER_AGENT;
 
 /**
- * This class create a database in influxDB and a Data Source in
+ * This class create a database in influxDB and a Data Source in Grafana according to the test plan
  */
 public class DashboardSetup {
 
@@ -112,7 +112,7 @@ public class DashboardSetup {
      */
     public void addGrafanaDataSource() {
 
-        DataOutputStream wr = null;
+        DataOutputStream dataOutputStream = null;
         try {
             String url = "https://" + ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties
                     .GRAFANA_DATASOURCE) + ":3000/api/datasources/";
@@ -132,10 +132,9 @@ public class DashboardSetup {
             con.setSSLSocketFactory(sslSocketFactory);
             String urlParameters = getDataSource(testplanID);
             con.setDoOutput(true);
-            //logger.info("garafana COnnection: " + con.toString());
-            wr = new DataOutputStream(con.getOutputStream());
-            wr.writeBytes(urlParameters);
-            wr.flush();
+            dataOutputStream = new DataOutputStream(con.getOutputStream());
+            dataOutputStream.writeBytes(urlParameters);
+            dataOutputStream.flush();
             int responseCode = con.getResponseCode();
             if (responseCode == 200) {
                 logger.info("grafana Data Source created for testplan " + testplanID);
@@ -148,9 +147,9 @@ public class DashboardSetup {
         } catch (Exception e) {
             logger.error("Error while creating Grafana data source" + e.toString());
         } finally {
-            if (wr != null) {
+            if (dataOutputStream != null) {
                 try {
-                    wr.close();
+                    dataOutputStream.close();
                 } catch (Exception e) {
                     logger.error("Couldn't close the output stream");
                 }

--- a/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
@@ -66,8 +66,8 @@ public class DashboardSetup {
     public void initDashboard() {
         // create influxDB database according to tp_id
         try {
-            InfluxDB influxDB = InfluxDBFactory.connect(TestGridConstants.HTTP + restUrl + ":8086",
-                    username, password);
+            InfluxDB influxDB = InfluxDBFactory.connect(TestGridConstants.HTTP + restUrl +
+                            TestGridConstants.INFLUXDB_PORT, username, password);
             String dbName = testplanID;
             influxDB.createDatabase(dbName);
             influxDB.close();
@@ -94,7 +94,7 @@ public class DashboardSetup {
         user.put("name", name);
         user.put("type", "influxdb");
         user.put("url", TestGridConstants.HTTP + ConfigurationContext.getProperty(ConfigurationContext.
-                ConfigurationProperties.GRAFANA_DATASOURCE) + ":8086");
+                ConfigurationProperties.GRAFANA_DATASOURCE) + TestGridConstants.INFLUXDB_PORT);
         user.put("access", "proxy");
         user.put("basicAuth", false);
         user.put("password", ConfigurationContext.getProperty(ConfigurationContext.

--- a/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
+++ b/common/src/main/java/org/wso2/testgrid/common/DashboardSetup.java
@@ -28,6 +28,7 @@ import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.util.StringUtil;
 
 import java.io.DataOutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
@@ -66,8 +67,7 @@ public class DashboardSetup {
     public void initDashboard() {
         // create influxDB database according to tp_id
         try {
-            InfluxDB influxDB = InfluxDBFactory.connect(TestGridConstants.HTTP + restUrl +
-                            TestGridConstants.INFLUXDB_PORT, username, password);
+            InfluxDB influxDB = InfluxDBFactory.connect(TestGridConstants.HTTP + restUrl, username, password);
             String dbName = testplanID;
             influxDB.createDatabase(dbName);
             influxDB.close();
@@ -94,7 +94,7 @@ public class DashboardSetup {
         user.put("name", name);
         user.put("type", "influxdb");
         user.put("url", TestGridConstants.HTTP + ConfigurationContext.getProperty(ConfigurationContext.
-                ConfigurationProperties.GRAFANA_DATASOURCE) + TestGridConstants.INFLUXDB_PORT);
+                ConfigurationProperties.INFLUXDB_URL));
         user.put("access", "proxy");
         user.put("basicAuth", false);
         user.put("password", ConfigurationContext.getProperty(ConfigurationContext.
@@ -135,7 +135,7 @@ public class DashboardSetup {
             dataOutputStream.writeBytes(urlParameters);
             dataOutputStream.flush();
             int responseCode = con.getResponseCode();
-            if (responseCode == 200) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 logger.info("grafana Data Source created for testplan " + testplanID);
             } else {
                 logger.error(StringUtil.concatStrings("failed to create grafana Data testplan ", testplanID,

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -82,4 +82,5 @@ public class TestGridConstants {
     public static final String AMAZON_S3_DEFAULT_BUCKET_NAME = "unknown";
 
     public static final String HTTP = "http://";
+    public static final String INFLUXDB_PORT = ":8086";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -82,5 +82,4 @@ public class TestGridConstants {
     public static final String AMAZON_S3_DEFAULT_BUCKET_NAME = "unknown";
 
     public static final String HTTP = "http://";
-    public static final String INFLUXDB_PORT = ":8086";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -80,4 +80,6 @@ public class TestGridConstants {
     public static final String SCENARIO_SCRIPT = "run-scenario.sh";
     public static final String AMAZON_S3_URL = "https://s3.amazonaws.com";
     public static final String AMAZON_S3_DEFAULT_BUCKET_NAME = "unknown";
+
+    public static final String HTTP = "http://";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -153,7 +153,7 @@ public class ConfigurationContext {
         /**
          * URL of InfluxDB data base
          */
-        PERFORMANCE_DASHBOARD_URL("PERFORMANCE_DASHBOARD_URL"),
+        INFLUXDB_URL("INFLUXDB_URL"),
 
         /**
          * InfluxDB username
@@ -166,6 +166,11 @@ public class ConfigurationContext {
         INFLUXDB_PASS("INFLUXDB_PASS"),
 
         /**
+         * Grafana Datasource
+         */
+        GRAFANA_DATASOURCE("GRAFANA_DATASOURCE"),
+
+        /**
          * Grafana api Key
          */
         GRAFANA_APIKEY("GRAFANA_APIKEY"),
@@ -173,7 +178,19 @@ public class ConfigurationContext {
         /**
          * Grafana Dashboard URL
          */
-        GRAFANA_URL("GRAFANA_URL");
+        GRAFANA_URL("GRAFANA_URL"),
+
+        /**
+         * Location to trustsore .jks file
+         */
+        TRUSTSTORE_KEY("TRUSTSTORE_KEY"),
+
+        /**
+         * Password of trustore key file
+         */
+        TRUSTSTORE_PASSWORD("TRUSTSTORE_PASSWORD");
+
+
 
 
 

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -407,7 +407,7 @@ public class AWSProvider implements InfrastructureProvider {
                         deploymentTinkererEP, " ", awsRegion, " ", testPlanId, " aws ", deploymentTinkererUserName, " ",
                         deploymentTinkererPassword, "\n", "/opt/testgrid/agent/telegraf_setup.sh ", testPlanId, " ",
                         ConfigurationContext.getProperty
-                                (ConfigurationContext.ConfigurationProperties.PERFORMANCE_DASHBOARD_URL), ":8086 ",
+                                (ConfigurationContext.ConfigurationProperties.INFLUXDB_URL), ":8086 ",
                         ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_USER),
                         " ", ConfigurationContext.getProperty(ConfigurationContext.
                                 ConfigurationProperties.INFLUXDB_PASS));

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -407,7 +407,7 @@ public class AWSProvider implements InfrastructureProvider {
                         deploymentTinkererEP, " ", awsRegion, " ", testPlanId, " aws ", deploymentTinkererUserName, " ",
                         deploymentTinkererPassword, "\n", "/opt/testgrid/agent/telegraf_setup.sh ", testPlanId, " ",
                         ConfigurationContext.getProperty
-                                (ConfigurationContext.ConfigurationProperties.INFLUXDB_URL), ":8086 ",
+                                (ConfigurationContext.ConfigurationProperties.INFLUXDB_URL), " ",
                         ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_USER),
                         " ", ConfigurationContext.getProperty(ConfigurationContext.
                                 ConfigurationProperties.INFLUXDB_PASS));


### PR DESCRIPTION
**Purpose**

Currently Grafana data source is not getting created when SSL is enabled. So the dashboard cannot display the gathered perfomance metrics. These changes will fix this issue
Resolves #973 

**Goals**

Create Grafana data sources successfully 

**Approach**

Bypassed host verification for Grafana URL.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 