### PR TITLE
Add packer resources to create AMIs.

### DIFF
--- a/packer/resource-ami/config.sh
+++ b/packer/resource-ami/config.sh
@@ -1,0 +1,367 @@
+#!/bin/bash
+
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#=== FUNCTION ==================================================================
+# NAME: echoLogo
+# DESCRIPTION: Print the WSO2 TestGrid Logo.
+#===============================================================================
+function echoLogo() {
+	echo "__          __ ____  ____ ___    _______        _    _____      _     _ "
+	echo "\ \        / / ____|/ __ \__ \  |__   __|      | |  / ____|    (_)   | |"
+	echo " \ \  /\  / / (___ | |  | | ) |    | | ___  ___| |_| |  __ _ __ _  __| |"
+	echo "  \ \/  \/ / \___ \| |  | |/ /     | |/ _ \/ __| __| | |_ |  __| |/ _  |"
+	echo "   \  /\  /  ____) | |__| / /_     | |  __/\__ \ |_| |__| | |  | | (_| |"
+	echo "    \/  \/  |_____/ \____/____|    |_|\___||___/\__|\_____|_|  |_|\____|"
+	echo ""
+	echo "                            AMI-Creation-Tool                           "
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installPackage
+# DESCRIPTION: Install passed package using the package installer based on OS.
+# PARAMETER 1: Package (Or set of packages) to install
+#===============================================================================
+function installPackage() {
+    package=$1;
+    echo "installing $package"
+    case "$AMI_OS" in
+    Ubuntu)
+    sudo apt -y install $package
+    ;;
+    CentOS)
+    sudo yum -y install $package
+    ;;
+    esac
+}
+
+#=== FUNCTION ==================================================================
+# NAME: showMessage
+# DESCRIPTION: Display message with highlighting.
+# PARAMETER 1: Message to display
+#===============================================================================
+function showMessage() {
+	message=$1;
+	echo ""
+    echo ""
+	echo "*****************************************************************"
+	echo "$message"
+	echo ""
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installJDKs
+# DESCRIPTION: Install Java Development Kits. (ORACLE JDK8 and OPEN JDK8)
+#===============================================================================
+function installJDKs() {
+	case "$AMI_OS" in
+    Ubuntu)
+	#Installing ORACLE_JAVA8
+	echo "Installing ORACLE_JAVA8"
+	sudo add-apt-repository -y ppa:webupd8team/java	
+	sudo apt-get update -y
+	echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+	echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+	sudo apt-get -y install oracle-java8-installer
+	#Installing OpenJDK8
+	echo "Installing OPENJDK 8"
+	sudo add-apt-repository -y ppa:openjdk-r/ppa
+	sudo apt-get update -y
+	sudo apt-get -y install openjdk-8-jdk
+	#Download JCE policies
+	echo "Installing JCE policies (Presumed agreement on Oracle license at https://www.oracle.com/technetwork/java/javase/terms/license/index.html)"
+	wget -v --header "Cookie: oraclelicense=oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
+	sudo mv UnlimitedJCEPolicyJDK8/local_policy.jar /usr/java/jdk1.8.0_181-amd64/jre/lib/security/
+	sudo mv UnlimitedJCEPolicyJDK8/US_export_policy.jar /usr/java/jdk1.8.0_181-amd64/jre/lib/security/
+	;;
+
+    CentOS)
+	#Installing ORACLE_JAVA8
+	echo "Installing ORACLE_JAVA8"
+	sudo yum localinstall -y resources/jdk-8u181-linux-x64.rpm
+	#Installing OpenJDK8
+	echo "Installing OPENJDK 8"
+	sudo yum install -y java-1.8.0-openjdk-devel
+ 	#Download JCE policies
+	echo "Installing JCE policies (Presumed agreement on Oracle license at https://www.oracle.com/technetwork/java/javase/terms/license/index.html)"
+	sudo yum install -y wget
+	wget -v --header "Cookie: oraclelicense=oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
+	unzip jce_policy-8.zip -d .
+	sudo mv UnlimitedJCEPolicyJDK8/local_policy.jar /usr/java/jdk1.8.0_181-amd64/jre/lib/security/
+	sudo mv UnlimitedJCEPolicyJDK8/US_export_policy.jar /usr/java/jdk1.8.0_181-amd64/jre/lib/security/
+	;;
+    esac
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installMaven
+# DESCRIPTION: Install Maven.
+#===============================================================================
+function installMaven() {
+	installPackage maven
+	mvn --version
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installGit
+# DESCRIPTION: Install Git client.
+#===============================================================================
+function installGit() {
+	installPackage git
+	git --version
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installSQLclientsAndTools.
+# DESCRIPTION: Install SQL clients and tools.
+# (MSSQL client, MySQL client, Mariadb client, Oracle client)
+#===============================================================================
+function installSQLclientsAndTools() {
+    installPackage "unzip zip"
+    case "$AMI_OS" in
+    Ubuntu)
+	#Add MSSQL repositories
+	curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
+        curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+	sudo apt-get update -y
+	#Install mysql client, prostgres client and mssql tools
+	echo "Agreeing on EULAs of the libs; unzip, zip, alien, postgresql-client, mysql-client and continuing installation."
+	sudo env ACCEPT_EULA=Y
+	sudo env DEBIAN_FRONTEND="noninteractive"
+	sudo apt-get install -y alien
+	sudo apt-get install -y postgresql-client
+	sudo apt-get install -y mysql-client
+
+	#Install mariadb client
+	sudo apt-get install -y mariadb-client
+	sudo ln -sfn /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd
+	sudo ln -sfn /opt/mssql-tools/bin/bcp /usr/bin/bcp
+
+	sudo alien -i resources/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm
+	sudo alien -i resources/oracle-instantclient12.2-sqlplus-12.2.0.1.0-1.x86_64.rpm
+	sudo ldconfig
+	;;
+     CentOS)
+	#Add MSSQL repositories
+	echo "Adding MSSQL repositories"
+	sudo su -c "curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo"
+	#Installing tools
+	sudo ACCEPT_EULA=Y yum install -y mssql-tools
+	sudo yum -y install unixODBC-devel mysql postgresql
+	#Installing Oracle
+	sudo yum -y install resources/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm
+	sudo yum -y install resources/oracle-instantclient12.2-sqlplus-12.2.0.1.0-1.x86_64.rpm
+	#Add symbolic links
+	sudo sh -c "echo /usr/lib/oracle/12.2/client64/lib > /etc/ld.so.conf.d/oracle-instantclient.conf"
+	sudo ldconfig
+	;;
+    esac
+}
+
+#=== FUNCTION ==================================================================
+# NAME: downloadJDBCDrivers
+# DESCRIPTION: Download JDBC drivers required to configure the product.
+# (mssql, mariadb, mysql, Oracle, postgresql clients)
+# Note: Oracle client is received from resources directory (Since user-agreement
+# -has to be done when downloading)
+#===============================================================================
+function downloadJDBCDrivers() {
+	mkdir sql-drivers
+	curl http://central.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/6.4.0.jre8/mssql-jdbc-6.4.0.jre8.jar --output sql-drivers/sqlserver-ex.jar
+	curl https://downloads.mariadb.com/Connectors/java/connector-java-2.2.3/mariadb-java-client-2.2.3.jar --output sql-drivers/mariadb.jar
+	curl http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.44/mysql-connector-java-5.1.44.jar --output sql-drivers/mysql.jar
+	curl https://jdbc.postgresql.org/download/postgresql-42.2.1.jar --output sql-drivers/postgres.jar
+	#Copy “ojdbc8.jar” from resources directory to sql-drivers directory
+	mv resources/ojdbc8.jar sql-drivers/
+	echo "JDBC drivers are copied to 'sql-drivers' directory."
+	ls sql-drivers
+	sudo mv sql-drivers /opt/testgrid/sql-drivers
+}
+
+#=== FUNCTION ==================================================================
+# NAME: updatePathVariable
+# DESCRIPTION: Update path variable with appending MSSQL tools & Oracle client
+#===============================================================================
+function updatePathVariable() {
+	 case "$AMI_OS" in
+    Ubuntu)
+	echo "updating path variable..."
+	#Todo: verify the path update for Ubuntu.
+	#echo 'PATH=/opt/mssql-tools/bin:/usr/lib/oracle/12.2/client64/bin:$PATH' | sudo tee --append /etc/environment	
+	;;
+    CentOS)
+	sudo su -c "echo 'pathmunge /opt/mssql-tools/bin:/usr/lib/oracle/12.2/client64/bin' > /etc/profile.d/testgrid-libs.sh"
+	sudo chmod +x /etc/profile.d/ree.sh
+	. /etc/profile
+	;;
+	esac
+}
+
+#=== FUNCTION ==================================================================
+# NAME: addEnvVariables
+# DESCRIPTION: Adding environmental variables to JDKS
+#===============================================================================
+function addEnvVariables() {
+    sudo su -c "echo 'ORACLE_JDK8=/usr/java/jdk1.8.0_181-amd64' > /etc/environment"
+    sudo su -c "echo 'OPEN_JDK8=/usr/lib/jvm/java-1.8.0-openjdk-amd64' >> /etc/environment"
+    source /etc/environment
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installTinkererAgent
+# DESCRIPTION: Install TestGrid Tinkerer agent to AMI.
+#===============================================================================
+function installTinkererAgent() {
+	sudo unzip resources/agent.zip -d /opt/testgrid/
+	rm resources/agent.zip
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installPerfMonitoringArtifacts
+# DESCRIPTION: Install artifacts relates to performance monitoring to AMI.
+#===============================================================================
+function installPerfMonitoringArtifacts() {
+	mv resources/perf_monitoring_artifacts.zip resources/agent.zip	#Need to unzip to same Tinker agent directory
+	sudo unzip resources/agent.zip -d /opt/testgrid/
+}
+
+#=== FUNCTION ==================================================================
+# NAME: installPython
+# DESCRIPTION: Install Python (Download python from official FTP server and build)
+#===============================================================================
+function installPython() {
+	python_version=3.6.5	#We can use any version available in python.org ftp server
+    echo "Installing dependencies for python"
+	case "$AMI_OS" in
+    Ubuntu)
+	sudo apt-get install -y build-essential #Adding gcc which is dependency to build python
+	sudo apt install -y zlib1g-dev		    #Dependency for python installing
+	;;
+    CentOS)
+	sudo yum groupinstall -y "Development Tools"
+	sudo yum install -y zlib-devel	        #Dependency for python installing
+	;;
+    esac
+
+    installPackage "bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel"
+    wget https://www.python.org/ftp/python/$python_version/Python-$python_version.tgz
+    tar -xvf Python-$python_version.tgz
+    cd Python-$python_version
+	./configure
+    sudo make
+	sudo make install
+	cd ..
+	sudo rm -r Python-$python_version
+	sudo rm Python-$python_version.tgz
+    #Installing necessary python libs (All python lib installations should go here..)
+    #pip defaults to installing Python packages to a system directory (such as /usr/local/lib/python3.4). This requires root access.
+    #"--user" makes pip install packages in your home directory instead, which doesn't require any special privileges.
+    pip3 install --user virtualenv
+}
+
+#=== FUNCTION ==================================================================
+# NAME: showInstallations
+# DESCRIPTION: Verify installations in the AMI.
+#===============================================================================
+function showInstallations() {
+	echo "----git----"
+	git --version	
+	echo "----python----"
+	python3.6 -V
+	echo	
+	echo "----maven----"
+	mvn -v
+	echo	
+	echo "----mysql (MySQL DB-Client)----" 
+	mysql --version
+	echo
+	echo "----sqlcmd (MSSQL DB-Client)----"
+	sqlcmd | head -3
+	echo
+	echo "----sqlplus (Oracle DB-Client)----"
+	sqlplus -version
+	echo
+	echo "----postgre (Postgre DB-Client)----"
+	psql --version
+	echo
+	echo "----JDKs (all versions)----"
+    case "$AMI_OS" in
+    Ubuntu)
+	sudo update-alternatives --list java 
+	;;
+    CentOS)
+	sudo update-alternatives --display java #list is only working in ubuntu.
+	;;
+    esac
+	echo
+	echo "----PATH variable----"
+	echo $PATH
+	echo
+	echo "----agent directory (/opt/testgrid/)----"
+	ls /opt/testgrid/agent/
+	echo
+	echo "----JDBC drivers directory (/opt/testgrid/sql-drivers)----"
+	ls /opt/testgrid/sql-drivers
+	echo
+	echo "----Environment Variables----"
+	echo OracleJDK8 env= $ORACLE_JDK8
+	echo OpenJDK8 env=$OPEN_JDK8
+	echo
+}
+
+
+case "$AMI_OS" in
+    Ubuntu)
+	showMessage "Starting Ubuntu configuration steps.."
+        ;;
+    CentOS)
+	showMessage "Starting CentOS configuration steps.."
+        ;;
+    Windows)
+	showMessage "Windows configurations steps are not added yet."
+	exit;
+        ;;
+    *)
+        echo "$AMI_OS is not a valid choice."
+	exit;
+        ;;
+esac
+
+echoLogo;
+sudo mkdir /opt/testgrid;
+sudo mkdir /opt/wso2;
+showMessage "1.Installing JDKs"
+installJDKs;
+showMessage "2.Installing SQL-clients and Tools"
+installSQLclientsAndTools;
+showMessage "3.Downloading JDBCDrivers"
+downloadJDBCDrivers;
+showMessage "4.Installing Maven"
+installMaven
+showMessage "5.Installing Git"
+installGit
+showMessage "6.Updating PathVariable"
+updatePathVariable;
+showMessage "7.Installing Tinkerer agent"
+installTinkererAgent
+showMessage "8.Installing Python"
+installPython
+showMessage "9.Installing Performance monitoring artifacts"
+installPerfMonitoringArtifacts
+showMessage "10. Adding environment variables"
+addEnvVariables
+showMessage "11.Showing installations"
+showInstallations
+sudo rm -f -r *

--- a/packer/resource-ami/init.sh
+++ b/packer/resource-ami/init.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ubuntu_ami="ami-0584bcdcc2b2a82e9"
+ubuntu_os_version="16.04"
+ubuntu_ssh_username="ubuntu"
+
+centos_ami="ami-9887c6e7"
+centos_os_version="7.4"
+centos_ssh_username="centos"
+
+packer_file="packer-conf.json"
+
+#=== FUNCTION ==================================================================
+# NAME: startPacker
+# DESCRIPTION: Validate config json and start packer.
+#===============================================================================
+function startPacker() {
+	packer validate packer-conf.json
+	packer build packer-conf.json
+}
+
+#=== FUNCTION ==================================================================
+# NAME: checkIfExists
+# DESCRIPTION: Check if the provided file exists.
+# PARAMETER 1: File to check 
+#===============================================================================
+function checkIfExists() {
+	file=$1
+	if [ -f "$file" ]
+	then
+		echo "$file found."
+		return 0
+	else
+		echo "$file not found."
+		return 1
+	fi
+}
+
+#=== FUNCTION ==================================================================
+# NAME: checkResources
+# DESCRIPTION: Check if the resources given in resource.txt exists.
+#===============================================================================
+function checkResources() {
+	notFound=0	
+	while read F  ; do
+		checkIfExists resources/$F
+		boolExist=$?
+		if [ "$boolExist" == 1 ]
+		then
+			notFound=1
+		fi		
+	done <resources/resources.txt
+	if [ "$notFound" = "1" ]
+	then
+		echo "Resources are missing.. Can not continue."
+		exit;
+	else 
+		creator_ip=$(ip route get 1.1.1.1 | awk '{print $NF; exit}')
+		export PACKER_AMI_CREATOR_IP=$creator_ip
+		startPacker;
+	fi
+}	
+
+#=== FUNCTION ==================================================================
+# NAME: downloadResourcesFromS3
+# DESCRIPTION: Download relevant artifacts from TestGrid S3 bucket. 
+# The function will download Unix resources and OS-specific resources.
+#===============================================================================
+function downloadResourcesFromS3() {
+	echo "Downloading $os AMI resources from S3 (testgrid-resources/packer directory)"
+	aws s3 sync s3://testgrid-resources/packer/Common resources/
+	aws s3 sync s3://testgrid-resources/packer/Unix resources/
+	aws s3 sync s3://testgrid-resources/packer/$os resources/
+}
+
+#Check if Packer, AWS CLI exists
+command -v packer >/dev/null 2>&1 || { echo >&2 "Packer was not found. Please install Packer first."; exit 1; }
+command -v aws >/dev/null 2>&1 || { echo >&2 "AWS CLI was not found. Please install AWS CLI first."; exit 1; }
+
+echo "Select the OS of the AMI:"
+echo "        1 - Ubuntu $ubuntu_os_version"
+echo "        2 - CentOS $centos_os_version"
+echo "        3 - Windows 2016"
+read os;
+case "$os" in
+    1)
+	os="Ubuntu"
+	export PACKER_SOURCE_AMI_ID=$ubuntu_ami
+	export PACKER_SSH_USERNAME=$ubuntu_ssh_username
+	export PACKER_SOURCE_OS=$os
+	export PACKER_SOURCE_OS_VERSION=$ubuntu_os_version
+	downloadResourcesFromS3
+	checkResources
+        ;;
+    2)
+	os="CentOS"
+	export PACKER_SOURCE_AMI_ID=$centos_ami
+	export PACKER_SSH_USERNAME=$centos_ssh_username
+	export PACKER_SOURCE_OS=$os
+	export PACKER_SOURCE_OS_VERSION=$centos_os_version
+	downloadResourcesFromS3
+	checkResources
+        ;;
+    3)
+	os="Windows"
+	echo "Not implemented yet."
+        ;;
+    *)
+        echo "$os is not a valid choice. Please enter the number"
+        ;;
+esac

--- a/packer/resource-ami/init.sh
+++ b/packer/resource-ami/init.sh
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ubuntu_ami="ami-0584bcdcc2b2a82e9"
 ubuntu_os_version="16.04"
 ubuntu_ssh_username="ubuntu"
+ubuntu_source_ami_filter_name="ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+ubuntu_source_ami_filter_owner="099720109477"
 
-centos_ami="ami-9887c6e7"
 centos_os_version="7.4"
 centos_ssh_username="centos"
-
+centos_source_ami_filter_name="CentOS Linux 7 x86_64 HVM EBS ENA*"
+centos_source_ami_filter_owner="679593333241"
 packer_file="packer-conf.json"
 
 #=== FUNCTION ==================================================================
@@ -29,6 +30,7 @@ packer_file="packer-conf.json"
 # DESCRIPTION: Validate config json and start packer.
 #===============================================================================
 function startPacker() {
+    echo "Starting packer.."
 	packer validate packer-conf.json
 	packer build packer-conf.json
 }
@@ -57,7 +59,7 @@ function checkIfExists() {
 function checkResources() {
 	notFound=0	
 	while read F  ; do
-		checkIfExists resources/$F
+	    checkIfExists resources/$F
 		boolExist=$?
 		if [ "$boolExist" == 1 ]
 		then
@@ -99,19 +101,21 @@ read os;
 case "$os" in
     1)
 	os="Ubuntu"
-	export PACKER_SOURCE_AMI_ID=$ubuntu_ami
 	export PACKER_SSH_USERNAME=$ubuntu_ssh_username
 	export PACKER_SOURCE_OS=$os
 	export PACKER_SOURCE_OS_VERSION=$ubuntu_os_version
+	export PACKER_SOURCE_AMI_FILTER_NAME=$ubuntu_source_ami_filter_name
+	export PACKER_SOURCE_AMI_FILTER_OWNER=$ubuntu_source_ami_filter_owner
 	downloadResourcesFromS3
 	checkResources
         ;;
     2)
 	os="CentOS"
-	export PACKER_SOURCE_AMI_ID=$centos_ami
 	export PACKER_SSH_USERNAME=$centos_ssh_username
 	export PACKER_SOURCE_OS=$os
 	export PACKER_SOURCE_OS_VERSION=$centos_os_version
+    export PACKER_SOURCE_AMI_FILTER_NAME=$centos_source_ami_filter_name
+	export PACKER_SOURCE_AMI_FILTER_OWNER=$centos_source_ami_filter_owner
 	downloadResourcesFromS3
 	checkResources
         ;;

--- a/packer/resource-ami/packer-conf.json
+++ b/packer/resource-ami/packer-conf.json
@@ -2,33 +2,42 @@
     "variables": {
         "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
         "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-	"source_ami_id":  "{{env `PACKER_SOURCE_AMI_ID`}}",
-	"os": "{{env `PACKER_SOURCE_OS`}}",
-	"os_version": "{{env `PACKER_SOURCE_OS_VERSION`}}",
-	"ssh_user_name": "{{env `PACKER_SSH_USERNAME`}}",
-	"ami_creator_ip": "{{env `PACKER_AMI_CREATOR_IP`}}",
+        "os": "{{env `PACKER_SOURCE_OS`}}",
+        "os_version": "{{env `PACKER_SOURCE_OS_VERSION`}}",
+        "ssh_user_name": "{{env `PACKER_SSH_USERNAME`}}",
+        "ami_creator_ip": "{{env `PACKER_AMI_CREATOR_IP`}}",
+        "source_ami_filter_name": "{{env `PACKER_SOURCE_AMI_FILTER_NAME`}}",
+        "source_ami_filter_owner": "{{env `PACKER_SOURCE_AMI_FILTER_OWNER`}}",
         "region": "us-east-1"
     },
     "builders": [
         {
             "access_key": "{{user `aws_access_key`}}",
             "ami_name": "TestGrid-{{user `os`}}-{{user `os_version`}}-{{isotime \"2006-01-02\"}}-{{timestamp}}",
-            "instance_type": "t2.micro",
+            "instance_type": "t2.medium",
             "region": "us-east-1",
             "secret_key": "{{user `aws_secret_key`}}",
-            "source_ami": "{{user `source_ami_id`}}",
+            "source_ami_filter": {
+              "filters": {
+                "virtualization-type": "hvm",
+                "name": "{{user `source_ami_filter_name`}}",
+                "root-device-type": "ebs"
+              },
+              "owners": ["{{user `source_ami_filter_owner`}}"],
+              "most_recent": true
+            },
             "ssh_username": "{{user `ssh_user_name`}}",
             "type": "amazon-ebs",
-	    "run_tags" : {
+	        "run_tags" : {
                 "OS" : "{{user `os`}}",
                 "Tool" : "Packer"
             },
-	    "tags": {
-        	"OS": "{{user `os`}}",
-		"OSVersion": "{{user `os_version`}}",
-		"Creator": "{{user `ami_creator_ip`}}",
-        	"Timestamp": "{{timestamp}}",
-		"AGENT_READY": "true"
+            "tags": {
+                "OS": "{{user `os`}}",
+                "OSVersion": "{{user `os_version`}}",
+                "Creator": "{{user `ami_creator_ip`}}",
+                "Timestamp": "{{timestamp}}",
+                "AGENT_READY": "true"
       	    }
         }
     ],
@@ -41,9 +50,9 @@
 	},
         {
             "type": "shell",
-	    "environment_vars": [
+	        "environment_vars": [
                                   "AMI_OS={{user `os`}}"
-                                ],
+            ],
             "script": "./config.sh"
         }
     ]

--- a/packer/resource-ami/packer-conf.json
+++ b/packer/resource-ami/packer-conf.json
@@ -1,0 +1,50 @@
+{
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+	"source_ami_id":  "{{env `PACKER_SOURCE_AMI_ID`}}",
+	"os": "{{env `PACKER_SOURCE_OS`}}",
+	"os_version": "{{env `PACKER_SOURCE_OS_VERSION`}}",
+	"ssh_user_name": "{{env `PACKER_SSH_USERNAME`}}",
+	"ami_creator_ip": "{{env `PACKER_AMI_CREATOR_IP`}}",
+        "region": "us-east-1"
+    },
+    "builders": [
+        {
+            "access_key": "{{user `aws_access_key`}}",
+            "ami_name": "TestGrid-{{user `os`}}-{{user `os_version`}}-{{isotime \"2006-01-02\"}}-{{timestamp}}",
+            "instance_type": "t2.micro",
+            "region": "us-east-1",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "source_ami": "{{user `source_ami_id`}}",
+            "ssh_username": "{{user `ssh_user_name`}}",
+            "type": "amazon-ebs",
+	    "run_tags" : {
+                "OS" : "{{user `os`}}",
+                "Tool" : "Packer"
+            },
+	    "tags": {
+        	"OS": "{{user `os`}}",
+		"OSVersion": "{{user `os_version`}}",
+		"Creator": "{{user `ami_creator_ip`}}",
+        	"Timestamp": "{{timestamp}}",
+		"AGENT_READY": "true"
+      	    }
+        }
+    ],
+
+    "provisioners": [
+	{
+	    "type": "file",
+	    "source": "resources",
+	    "destination": "/home/{{user `ssh_user_name`}}/"
+	},
+        {
+            "type": "shell",
+	    "environment_vars": [
+                                  "AMI_OS={{user `os`}}"
+                                ],
+            "script": "./config.sh"
+        }
+    ]
+}


### PR DESCRIPTION
**Purpose**
Currently the TestGrid AMIs are created and updated manually. This PR contains the necessary resources to use packer and automate AMI creation.
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
Fixes #625 #846 #853

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Documentation**

Add/Modify/Remove content from existing Testgrid AMIs

If there is a requirement to add/remove/modify an AMI of the TestGrid, you need to do the following steps.

1. Create an instance of the OS you need from OpenStack (TestGrid has its own account)
2. Try out how to do the configuration from a script avoiding(solving) external user-inputs. 
    Ex 1: Say you need to download a lib from internet and install it in CentOS;
       You can use CURL and download the file.
       You can use sudo yum install and install the file. (But this will request a user-input which has to be answered “Y”)
       To solve that, you can use sudo yum -y install <file>

     Ex 2: Let’s say the file that you need to download is not directly accessible, you have to go to their website, login / fill a form and then only the file is available;
        In TestGrid S3, there are packer resource directories that can be used to this kind of requirements. What you can do is, download the lib/file to your local machine using your browser and then upload to the relevant packer resource directory in S3.
Packer resource directories are as;
Ubuntu →  resources only used when configuring Ubuntu
CentOS → resources only used when configuring CentOS
Unix → resources used when configuring both Ubuntu & CentOS, and other Linux dists
Windows →  resource used when configuring Windows
Common → resource used across all the OSes.
When creating the AMI, all the relevant S3 directories (eg: if CentOS ⇒ Common, Unix, CentOS directories) will copied to the environment, so that from the script you can directly refer the files (Files will be copied to home/<ssh_user>/resource/)

	So you can call sudo yum -y localinstall resource/<file>.rpm

3. Once you have the script that can automatically configure the environment, create a EC2 instance from the existing TestGrid AMI.
Run your script there (you may have to manually scp the files which you hope to add to S3 in this case) and verify its successful.

4. Add the changes into the packer resource→ config.sh file.
	config.sh file is written for both Ubuntu and CentOS cases. So you have to add the commands to relevant case.
	If you have added resources to S3 directories and hoping to use, then you have to update the resources.txt file in relevant OS-specific directory in S3. (At AMI creation, it will check all the resources listed in the resource.txt are available before continuing as a verification step)

5. Run init.sh

<!-- Provide high-level details about the samples related to this feature -->

