### PR TITLE
Get test.sh as test excecutor

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
@@ -243,8 +243,8 @@ public class ScenarioExecutor {
     private List<String> getTestScriptsToRun(Path scenarioDir) {
 
         List<String> testScripts = new ArrayList<String>();
-        if (Files.exists(Paths.get(scenarioDir.toString(),"test.sh"))) {
-            testScripts.add(Paths.get(scenarioDir.toString(),"test.sh").toString());
+        if (Files.exists(Paths.get(scenarioDir.toString(), "test.sh"))) {
+            testScripts.add(Paths.get(scenarioDir.toString(), "test.sh").toString());
         } else {
             logger.info("test.sh is missing in Scenario directory. Looking for run-*sh files. " +
                     "Please create test.sh");

--- a/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/ScenarioExecutor.java
@@ -219,7 +219,7 @@ public class ScenarioExecutor {
                     }
                 }
                 if (testList.isEmpty()) {
-                    List<String> scripts = getDefaultScriptsToRun(testLocationPath);
+                    List<String> scripts = getTestScriptsToRun(testLocationPath);
                     Test defaultTest = new Test(testScenario.getName(), TestEngine.DEFAULT, scripts, testScenario);
                     testList.add(defaultTest);
                 }
@@ -235,12 +235,32 @@ public class ScenarioExecutor {
     }
 
     /**
+     * By default, this looks for any shell script that has the name format as test.sh,
+     * and returns them as a list.
+     *
+     * @param scenarioDir the scenario test location where tests are located.
+     */
+    private List<String> getTestScriptsToRun(Path scenarioDir) {
+
+        List<String> testScripts = new ArrayList<String>();
+        if (Files.exists(Paths.get(scenarioDir.toString(),"test.sh"))) {
+            testScripts.add(Paths.get(scenarioDir.toString(),"test.sh").toString());
+        } else {
+            logger.info("test.sh is missing in Scenario directory. Looking for run-*sh files. " +
+                    "Please create test.sh");
+            testScripts = getRunScenarioScriptsToRun(scenarioDir);
+        }
+        return testScripts;
+    }
+
+    /**
      * By default, this looks for any shell script that has the name format as run-.*.sh,
      * and returns them as a list.
      *
      * @param scenarioDir the scenario test location where tests are located.
      */
-    private List<String> getDefaultScriptsToRun(Path scenarioDir) {
+    @Deprecated
+    private List<String> getRunScenarioScriptsToRun(Path scenarioDir) {
         try {
             return Files.list(scenarioDir)
                     .filter(p -> p.getFileName().toString().matches("run-.*" + SHELL_SUFFIX))


### PR DESCRIPTION
**Purpose**

Use test.sh in place of run.scenario.sh

**Goals**

Use test.sh to run tests

**Approach**

Check if the test.sh is existing and use that it. If test.sh is missing use the previous logic 

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

