### PR TITLE
Rename oracle db client when adding to AMI

### DIFF
--- a/packer/resource-ami/config.sh
+++ b/packer/resource-ami/config.sh
@@ -180,7 +180,7 @@ function downloadJDBCDrivers() {
 	curl http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.44/mysql-connector-java-5.1.44.jar --output sql-drivers/mysql.jar
 	curl https://jdbc.postgresql.org/download/postgresql-42.2.1.jar --output sql-drivers/postgres.jar
 	#Copy “ojdbc8.jar” from resources directory to sql-drivers directory
-	mv resources/ojdbc8.jar sql-drivers/
+	mv resources/ojdbc8.jar sql-drivers/oracle-se.jar
 	echo "JDBC drivers are copied to 'sql-drivers' directory."
 	ls sql-drivers
 	sudo mv sql-drivers /opt/testgrid/sql-drivers


### PR DESCRIPTION
**Purpose**
Rename oracle db client when adding to AMI
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
