### PR TITLE
No need to print entire stack trace for specific errors

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -191,8 +191,12 @@ public class TestPlanExecutor {
                 logger.error("Unable to find a Tinker Executor for OS category " + osCategory);
             }
         } catch (TinkererOperationException e) {
-            logger.error("Error while downloading the log files for TestPlan" +
-                    testPlan.getDeploymentPattern().getProduct().getName(), e);
+            final String msg = "Error while downloading the log files for TestPlan" +
+                    testPlan.getDeploymentPattern().getProduct().getName();
+            logger.warn(msg);
+            if (logger.isDebugEnabled()) {
+                logger.debug(msg, e);
+            }
         }
         //report generation
         logger.info("Generating report for the test plan: " + testPlan.getId());
@@ -200,7 +204,7 @@ public class TestPlanExecutor {
             ReportGenerator reportGenerator = ReportGeneratorFactory.getReportGenerator(testPlan);
             reportGenerator.generateReport();
         } catch (ReportGeneratorNotFoundException e) {
-            logger.error("Could not find a report generator " +
+            logger.warn("Could not find a report generator " +
                     " for TestPlan of " + testPlan.getDeploymentPattern().getProduct().getName() +
                     ". Test type: " + testPlan.getScenarioConfig().getTestType());
         } catch (ReportGeneratorInitializingException e) {

--- a/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
+++ b/core/src/main/java/org/wso2/testgrid/tinkerer/UnixClient.java
@@ -180,8 +180,9 @@ public class UnixClient extends TinkererClient {
             }
             if (resultMap != null && resultMap.containsKey("response")) {
                 String response = resultMap.get("response");
+                // TODO: the response can also contain an error log instead of the actual response.
+                // so, we need to first make sure the command was successful via exit code.
                 List<String> logFileNames = Arrays.asList(response.split("\n"));
-
 
                 for (String logFileName : logFileNames) {
                     try {


### PR DESCRIPTION
**Purpose**
Since the log message is meaningful enough, there is no need to pollute the log file
with unnecessarily long stack traces.

**Goals**
Better readability of testgrid logs.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
