### PR TITLE
 Remove 'builds' directory from unnecessary locations

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -39,20 +39,16 @@ public class TestGridConstants {
     public static final String SCENARIO_RESULTS_FILTER_PATTERN = "*.{log,jtl}";
 
     public static final String TESTGRID_LOG_FILE_NAME = "testgrid.log";
-    public static final String TESTGRID_LOGS_DIR = "logs";
     public static final String TESTGRID_COMPRESSED_FILE_EXT = ".zip";
 
     public static final String TESTRUN_LOG_FILE_NAME = "test-run.log";
     public static final String TRUNCATED_TESTRUN_LOG_FILE_NAME = "truncated-test-run.log";
-    public static final String TEST_INTEGRATION_LOG_FILE_NAME = "TestSuite.txt";
-    public static final String TESTGRID_BUILDS_DIR = "builds";
     public static final String PRODUCT_TEST_PLANS_DIR = "test-plans";
     public static final String FILE_SEPARATOR = "/";
     public static final String HIDDEN_FILE_INDICATOR = ".";
     public static final String PARAM_SEPARATOR = "_";
     public static final String TESTRUN_NUMBER_PREFIX = "run";
 
-    public static final String WORKSPACE = "workspace";
     public static final String TESTGRID_JOB_DIR = "jobs";
     public static final String TESTGRID_HOME_ENV = "TESTGRID_HOME";
     public static final String TESTGRID_HOME_SYSTEM_PROPERTY = "testgrid.home";

--- a/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/S3StorageUtil.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
  */
 public final class S3StorageUtil {
 
+    private static final String TESTGRID_BUILDS_DIR = "builds";
     /**
      * Returns the path of the test-run log file in S3 bucket.
      * <p>
@@ -56,8 +57,8 @@ public final class S3StorageUtil {
         String productName = testPlan.getDeploymentPattern().getProduct().getName();
         String artifactsDir = ConfigurationContext.
                 getProperty(ConfigurationContext.ConfigurationProperties.AWS_S3_ARTIFACTS_DIR);
-        return Paths.get(artifactsDir, TestGridConstants.TESTGRID_JOB_DIR, productName,
-                TestGridConstants.TESTGRID_BUILDS_DIR, testPlan.getId()).toString();
+        return Paths.get(artifactsDir, TestGridConstants.TESTGRID_JOB_DIR, productName, TESTGRID_BUILDS_DIR,
+                testPlan.getId()).toString();
     }
 
     /**

--- a/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/TestGridUtil.java
@@ -300,7 +300,7 @@ public final class TestGridUtil {
      * @return log file path
      */
     public static String deriveTestGridLogFilePath(String productName, String logFileName) {
-        return Paths.get(TestGridConstants.TESTGRID_JOB_DIR, productName, TestGridConstants.TESTGRID_BUILDS_DIR,
+        return Paths.get(TestGridConstants.TESTGRID_JOB_DIR, productName,
                 logFileName).toString();
     }
 
@@ -318,8 +318,7 @@ public final class TestGridUtil {
     }
 
     public static Path getTestScenarioArtifactPath(TestScenario testScenario) {
-        return Paths.get(testScenario.getTestPlan().getWorkspace(),
-                TestGridConstants.TESTGRID_BUILDS_DIR, testScenario.getDir());
+        return Paths.get(testScenario.getTestPlan().getWorkspace(), testScenario.getDir());
     }
 
     /**

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/TestReportEngine.java
@@ -23,7 +23,6 @@ import org.wso2.testgrid.common.DeploymentPattern;
 import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestCase;
-import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.TestScenario;
 import org.wso2.testgrid.common.exception.TestGridException;
@@ -801,7 +800,7 @@ public class TestReportEngine {
         String htmlString = renderer.render(EMAIL_REPORT_MUSTACHE, perSummariesMap);
 
         // Write to HTML file
-        Path reportPath = Paths.get(workspace, TestGridConstants.TESTGRID_BUILDS_DIR, TESTGRID_EMAIL_REPORT_NAME);
+        Path reportPath = Paths.get(workspace, TESTGRID_EMAIL_REPORT_NAME);
         writeHTMLToFile(reportPath, htmlString);
         return Optional.of(reportPath);
     }
@@ -935,8 +934,7 @@ public class TestReportEngine {
         String htmlString = renderer.render(SUMMARIZED_EMAIL_REPORT_MUSTACHE, results);
 
         // Write to HTML file
-        Path reportPath = Paths.get(workspace, TestGridConstants.TESTGRID_BUILDS_DIR,
-                TESTGRID_SUMMARIZED_EMAIL_REPORT_NAME);
+        Path reportPath = Paths.get(workspace, TESTGRID_SUMMARIZED_EMAIL_REPORT_NAME);
         writeHTMLToFile(reportPath, htmlString);
         Path reportParentPath = reportPath.getParent();
 


### PR DESCRIPTION
**Purpose**
According to the current folder structure, the builds directory is only needed in the S3 bucket. When running the jobs, TestGrid doesn't have to create 'builds' directory and store the data there. The pipeline will sync the data directly to the builds directory in S3.
This PR will remove unnecessary builds directories.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
