### PR TITLE
Fix incorrect git build details in email report

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -111,6 +111,11 @@ public class ConfigurationContext {
         AWS_S3_BUCKET_NAME("AWS_S3_BUCKET_NAME"),
 
         /**
+         * AWS S3 artifacts directory used to upload testplan artifacts
+         */
+        AWS_S3_ARTIFACTS_DIR("AWS_S3_ARTIFACTS_DIR"),
+
+        /**
          * WUM Username of TestGrid deployment
          */
         WUM_USERNAME("WUM_USERNAME"),
@@ -194,10 +199,6 @@ public class ConfigurationContext {
          * Password of trustore key file
          */
         TRUSTSTORE_PASSWORD("TRUSTSTORE_PASSWORD");
-
-
-
-
 
         private String propertyName;
 

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -104,5 +104,9 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/EmailReportProcessor.java
@@ -19,12 +19,18 @@
 
 package org.wso2.testgrid.reporting;
 
+import com.amazonaws.auth.PropertiesFileCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
+import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.config.ConfigurationContext;
+import org.wso2.testgrid.common.config.ConfigurationContext.ConfigurationProperties;
 import org.wso2.testgrid.common.config.PropertyFileReader;
 import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
 import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
@@ -39,12 +45,17 @@ import org.wso2.testgrid.reporting.summary.InfrastructureSummaryReporter;
 import org.wso2.testgrid.reporting.surefire.SurefireReporter;
 import org.wso2.testgrid.reporting.surefire.TestResult;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -180,17 +191,16 @@ public class EmailReportProcessor {
         //All the test-plans are executed from the same git revision. Thus git build details are similar across them.
         //Therefore we refer the fist test-plan's git-build details.
         TestPlan testPlan = testPlans.get(0);
-        String outputPropertyFilePath;
-        outputPropertyFilePath =
-                DataBucketsHelper.getInputLocation(testPlan).toAbsolutePath().toString();
-        PropertyFileReader propertyFileReader = new PropertyFileReader();
-        logger.info("Output property file path is : " + outputPropertyFilePath);
-        String gitRevision = propertyFileReader.
-                getProperty(PropertyFileReader.BuildOutputProperties.GIT_REVISION, outputPropertyFilePath)
-                .orElse("");
-        String gitLocation = propertyFileReader.
-                getProperty(PropertyFileReader.BuildOutputProperties.GIT_LOCATION, outputPropertyFilePath)
-                .orElse("");
+        String gitRevision = "";
+        String gitLocation = "";
+
+        Properties properties = getOutputPropertiesFile(testPlan);
+
+        if (!properties.isEmpty()) {
+            gitRevision = properties.getProperty(PropertyFileReader.BuildOutputProperties.GIT_REVISION.toString());
+            gitLocation = properties.getProperty(PropertyFileReader.BuildOutputProperties.GIT_LOCATION.toString());
+        }
+
         if (gitLocation.isEmpty()) {
             logger.error("Git location received as null/empty for test plan with id " + testPlan.getId());
             stringBuilder.append("Git location: Unknown!");
@@ -276,5 +286,43 @@ public class EmailReportProcessor {
             }
         }
         return erroneousInfraMap;
+    }
+
+    /**
+     * Returns the Properties in output.properties located in AWS S3 bucket.
+     *
+     * @param testPlan test plan to read the outputs from
+     * @return Properties in output.properties
+     * @throws IOException if exception occurs when loading properties
+     */
+    private Properties getOutputPropertiesFile (TestPlan testPlan) {
+        String testPlanDirName = TestGridUtil.deriveTestPlanDirName(testPlan);
+        String productName = testPlan.getDeploymentPattern().getProduct().getName();
+        Path configFilePath = TestGridUtil.getConfigFilePath();
+        String bucketKey = ConfigurationContext.getProperty(ConfigurationProperties.AWS_S3_BUCKET_NAME);
+        String awsBucketRegion = ConfigurationContext.getProperty(ConfigurationProperties.AWS_REGION_NAME);
+
+        String outputPropertyFilePath = Paths.get(
+                ConfigurationContext.getProperty(ConfigurationProperties.AWS_S3_ARTIFACTS_DIR),
+                TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants.TESTGRID_BUILDS_DIR,
+                testPlanDirName, DataBucketsHelper.DATA_BUCKET_OUTPUT_DIR_NAME,
+                TestGridConstants.TESTGRID_SCENARIO_OUTPUT_PROPERTY_FILE).toString();
+        logger.info("Output property file path in S3 bucket is : " +
+                Paths.get(bucketKey, outputPropertyFilePath).toString());
+
+        AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                .withRegion(awsBucketRegion)
+                .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
+                .build();
+        S3Object s3object = s3Client.getObject(bucketKey, outputPropertyFilePath);
+        Properties properties = new Properties();
+
+        try (InputStreamReader inputStreamReader = new InputStreamReader(
+                s3object.getObjectContent(), StandardCharsets.UTF_8)) {
+            properties.load(inputStreamReader);
+        } catch (IOException e) {
+            logger.error("Error while reading properties from output.properties.", e);
+        }
+        return properties;
     }
 }

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/BaseClass.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/BaseClass.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -71,7 +72,7 @@ import static org.mockito.Mockito.when;
 /**
  * Base test class for reporting module.
  */
-public class BaseClass {
+public class BaseClass extends PowerMockTestCase {
 
     private static final String TESTGRID_HOME = Paths.get("target", "testgrid-home").toString();
     private static final Logger logger = LoggerFactory.getLogger(BaseClass.class);


### PR DESCRIPTION
**Purpose**

Contains changes related to retrieving the build details from output.properties locates in S3.
Resolves #1002

**Goals**

To display the correct git revision and location in the summarized email report.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes