### PR TITLE
Set the correct time limits in grafana dashboard url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <commons.validator.version>1.6</commons.validator.version>
         <google.gson.version>2.2.4</google.gson.version>
         <glassfish.tyrus.version>1.13.1</glassfish.tyrus.version>
-        <org.influxdb.version>2.5</org.influxdb.version>
+        <org.influxdb.version>2.11</org.influxdb.version>
         <json-simple.version>1.1</json-simple.version>
     </properties>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -152,6 +152,10 @@
             <groupId>org.wso2.testgrid</groupId>
             <artifactId>org.wso2.testgrid.reporting</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.influxdb</groupId>
+            <artifactId>influxdb-java</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -29,6 +29,7 @@ import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.exception.TestGridException;
+import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
@@ -39,9 +40,9 @@ import org.wso2.testgrid.web.bean.TestCaseEntry;
 import org.wso2.testgrid.web.bean.TestExecutionSummary;
 import org.wso2.testgrid.web.bean.TestPlanRequest;
 import org.wso2.testgrid.web.bean.TestPlanStatus;
+import org.wso2.testgrid.web.operation.GrafanaTimeLimitGetter;
 import org.wso2.testgrid.web.operation.JenkinsJobConfigurationProvider;
 import org.wso2.testgrid.web.operation.JenkinsPipelineManager;
-import org.wso2.testgrid.web.operation.TimeLimitGetter;
 import org.wso2.testgrid.web.plugins.AWSArtifactReader;
 import org.wso2.testgrid.web.plugins.ArtifactReadable;
 import org.wso2.testgrid.web.plugins.ArtifactReaderException;
@@ -297,11 +298,11 @@ public class TestPlanService {
     @Path("/perf-url/{id}")
     public Response getGrafanaURL(@PathParam("id") String id) {
 
-        TimeLimitGetter timeLimitGetter = new TimeLimitGetter(id);
+        GrafanaTimeLimitGetter timeLimitGetter = new GrafanaTimeLimitGetter(id);
         try {
-            String dashURL = ConfigurationContext.getProperty(ConfigurationProperties.GRAFANA_URL) +
-                    "&from=" + timeLimitGetter.getStartTime() + "&to=" + timeLimitGetter.getEndTime() +
-                    "&var-VM=All&var-TestPlan=" + id;
+            String dashURL = StringUtil.concatStrings(ConfigurationContext.getProperty
+                    (ConfigurationProperties.GRAFANA_URL), "&from=", timeLimitGetter.getStartTime(), "&to=",
+                    timeLimitGetter.getEndTime(), "&var-VM=All&var-TestPlan=", id);
             return Response.status(Response.Status.OK).entity(dashURL).build();
         } catch (Exception e) {
             String msg = "Error occurred while fetching the Grafana dashboard url by id : '" + id + "'";

--- a/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/TestPlanService.java
@@ -41,6 +41,7 @@ import org.wso2.testgrid.web.bean.TestPlanRequest;
 import org.wso2.testgrid.web.bean.TestPlanStatus;
 import org.wso2.testgrid.web.operation.JenkinsJobConfigurationProvider;
 import org.wso2.testgrid.web.operation.JenkinsPipelineManager;
+import org.wso2.testgrid.web.operation.TimeLimitGetter;
 import org.wso2.testgrid.web.plugins.AWSArtifactReader;
 import org.wso2.testgrid.web.plugins.ArtifactReadable;
 import org.wso2.testgrid.web.plugins.ArtifactReaderException;
@@ -295,9 +296,12 @@ public class TestPlanService {
     @GET
     @Path("/perf-url/{id}")
     public Response getGrafanaURL(@PathParam("id") String id) {
+
+        TimeLimitGetter timeLimitGetter = new TimeLimitGetter(id);
         try {
             String dashURL = ConfigurationContext.getProperty(ConfigurationProperties.GRAFANA_URL) +
-                    "&from=now%2FM&to=now%2FM&var-VM=All&var-TestPlan=" + id;
+                    "&from=" + timeLimitGetter.getStartTime() + "&to=" + timeLimitGetter.getEndTime() +
+                    "&var-VM=All&var-TestPlan=" + id;
             return Response.status(Response.Status.OK).entity(dashURL).build();
         } catch (Exception e) {
             String msg = "Error occurred while fetching the Grafana dashboard url by id : '" + id + "'";

--- a/web/src/main/java/org/wso2/testgrid/web/operation/GrafanaTimeLimitGetter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/GrafanaTimeLimitGetter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.testgrid.web.operation;
 
 import org.influxdb.InfluxDB;
@@ -16,9 +34,9 @@ import java.util.List;
  * This class is to get the start time and end time of the test run. These values are used to set the time period of
  * Grafana dashboard
  */
-public class TimeLimitGetter {
+public class GrafanaTimeLimitGetter {
 
-    private static final Logger logger = LoggerFactory.getLogger(JenkinsPipelineManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(GrafanaTimeLimitGetter.class);
     private String testplanID;
     private String startTime;
     private String endTime;
@@ -29,7 +47,7 @@ public class TimeLimitGetter {
     private String password =
             ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_PASS);
 
-    public TimeLimitGetter(String testplanID) {
+    public GrafanaTimeLimitGetter(String testplanID) {
         this.testplanID = testplanID;
         setTimePeriod();
     }
@@ -64,9 +82,6 @@ public class TimeLimitGetter {
 
         } catch (Throwable e) {
             logger.error("Error while getting start time and end time of test run" + e);
-
         }
-
-
     }
 }

--- a/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimitGetter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimitGetter.java
@@ -52,7 +52,7 @@ public class TimeLimitGetter {
             Query query = new Query("select first(used), time from mem", dbName);
             QueryResult queryResult = influxDB.query(query);
 
-            InfluxDBResultMapper resultMapper = new InfluxDBResultMapper(); // thread-safe - can be reused
+            InfluxDBResultMapper resultMapper = new InfluxDBResultMapper();
             List<TimeLimits> cpuList = resultMapper.toPOJO(queryResult, TimeLimits.class);
             TimeLimits timeLimits = cpuList.get(cpuList.size() - 1);
             startTime = String.valueOf(timeLimits.getTime().getEpochSecond() * 1000);

--- a/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimitGetter.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimitGetter.java
@@ -1,0 +1,72 @@
+package org.wso2.testgrid.web.operation;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.impl.InfluxDBResultMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.config.ConfigurationContext;
+
+import java.util.List;
+
+/**
+ * This class is to get the start time and end time of the test run. These values are used to set the time period of
+ * Grafana dashboard
+ */
+public class TimeLimitGetter {
+
+    private static final Logger logger = LoggerFactory.getLogger(JenkinsPipelineManager.class);
+    private String testplanID;
+    private String startTime;
+    private String endTime;
+    private String influxUrl = TestGridConstants.HTTP + ConfigurationContext.getProperty
+            (ConfigurationContext.ConfigurationProperties.INFLUXDB_URL);
+    private String username =
+            ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_USER);
+    private String password =
+            ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_PASS);
+
+    public TimeLimitGetter(String testplanID) {
+        this.testplanID = testplanID;
+        setTimePeriod();
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
+    }
+
+    /**
+     * this method wil get the time stamp of the first data point and the last data point with respect to testplan ID
+     */
+    private void setTimePeriod() {
+        try {
+            InfluxDB influxDB = InfluxDBFactory.connect(influxUrl, username, password);
+            String dbName = testplanID;
+            Query query = new Query("select first(used), time from mem", dbName);
+            QueryResult queryResult = influxDB.query(query);
+
+            InfluxDBResultMapper resultMapper = new InfluxDBResultMapper(); // thread-safe - can be reused
+            List<TimeLimits> cpuList = resultMapper.toPOJO(queryResult, TimeLimits.class);
+            TimeLimits timeLimits = cpuList.get(cpuList.size() - 1);
+            startTime = String.valueOf(timeLimits.getTime().getEpochSecond() * 1000);
+            query = new Query("select last(used), time from mem", dbName);
+            queryResult = influxDB.query(query);
+            cpuList = resultMapper.toPOJO(queryResult, TimeLimits.class);
+            timeLimits = cpuList.get(cpuList.size() - 1);
+            endTime = String.valueOf(timeLimits.getTime().getEpochSecond() * 1000);
+
+        } catch (Throwable e) {
+            logger.error("Error while getting start time and end time of test run" + e);
+
+        }
+
+
+    }
+}

--- a/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimits.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimits.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.testgrid.web.operation;
 
 import org.influxdb.annotation.Column;

--- a/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimits.java
+++ b/web/src/main/java/org/wso2/testgrid/web/operation/TimeLimits.java
@@ -1,0 +1,21 @@
+package org.wso2.testgrid.web.operation;
+
+import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Measurement;
+
+import java.time.Instant;
+
+/**
+ * this class is to hold the data returned from influxDB
+ */
+@Measurement(name = "mem")
+public class TimeLimits {
+    @Column(name = "time")
+    private Instant time;
+    @Column(name = "value")
+    private Double value;
+
+    public Instant getTime() {
+        return time;
+    }
+}


### PR DESCRIPTION
**Purpose**

Resolves:#990 

**Goals**

Display the graphs only in the data available time period

**Approach**

Get the first and last time stamps from influxDB database and set the Grafana url to use these time stamps

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
