### PR TITLE
Add remoteBranch property into testgrid.yaml to specify the git branch

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -62,6 +62,10 @@ public class TestGridConstants {
     public static final String WUM_USERNAME_PROPERTY = "WUMUsername";
     public static final String WUM_PASSWORD_PROPERTY = "WUMPassword";
 
+    /**
+     * FUNCTIONAL test type is for JMETER tests.
+     * TODO: rename this to JMETER.
+     */
     public static final String TEST_TYPE_FUNCTIONAL = "FUNCTIONAL";
     public static final String TEST_TYPE_PERFORMANCE = "PERFORMANCE";
     public static final String TEST_TYPE_INTEGRATION = "INTEGRATION";

--- a/common/src/main/java/org/wso2/testgrid/common/config/DeploymentConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/DeploymentConfig.java
@@ -77,6 +77,7 @@ public class DeploymentConfig implements Serializable {
         private String description;
         private String dir;
         private String remoteRepository;
+        private String remoteBranch = "master";
         private List<Script> scripts;
 
         public String getName() {
@@ -95,12 +96,31 @@ public class DeploymentConfig implements Serializable {
             this.description = description;
         }
 
+        /**
+         * The git repo URL of the remote git repository.
+         * This parameter is only used within Jenkins pipeline (for cloning purpose).
+         * It does not have any relevance within the testgrid core.
+         *
+         * Same applies to {@link #getRemoteBranch()} as well.
+         */
         public String getRemoteRepository() {
             return remoteRepository;
         }
 
         public void setRemoteRepository(String remoteRepository) {
             this.remoteRepository = remoteRepository;
+        }
+
+        /**
+         * The git branch name of the remote git repository.
+         *
+         */
+        public String getRemoteBranch() {
+            return remoteBranch;
+        }
+
+        public void setRemoteBranch(String remoteBranch) {
+            this.remoteBranch = remoteBranch;
         }
 
         /**

--- a/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ScenarioConfig.java
@@ -41,6 +41,7 @@ public class ScenarioConfig implements Serializable {
     //keep default value of test type as functional
     private String testType = TestGridConstants.TEST_TYPE_FUNCTIONAL;
     private String remoteRepository;
+    private String remoteBranch = "master";
 
     /**
      * This method returns the list of scenarios.
@@ -80,12 +81,31 @@ public class ScenarioConfig implements Serializable {
         this.testType = testType;
     }
 
+    /**
+     * The git repo URL of the remote git repository.
+     * This parameter is only used within Jenkins pipeline (for cloning purpose).
+     * It does not have any relevance within the testgrid core.
+     *
+     * Same applies to {@link #getRemoteBranch()} as well.
+     */
     public String getRemoteRepository() {
         return remoteRepository;
     }
 
     public void setRemoteRepository(String remoteRepository) {
         this.remoteRepository = remoteRepository;
+    }
+
+    /**
+     * The git branch name of the remote git repository.
+     *
+     */
+    public String getRemoteBranch() {
+        return remoteBranch;
+    }
+
+    public void setRemoteBranch(String remoteBranch) {
+        this.remoteBranch = remoteBranch;
     }
 }
 

--- a/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/GenerateTestPlanCommandTest.java
@@ -144,8 +144,7 @@ public class GenerateTestPlanCommandTest extends PowerMockTestCase {
                 .replaceAll(repoPath, Paths.get(repoPath).toAbsolutePath().normalize().toString());
         expectedTestPlanContent = expectedTestPlanContent.replace("<workspace-to-be-added-at-runtime>",
                 testPlan.getWorkspace());
-        Assert.assertEquals(generatedTestPlanContent, expectedTestPlanContent,
-                String.format("Generated test-plan is not correct: %n%s", generatedTestPlanContent));
+        Assert.assertEquals(generatedTestPlanContent, expectedTestPlanContent, "Generated test-plan is not correct.");
     }
 
     @AfterMethod

--- a/core/src/test/resources/test-plan-01.yaml
+++ b/core/src/test/resources/test-plan-01.yaml
@@ -5,6 +5,7 @@ deploymentConfig:
   - description: Deploys a IS node locally
     dir: .
     name: 01-dummy-deployment
+    remoteBranch: master
     scripts:
     - description: Do a IS two node deployment.
       file: deploy.sh
@@ -23,6 +24,7 @@ infrastructureConfig:
   - description: Provision Infra for a dummy deployment
     dir: .
     name: 01-dummy-deployment
+    remoteBranch: test-branch
     scripts:
     - description: Creates infrastructure for a IS node deployment.
       file: infra-provision.sh
@@ -40,6 +42,7 @@ jobProperties:
   PROPERTY1: value1
 keyFileLocation: workspace/testkey.pem
 scenarioConfig:
+  remoteBranch: master
   scenarios:
   - description: Test Scenario
     dir: scenario01

--- a/core/src/test/resources/workspace/testgrid.yaml
+++ b/core/src/test/resources/workspace/testgrid.yaml
@@ -10,6 +10,7 @@ infrastructureConfig:
     - name: 01-dummy-deployment
       description: Provision Infra for a dummy deployment
       dir: .
+      remoteBranch: test-branch
       scripts:
         - name: infra-for-dummy-deployment
           description: Creates infrastructure for a IS node deployment.


### PR DESCRIPTION
**Purpose**
Along with git repo url, we must get the repo branch as well. It is incorrect to assume that the branch will always be the default/master branch.

**Approach**
Introduced a new property called `remoteBranch` alongside `remoteRepository` for each infra/deploy/test configs.

<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

**Automation tests**
Yes.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

