### PR TITLE
Code refactor to add databucket logic to shell provisioners

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -181,7 +181,7 @@ public final class TestGridUtil {
 
     /**
      * This method builds and returns the parameter string from given properties.
-     *
+     * @deprecated Parameter parsing should only happen via the databuckets
      * @param properties {@link Properties} with required paramters as key value pairs
      * @return the String representation of input paramters
      */

--- a/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/RunTestPlanCommandTest.java
@@ -61,7 +61,6 @@ import org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -171,11 +170,6 @@ public class RunTestPlanCommandTest extends PowerMockTestCase {
         final Path infrastructurePath = Paths.get(testPlan.getInfrastructureRepository());
         assertTrue(Files.exists(infrastructurePath), "Infrastructure provision script failed to run. Dir does not "
                 + "exist: " + infrastructurePath.toString());
-        final Path generatedDeploymentFile = infrastructurePath.resolve("my-deployment.txt");
-        assertTrue(Files.exists(generatedDeploymentFile), "Deployment creation script failed to run. Files does not "
-                + "exist: " + generatedDeploymentFile);
-        String content = new String(Files.readAllBytes(generatedDeploymentFile), StandardCharsets.UTF_8);
-        Assert.assertEquals(content, "Deploy server1\n", "my-deployment.txt file does not contain expected content.");
     }
 
     private void copyWorkspaceArtifacts() throws IOException {

--- a/core/src/test/resources/workspace/deployment/deploy.sh
+++ b/core/src/test/resources/workspace/deployment/deploy.sh
@@ -2,33 +2,20 @@
 
 echo "dummy deployment creation for tests"
 
-while [ "$1" != "" ]; do
-    PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
-    case $PARAM in
-        -h | --help)
-            usage
-            exit
-        ;;
-        --workspace | -w | --output-dir | -o)
-            WORKSPACE=${VALUE}
-            echo Workspace: ${WORKSPACE}
-        ;;
-        *)
-            echo "ERROR: unknown parameter \"$PARAM\""
-            usage
-            exit 1
-        ;;
-    esac
-    shift
-done
+DIR=$2
+echo $DIR
+FILE=${DIR}/testplan-props.properties
 
-INFRA=$WORKSPACE/workspace/infrastructure
-echo $(pwd)
-if [ ! -d $INFRA ]; then
-  echo 'Cannot proceed the deployment. infrastructure dir is empty: ' ${INFRA}
-  exit 1;
+cat $FILE
+PROP_KEY=DEPLOY_VALUE
+
+#----------------------------------------------------------------------
+# getting data from databuckets
+#----------------------------------------------------------------------
+value=`grep -w "$PROP_KEY" ${FILE} | cut -d'=' -f2`
+echo "value is $value"
+if [ "$value" != "deploy_value1" ];then
+    exit 1;
 fi
 
-echo "Deploy server1" > $INFRA/my-deployment.txt
-cat $INFRA/my-deployment.txt
+echo "deployment succesful"

--- a/core/src/test/resources/workspace/infrastructure/infra-provision.sh
+++ b/core/src/test/resources/workspace/infrastructure/infra-provision.sh
@@ -1,27 +1,20 @@
 #!/usr/bin/env bash
 
-echo "dummy infrastructure provisioning for tests"
+DIR=$2
+echo $DIR
+FILE=${DIR}/testplan-props.properties
 
-while [ "$1" != "" ]; do
-    PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
-    case $PARAM in
-        -h | --help)
-            usage
-            exit
-        ;;
-        --workspace | -w | --output-dir | -o)
-            WORKSPACE=${VALUE}
-            echo Workspace: ${WORKSPACE}
-        ;;
-        *)
-            echo "ERROR: unknown parameter \"$PARAM\""
-            usage
-            exit 1
-        ;;
-    esac
-    shift
-done
+PROP_KEY=PROPERTY1
 
-echo 'PWD:' `pwd`
-echo 'We are in:' `uname`
+#----------------------------------------------------------------------
+# getting data from databuckets
+#----------------------------------------------------------------------
+value=`grep -w "$PROP_KEY" ${FILE} | cut -d'=' -f2`
+echo "value is $value"
+if [ "$value" != "value1" ];then
+    exit 1;
+fi
+
+echo -e "\nDEPLOY_VALUE=deploy_value1" >> ${DIR}/testplan-props.properties
+
+echo "infra provision succesful"


### PR DESCRIPTION
**Purpose**
Resolves #1014 

Shell Provisioner and Shell deployer are updated to use the current TestGrid standard of using databuckets to pass parameters between test phases.

**Goals**
Refactor the Shell script execution to the current TestGrid standard

**Approach**

Every Shell script will receive the data bucket location as a parameter, All the parameters are written to properties files located at that location. required parameters are also read from the same files.

**Automation tests**
 Updated the relevant test cases.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
