### PR TITLE
 Create a common user as testgrid

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -289,7 +289,22 @@ Resources:
           source /etc/environment
 
           cat /dev/null > ~/.bash_history && history -c
+
+
           ${CustomUserData}
+
+          # creating a new user(testgrid) in ec2
+          cp .ssh/authorized_keys /tmp/
+          chmod 777 /tmp/authorized_keys
+          sudo adduser testgrid
+          sudo mkdir /home/testgrid/.ssh
+          sudo cp /tmp/authorized_keys /home/testgrid/.ssh/
+          sudo chmod 700 /home/testgrid/.ssh
+          sudo chmod 600 /home/testgrid/.ssh/authorized_keys
+          sudo chown testgrid /home/testgrid/.ssh
+          sudo chown testgrid /home/testgrid/.ssh/authorized_keys
+          sudo su -c "echo 'testgrid        ALL=(ALL)       NOPASSWD: ALL' >> /etc/sudoers"
+
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -159,7 +159,7 @@ Mappings:
 #Conditions
 Conditions:
  IsWindows: !Equals [ !Ref OS, "Windows" ]
- IsUnix: !Or [ !Equals [ !Ref OS, "CentOS"], !Equals [ !Ref OS, "UBUNTU" ]]
+ IsUnix: !Or [ !Equals [ !Ref OS, "CentOS"], !Equals [ !Ref OS, "UBUNTU" ], !Equals [ !Ref OS, "RHEL" ]]
 Resources:
   WSO2InstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'


### PR DESCRIPTION
**Purpose**

Create a common user as testgrid for all unix instances

**Goals**

log in using a common user in all unix instances

**Approach**

created a sudo user named testgrid from CF script


**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes