### PR TITLE
Set infra-provisioner name to default depl pattern name

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -400,8 +400,9 @@ public class GenerateTestPlanCommand implements Command {
      */
     private void populateDefaults(TestgridYaml testgridYaml) {
         if (testgridYaml.getDeploymentConfig().getDeploymentPatterns().isEmpty()) {
+            String deploymentPatternName = TestGridUtil.getDeploymentPatternName(testgridYaml);
             DeploymentConfig.DeploymentPattern deploymentPatternConfig = new DeploymentConfig.DeploymentPattern();
-            deploymentPatternConfig.setName(TestGridConstants.DEFAULT_DEPLOYMENT_PATTERN_NAME);
+            deploymentPatternConfig.setName(deploymentPatternName);
             deploymentPatternConfig.setDescription(TestGridConstants.DEFAULT_DEPLOYMENT_PATTERN_NAME);
             Script script = new Script();
             script.setName("default");


### PR DESCRIPTION
**Purpose**

Contains necessary changes to set the name of infra provisioner to the deployment pattern if deploymentConfig is not given in testgrid.yaml. Applicable to CLOUDFORMATION infra provisioners.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes