### PR TITLE
Set correct JAVA_HOME for openjdk in CentOS

### DIFF
--- a/packer/resource-ami/config.sh
+++ b/packer/resource-ami/config.sh
@@ -212,7 +212,7 @@ function updatePathVariable() {
 #===============================================================================
 function addEnvVariables() {
     sudo su -c "echo 'ORACLE_JDK8=/usr/java/jdk1.8.0_181-amd64' > /etc/environment"
-    sudo su -c "echo 'OPEN_JDK8=/usr/lib/jvm/java-1.8.0-openjdk-amd64' >> /etc/environment"
+    sudo su -c "echo 'OPEN_JDK8=/usr/lib/jvm/java-1.8.0-openjdk' >> /etc/environment"
     source /etc/environment
 }
 


### PR DESCRIPTION
**Purpose**
Set correct JAVA_HOME for openjdk in CentOS
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

