### PR TITLE
Get performance data from windows

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -406,24 +406,20 @@ public class AWSProvider implements InfrastructureProvider {
                 String awsRegion = ConfigurationContext.getProperty(ConfigurationContext.
                         ConfigurationProperties.AWS_REGION_NAME);
                 String customScript;
+                String scriptInputs = StringUtil.concatStrings(testPlanId, " ",
+                        ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_URL),
+                        " ", ConfigurationContext.getProperty(ConfigurationContext.
+                                ConfigurationProperties.INFLUXDB_USER), " ", ConfigurationContext.getProperty
+                                (ConfigurationContext.ConfigurationProperties.INFLUXDB_PASS));
+
                 if (testPlan.getInfraParameters().toLowerCase(Locale.ENGLISH).contains("windows")) {
-                    customScript = StringUtil.concatStrings(".\\telegraf_setup.sh ", testPlanId, " ",
-                            ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.INFLUXDB_URL),
-                            " ", ConfigurationContext.getProperty(ConfigurationContext.
-                                    ConfigurationProperties.INFLUXDB_USER), " ", ConfigurationContext.getProperty
-                                    (ConfigurationContext.ConfigurationProperties.INFLUXDB_PASS));
+                    customScript = StringUtil.concatStrings(".\\telegraf_setup.sh ", scriptInputs);
                 } else {
                     customScript = StringUtil.concatStrings("/opt/testgrid/agent/init.sh ",
                             deploymentTinkererEP, " ", awsRegion, " ", testPlanId, " aws ", deploymentTinkererUserName,
-                            " ", deploymentTinkererPassword, "\n", "/opt/testgrid/agent/telegraf_setup.sh ", testPlanId,
-                            " ", ConfigurationContext.getProperty(ConfigurationContext.
-                                    ConfigurationProperties.INFLUXDB_URL), " ", ConfigurationContext.getProperty
-                                    (ConfigurationContext.ConfigurationProperties.INFLUXDB_USER),
-                            " ", ConfigurationContext.getProperty(ConfigurationContext.
-                                    ConfigurationProperties.INFLUXDB_PASS));
+                            " ", deploymentTinkererPassword, "\n", "/opt/testgrid/agent/telegraf_setup.sh ",
+                            scriptInputs);
                 }
-                logger.info("\n Custom User data : " + customScript);
-
                 Parameter awsParameter = new Parameter().withParameterKey(expected.getParameterKey()).
                         withParameterValue(customScript);
                 cfCompatibleParameters.add(awsParameter);

--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -337,6 +337,11 @@ Resources:
 
             $Old_Path=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name Path).Path
             Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value ($Old_Path += ';c:\\testgrid\\workspace\\apache-maven-${MavenVersion}\\bin') -Verbose -PassThru|fl
+            cd C:\"Program Files"\telegraf
+            curl http://169.254.169.254/latest/meta-data/instance-id -o instance_id.txt
+            ${CustomUserData}
+            .\telegraf.exe  --service install > service.log
+            while(!(netstat -o | findstr 8086 | findstr ESTABLISHED)) { $val++;Write-Host $val;net stop telegraf;net start telegraf } >> service.log
             </powershell>
             <persist>true</persist>
         SecurityGroups:

--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -182,6 +182,10 @@ Resources:
           FromPort: 9443
           ToPort: 9443
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 8086
+          ToPort: 8086
+          CidrIp: 0.0.0.0/0
     Metadata:
       'AWS::CloudFormation::Designer':
         id: abbdb5e8-f28b-4bc6-8b63-da9595b59c4a


### PR DESCRIPTION
**Purpose**

 Resolves:#992 

**Goals**

collect and visualize product performance data for windows

**Approach**

Using User data in cloud formation script telegraf service is started. This will send data to remote influxDB data source same as in Cent OS. 

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
