### PR TITLE
Fix html structure error in mustache template

### DIFF
--- a/reporting/src/main/resources/templates/summarized_email_report.mustache
+++ b/reporting/src/main/resources/templates/summarized_email_report.mustache
@@ -156,10 +156,12 @@
             <div>{{{gitBuildDetails}}}</div>
             <div>Detailed results: <a href="{{dashboardURL}}">{{jobName}} :: TestGrid Dashboard</a></div>
             <br/><div><strong>Tested Infrastructures:</strong> <br/> <em>{{{testedInfrastructures}}}</em></div><br/>
-            {{#infrastructureErrors}}
             <div class="red-font">
                 <strong>Infrastructure Errors:</strong> <br/>
-                <em>&nbsp;&nbsp;{{key}}</em> - <a href="{{value}}">Download Log File</a><br/>
+            </div><br/>
+            {{#infrastructureErrors}}
+            <div class="red-font">
+                <em>&nbsp;&nbsp;{{key}}</em> - <a href="{{value}}">Download Log File</a>
             </div><br/>
             {{/infrastructureErrors}}
             {{^infrastructureErrors}}


### PR DESCRIPTION
**Purpose**

Fixes the wrong html structure in mustache template.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
