### PR TITLE
Set Java executable path to PATH variable

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -284,7 +284,7 @@ Resources:
           ln -fs apache-maven-${MavenVersion} maven
           echo 'export MAVEN_OPTS="-Xmx2048m -Xms256m"' >> /etc/environment
           echo 'export M3_HOME=/opt/wso2/workspace/maven' >> /etc/environment
-          echo PATH=/opt/wso2/workspace/maven/bin/:$PATH >> /etc/environment
+          echo PATH=$JAVA_HOME/bin:/opt/wso2/workspace/maven/bin/:$PATH >> /etc/environment
 
           source /etc/environment
 


### PR DESCRIPTION
**Purpose**

Seting Java executable path to PATH variable

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes