### PR TITLE
Remove using multiple directories for test-resources

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -249,7 +249,7 @@ Resources:
           JDK=ORACLE_JDK8
           source /etc/environment
 
-          echo JDK_PARAM=${JDK} >> /opt/wso2/java.txt
+          echo JDK_PARAM=${JDK} >> /opt/testgrid/java.txt
           REQUESTED_JDK_PRESENT=$(grep "^${JDK}=" /etc/environment | wc -l)
           if [ $REQUESTED_JDK_PRESENT = 0 ]; then
           printf "The requested JDK, ${JDK}, not found in /etc/environment: \n $(cat /etc/environment)."
@@ -271,11 +271,11 @@ Resources:
                       source /etc/profile
             }
 
-          mkdir -p /opt/wso2/workspace
+          mkdir -p /opt/testgrid/workspace
           #TODO: We need to figure out the default user in the system.
           #So, provided permissions to all the users. Need to fix!
-          chmod 777 -R /opt/wso2
-          cd /opt/wso2/workspace
+          chmod 777 -R /opt/testgrid
+          cd /opt/testgrid/workspace
 
           setup_java_env
           echo "Installing Apache Maven"
@@ -283,8 +283,8 @@ Resources:
           tar -xvzf apache-maven-${MavenVersion}-bin.tar.gz
           ln -fs apache-maven-${MavenVersion} maven
           echo 'export MAVEN_OPTS="-Xmx2048m -Xms256m"' >> /etc/environment
-          echo 'export M3_HOME=/opt/wso2/workspace/maven' >> /etc/environment
-          echo PATH=$JAVA_HOME/bin:/opt/wso2/workspace/maven/bin/:$PATH >> /etc/environment
+          echo 'export M3_HOME=/opt/testgrid/workspace/maven' >> /etc/environment
+          echo PATH=$JAVA_HOME/bin:/opt/testgrid/workspace/maven/bin/:$PATH >> /etc/environment
 
           source /etc/environment
 


### PR DESCRIPTION
**Purpose**
Fixes #1046 

Currently there are 2 paths we have been keeping resource in CentOS instances of the stacks.
1. /opt/wso2/
2. /opt/testgrid/

This will stick all the resource to **/opt/testgrid**
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
