### PR TITLE
Improve finalize-run-testplan to change interval using config.properties

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -213,7 +213,12 @@ public class ConfigurationContext {
         /**
          * API access token for testing
          */
-        API_TOKEN("API_TOKEN");
+        API_TOKEN("API_TOKEN"),
+
+        /**
+         * Interval (in hours) to run finalize run testplan
+         */
+        FINALIZE_RUN_TESTPLAN_INTERVAL("FINALIZE_RUN_TESTPLAN_INTERVAL");
 
 
         private String propertyName;

--- a/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/repository/TestPlanRepository.java
@@ -291,8 +291,8 @@ public class TestPlanRepository extends AbstractRepository<TestPlan> {
      */
     public List<TestPlan> getTestPlanOlderThan(String duration, String timeUnit) {
         String sql = StringUtil.concatStrings(
-                "select t.* from test_plan t where t.created_timestamp < NOW() - INTERVAL ",
-                duration , " ", timeUnit, " ", " and t.status = 'PENDING' or t.status = 'RUNNING' ");
+                "select t.* from test_plan t where t.created_timestamp < (NOW() - INTERVAL ",
+                duration , " ", timeUnit, ") and (t.status = 'PENDING' or t.status = 'RUNNING') ");
         @SuppressWarnings("unchecked")
         List<TestPlan> resultList = (List<TestPlan>) entityManager.createNativeQuery(sql, TestPlan.class)
                 .getResultList();


### PR DESCRIPTION
**Purpose**

Contains improvements to finalize-run-testplan command to be able to set the running interval through a property in config.properties.
Introduces `FINALIZE_RUN_TESTPLAN_INTERVAL` property

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes