### PR TITLE
Set failed-tests collapsible to be opened by default

### DIFF
--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -24,7 +24,6 @@ import ReactTooltip from 'react-tooltip'
 import FlatButton from 'material-ui/FlatButton';
 import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT} from '../constants.js';
 import {Table, Input, Alert} from 'reactstrap';
-import {Button} from "reactstrap";
 import Moment from "moment/moment";
 
 class DeploymentPatternView extends Component {

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -478,7 +478,7 @@ class TestRunView extends Component {
             </Collapsible>
 
             {/*Scenario execution summary*/}
-            <Collapsible trigger="Failed tests" lazyRender={true} triggerWhenOpen="Failed tests >>" >
+            <Collapsible trigger="Failed tests" open="true" lazyRender={true} triggerWhenOpen="Failed tests >>" >
               {(() => {
                 if (this.state.testSummaryLoadStatus === SUCCESS)
                 switch (this.state.testSummaryLoadStatus) {


### PR DESCRIPTION
**Purpose**
Set failed-tests collapsible to be opened by default.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
