### PR TITLE
Fix showing blank infrastructure culprit in email summary table

### DIFF
--- a/reporting/src/main/resources/templates/summarized_email_report.mustache
+++ b/reporting/src/main/resources/templates/summarized_email_report.mustache
@@ -211,6 +211,13 @@
                                             </td>
                                         {{/.}}
                                     {{/failedInfra}}
+                                    {{^failedInfra}}
+                                        {{#.}}
+                                            <td style="font-weight: bold; background: repeating-radial-gradient(circle, #f0f000, #f3cf3d); border: 1px solid black;">
+                                                Failed on all infrastructure combinations
+                                            </td>
+                                        {{/.}}
+                                    {{/failedInfra}}
                                 </tr>
                                 </table>
                                 <!--</td>-->


### PR DESCRIPTION
**Purpose**
Contains the fix for resolving the blank value shown in summary table in summarized email report

**Goals**

Improve the email template

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes