### PR TITLE
Test plan data cleanup

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -125,7 +125,7 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
 
     @Transient
     private String workspace = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
-            "sample-product").toString();
+            "sample-").toString();
 
     /**
      * Returns the status of the infrastructure.

--- a/core/src/main/java/org/wso2/testgrid/core/command/CleanUpCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/CleanUpCommand.java
@@ -18,17 +18,20 @@
 
 package org.wso2.testgrid.core.command;
 
-
 import org.apache.commons.io.IOUtils;
 import org.apache.http.entity.ContentType;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.testgrid.common.HostValidator;
+import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.exception.CommandExecutionException;
+import org.wso2.testgrid.common.util.S3StorageUtil;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.dao.TestGridDAOException;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
 
 import java.io.IOException;
@@ -42,6 +45,7 @@ import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -51,8 +55,9 @@ import javax.net.ssl.X509TrustManager;
 
 import static org.apache.http.protocol.HTTP.USER_AGENT;
 
+
 /**
- * this class is for data purging. This class will be used to purge testplans, grafana data sources and keep only a
+ * This class is for data purging. This class will be used to purge testplans, grafana data sources and keep only a
  * specified number of testplans and grafana data sources for each infra combination in each job
  * It will not delete builds that are tagged as "keep forever"
  */
@@ -66,11 +71,16 @@ public class CleanUpCommand implements Command {
             (ConfigurationContext.ConfigurationProperties.GRAFANA_DATASOURCE);
     private String grafanaApikey =
             ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.GRAFANA_APIKEY);
-
     private List<String> toDelete = new ArrayList<String>();
 
+    @Option(name = "--count",
+            usage = "Build Count",
+            aliases = { "-c" },
+            required = true)
+    private int remainingBuildCount = 100;
 
-    private int remainingBuildCount = 10;
+
+
     private TestPlanUOW testPlanUOW;
 
     public List<String> getToDelete() {
@@ -116,13 +126,21 @@ public class CleanUpCommand implements Command {
             List<String> allTestPlans = testPlanUOW.deleteDatasourcesByAge(remainingBuildCount);
             logger.info("number of items to delete: " + allTestPlans.size());
 
+            logger.info("Clearing S3 files");
+            for (String deletingTestPlan : allTestPlans) {
+                deleteS3(deletingTestPlan);
+            }
+
+            logger.info("Deleting test plan from DB");
+            testPlanUOW.deleteTestPlans(allTestPlans);
+
+            logger.info("Deleting Grafana Data Sources");
             for (String deletingTestPlan : allTestPlans) {
                 if (datasource.contains(deletingTestPlan)) {
                     toDelete.add(deletingTestPlan);
                     logger.info(deletingTestPlan + " added to delete");
                 }
             }
-
             if (!toDelete.isEmpty()) {
                 for (String dataSource : toDelete) {
                     logger.info("deleting data source: " + dataSource);
@@ -131,6 +149,8 @@ public class CleanUpCommand implements Command {
             }
 
         } catch (IllegalArgumentException e) {
+            throw new CommandExecutionException("error while retrieving the data that needs to be deleted", e);
+        } catch (TestGridDAOException e) {
             throw new CommandExecutionException("error while retrieving the data that needs to be deleted", e);
         }
     }
@@ -176,7 +196,7 @@ public class CleanUpCommand implements Command {
     }
 
     /**
-     * this method is to get the list of data sources
+     * This method is to get the list of data sources
      * @return list of data sources in grafana
      */
     private List<String> getDataSources() {
@@ -230,6 +250,19 @@ public class CleanUpCommand implements Command {
                 }
             }
         }
+    }
+
+    /**
+     * This method delete the files in s3 for a given test plan
+     * @param testPlanId tes plan id of which the files need to be deleted
+     * @throws TestGridDAOException
+     */
+    public void deleteS3(String testPlanId) throws TestGridDAOException {
+
+        Optional<TestPlan> testPlanEntity = testPlanUOW.getTestPlanById(testPlanId);
+        TestPlan testPlan = testPlanEntity.get();
+        S3StorageUtil.deleteTestPlan(testPlan);
+
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/CleanUpCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/CleanUpCommand.java
@@ -149,7 +149,7 @@ public class CleanUpCommand implements Command {
             }
 
         } catch (IllegalArgumentException e) {
-            throw new CommandExecutionException("error while retrieving the data that needs to be deleted", e);
+            throw new CommandExecutionException(e.getMessage(), e);
         } catch (TestGridDAOException e) {
             throw new CommandExecutionException("error while retrieving the data that needs to be deleted", e);
         }

--- a/core/src/test/java/org/wso2/testgrid/core/command/CleanUpCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/CleanUpCommandTest.java
@@ -48,14 +48,13 @@ public class CleanUpCommandTest extends PowerMockTestCase {
         dataToDelete.add("TP1");
         String grafanaUrl = "ec2-34-232-211-33.compute-1.amazonaws.com:3000";
 
-        when(testPlanUOW.deleteDatasourcesByAge(10)).thenReturn(dataToDelete);
+        when(testPlanUOW.getTestPlansToCleanup(10)).thenReturn(dataToDelete);
         TestPlan testPlan = new TestPlan();
         String productName = "wso2-" + randomStr;
         actualTestPlanFileLocation = Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
                 productName, TestGridConstants.PRODUCT_TEST_PLANS_DIR, "test-plan-01.yaml").toString();
         workspaceDir = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
                 productName).toString();
-
 
         this.product = new Product();
         product.setName(productName);
@@ -64,16 +63,15 @@ public class CleanUpCommandTest extends PowerMockTestCase {
         deploymentPattern.setName("default-" + randomStr);
         deploymentPattern.setProduct(product);
 
-
         testPlan.setId("TP1");
         testPlan.setTestRunNumber(1);
         testPlan.setDeploymentPattern(deploymentPattern);
         testPlan.setInfraParameters(infraParamsString);
         testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
-        testPlan.setScenarioTestsRepository(Paths.get(workspaceDir, "/workspace/scenarioTests").toString());
-        testPlan.setInfrastructureRepository(Paths.get(workspaceDir, "/workspace/infrastructure").toString());
-        testPlan.setDeploymentRepository(Paths.get(workspaceDir, "/workspace/deployment").toString());
-        testPlan.setKeyFileLocation(Paths.get(workspaceDir, "/workspace/testkey.pem").toString());
+        testPlan.setScenarioTestsRepository(Paths.get(workspaceDir, "workspace", "scenarioTests").toString());
+        testPlan.setInfrastructureRepository(Paths.get(workspaceDir, "workspace", "scenarioTests").toString());
+        testPlan.setDeploymentRepository(Paths.get(workspaceDir, "workspace", "deployment").toString());
+        testPlan.setKeyFileLocation(Paths.get(workspaceDir, "workspace", "testkey.pem").toString());
         testPlan.setWorkspace(workspaceDir);
 
         when(testPlanUOW.getTestPlanById("TP1")).thenReturn(Optional.of(testPlan));

--- a/core/src/test/java/org/wso2/testgrid/core/command/CleanUpCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/CleanUpCommandTest.java
@@ -8,12 +8,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.testgrid.common.DeploymentPattern;
+import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
 import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.uow.TestPlanUOW;
 
-
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -23,19 +29,54 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class CleanUpCommandTest extends PowerMockTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(CleanUpCommandTest.class);
+    private static final String infraParamsString = "{\"operating_system\":\"ubuntu_16.04\"}";
 
     @Mock
     private TestPlanUOW testPlanUOW;
 
+    private Product product;
+    private DeploymentPattern deploymentPattern;
+
+    private String actualTestPlanFileLocation;
+    private String workspaceDir;
 
     @Test
     public void testCleanup() throws Exception {
+        final String randomStr = StringUtil.generateRandomString(5);
         testPlanUOW = mock(TestPlanUOW.class);
         List<String> dataToDelete = new ArrayList<String>();
         dataToDelete.add("TP1");
         String grafanaUrl = "ec2-34-232-211-33.compute-1.amazonaws.com:3000";
 
         when(testPlanUOW.deleteDatasourcesByAge(10)).thenReturn(dataToDelete);
+        TestPlan testPlan = new TestPlan();
+        String productName = "wso2-" + randomStr;
+        actualTestPlanFileLocation = Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
+                productName, TestGridConstants.PRODUCT_TEST_PLANS_DIR, "test-plan-01.yaml").toString();
+        workspaceDir = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
+                productName).toString();
+
+
+        this.product = new Product();
+        product.setName(productName);
+
+        this.deploymentPattern = new DeploymentPattern();
+        deploymentPattern.setName("default-" + randomStr);
+        deploymentPattern.setProduct(product);
+
+
+        testPlan.setId("TP1");
+        testPlan.setTestRunNumber(1);
+        testPlan.setDeploymentPattern(deploymentPattern);
+        testPlan.setInfraParameters(infraParamsString);
+        testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
+        testPlan.setScenarioTestsRepository(Paths.get(workspaceDir, "/workspace/scenarioTests").toString());
+        testPlan.setInfrastructureRepository(Paths.get(workspaceDir, "/workspace/infrastructure").toString());
+        testPlan.setDeploymentRepository(Paths.get(workspaceDir, "/workspace/deployment").toString());
+        testPlan.setKeyFileLocation(Paths.get(workspaceDir, "/workspace/testkey.pem").toString());
+        testPlan.setWorkspace(workspaceDir);
+
+        when(testPlanUOW.getTestPlanById("TP1")).thenReturn(Optional.of(testPlan));
         CleanUpCommand cleanUpCommand = new CleanUpCommand(0, 10, testPlanUOW, dataToDelete,
                 grafanaUrl);
 
@@ -44,5 +85,6 @@ public class CleanUpCommandTest extends PowerMockTestCase {
         Assert.assertEquals(cleanUpCommand.getToDelete().size(), dataToDelete.size());
         Assert.assertEquals(cleanUpCommand.getToDelete().get(0), dataToDelete.get(0));
     }
+
 
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -332,7 +332,7 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
      * @param count number of builds that need be saved for each infra combination in each job
      * @return a List of {@link String} testpan ids
      */
-    public List<String> deleteDatasourcesByAge(int count) {
+    public List<String> getTestPlansToCleanup(int count) {
 
 
         List<String> toDelete = new ArrayList<String>();
@@ -398,14 +398,22 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
      */
     public void deleteTestPlans(List<String> testPlans) {
         String sql;
-        EntityTransaction txn = entityManager.getTransaction();
-        txn.begin();
+        EntityTransaction txn = null;
+        try {
+            txn = entityManager.getTransaction();
+            txn.begin();
 
-        for (String testplan : testPlans) {
-            sql = "delete from test_plan where id = '" + testplan + "'";
-            entityManager.createNativeQuery(sql).executeUpdate();
+            for (String testplan : testPlans) {
+                sql = "delete from test_plan where id = '" + testplan + "'";
+                entityManager.createNativeQuery(sql).executeUpdate();
+            }
+            txn.commit();
+        } catch (Exception e) {
+            if (txn != null) {
+                logger.error("Transaction is being rolled back due to error : \n", e);
+                txn.rollback();
+            }
         }
-        txn.commit();
     }
 
     /**

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -393,6 +393,22 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
     }
 
     /**
+     * Delete a list of test_plans from db
+     * @param testPlans list of test plan ids that need to be deleted
+     */
+    public void deleteTestPlans(List<String> testPlans) {
+        String sql;
+        EntityTransaction txn = entityManager.getTransaction();
+        txn.begin();
+
+        for (String testplan : testPlans) {
+            sql = "delete from test_plan where id = '" + testplan + "'";
+            entityManager.createNativeQuery(sql).executeUpdate();
+        }
+        txn.commit();
+    }
+
+    /**
      * This method returns the test execution summary for given test plan ids(i.e for a given build job).
      *
      * @param testPlanIds test plan ids of a specific build job

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
@@ -87,6 +87,14 @@ public class TestPlanUOW {
     }
 
     /**
+     * Delete a list of test_plans from db
+     * @param testPlans list of test plan ids that need to be deleted
+     */
+    public void deleteTestPlans(List<String> testPlans) {
+        testPlanRepository.deleteTestPlans(testPlans);
+    }
+
+    /**
      * Returns a list of {@link TestPlan} instances for the given deployment-pattern-id and date.
      *
      * @param deploymentId id of the associated deployment-pattern

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
@@ -185,8 +185,8 @@ public class TestPlanUOW {
      * @param count number of datasource that need to be saved in each infra combination
      * @return list of testplans
      */
-    public List<String> deleteDatasourcesByAge(int count) {
-        return testPlanRepository.deleteDatasourcesByAge(count);
+    public List<String> getTestPlansToCleanup(int count) {
+        return testPlanRepository.getTestPlansToCleanup(count);
     }
 
     /**


### PR DESCRIPTION
**Purpose**

Resolves:#1040 

**Goals**

Clean up data of test plans including data base entries in test_plan, test_case, test_scenario and log files in S3

**Approach**

Added new functionality to cleanup sub command and through that user can delete all test plan related data keeping only a specific amount of builds for each infra combination in each job. Graph data is not deleted because all previous emails that contain the graphs are still been used.  

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
