### PR TITLE
Improve infrastructure parameters handling logic

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureCombination.java
+++ b/common/src/main/java/org/wso2/testgrid/common/infrastructure/InfrastructureCombination.java
@@ -34,6 +34,9 @@ import java.util.TreeSet;
 public class InfrastructureCombination implements Cloneable {
     private TreeSet<InfrastructureParameter> parameters = new TreeSet<>();
 
+    // Unique identification of an infra combination used for deriving the testplan id
+    private String infraCombinationId;
+
     /**
      * Initializes an @{@link InfrastructureCombination} object with the given
      * set of infrastructure parameters.
@@ -60,6 +63,35 @@ public class InfrastructureCombination implements Cloneable {
      */
     public void addParameter(InfrastructureParameter param) {
         parameters.add(param);
+    }
+
+    /**
+     * Add another set of infrastructure parameters.
+     *
+     * @param params the set of infrastructure parameters
+     */
+    public void addParameters(Set<InfrastructureParameter> params) {
+        parameters.addAll(params);
+    }
+
+    /**
+     * Return the created id of infra combination.
+     *
+     * @return a string containing uniquely identfiable infra combination
+     */
+    public String getInfraCombinationId() {
+
+        return infraCombinationId;
+    }
+
+    /**
+     * Sets the infra combination id string made out of infra parameters.
+     *
+     * @param infraCombinationId id string constructed using infra params
+     */
+    public void setInfraCombinationId(String infraCombinationId) {
+
+        this.infraCombinationId = infraCombinationId;
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -473,7 +473,7 @@ public class GenerateTestPlanCommand implements Command {
                     setUniqueNamesFor(dp.getScripts());
                     testPlan.setDeploymentConfig(new DeploymentConfig(Collections.singletonList(dp)));
                     try {
-                        testPlan.setId(TestGridUtil.deriveTestPlanId(testPlan, combination.getParameters(),
+                        testPlan.setId(TestGridUtil.deriveTestPlanId(testPlan, combination,
                                 getDeploymentPattern(createOrReturnProduct(productName), dp.getName())));
                     } catch (CommandExecutionException e) {
                         throw new CommandExecutionException(StringUtil

--- a/core/src/test/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProviderTest.java
+++ b/core/src/test/java/org/wso2/testgrid/infrastructure/InfrastructureCombinationsProviderTest.java
@@ -46,6 +46,15 @@ import java.util.TreeSet;
 public class InfrastructureCombinationsProviderTest {
 
     private static final Logger logger = LoggerFactory.getLogger(InfrastructureCombinationsProviderTest.class);
+    private final String dbEnginePropKey = "DBEngine";
+    private final String dbEngineVersionPropKey = "DBEngineVersion";
+    private final String osPropKey = "OS";
+    private final String jdkPropKey = "JDK";
+
+    private final String dbEnginePropVal = "mysql";
+    private final String dbEngineVersionPropVal = "5.7";
+    private final String osPropVal = "UBUNTU";
+    private final String jdkPropVal = "ORACLE_JDK8";
 
     @BeforeTest
     public void init() {
@@ -78,7 +87,7 @@ public class InfrastructureCombinationsProviderTest {
         logger.info("Generated infrastructure combinations: " + combinations);
         Assert.assertEquals(combinations.size(), 2, "There must be two infrastructure combinations.");
         for (InfrastructureCombination combination : combinations) {
-            Assert.assertEquals(combination.getParameters().size(), 5, "Combination contains more than three "
+            Assert.assertEquals(combination.getParameters().size(), 4, "Combination contains more than three "
                     + "infrastructure parameters: " + combination);
         }
 
@@ -92,44 +101,27 @@ public class InfrastructureCombinationsProviderTest {
         for (InfrastructureCombination combination : combinations) {
             //check os
             boolean osExists = combination.getParameters().removeIf(param ->
-                    param.getName().equals(operatingSystems.get(0)) &&
-                            param.getType().equals(DefaultInfrastructureTypes.OPERATING_SYSTEM));
-            if (!osExists && operatingSystems.size() == 2) {
-                osExists = combination.getParameters().removeIf(param ->
-                        param.getName().equals(operatingSystems.get(1)) &&
-                                param.getType().equals(DefaultInfrastructureTypes.OPERATING_SYSTEM));
-                Assert.assertTrue(osExists, StringUtil.concatStrings(operatingSystems.get(0), " nor ",
+                    param.getName().equals(osPropVal) &&
+                            param.getType().equals(osPropKey));
+            Assert.assertTrue(osExists, StringUtil.concatStrings(operatingSystems.get(0), " nor ",
                         operatingSystems.get(1), " does not exist in the combination: ", combination));
-                operatingSystems.remove(1);
-            } else if (!osExists) {
-                Assert.fail(StringUtil
-                        .concatStrings(operatingSystems.get(0), " was not found in the combinations: ", combinations));
-            } else {
-                operatingSystems.remove(0);
-            }
-
-            //check db
-            boolean dbExists = combination.getParameters().removeIf(param ->
-                    param.getName().equals(dbValueSet.getValues().iterator().next().getName()) &&
-                            param.getType().equals(DefaultInfrastructureTypes.DATABASE));
-            Assert.assertTrue(dbExists, "DB does not exist in the combination: " + combination);
 
             //check db property - dbengine
             boolean dbEngineExists = combination.getParameters().removeIf(param ->
-                    param.getName().equals("mysql") && param.getType().equals("DBEngine"));
+                    param.getName().equals(dbEnginePropVal) && param.getType().equals(dbEnginePropKey));
             Assert.assertTrue(dbEngineExists, "DBEngine property of database1 has not got added as a "
                     + "InfrastructureParameter. The infrastructure combination: " + combination);
 
             //check db property - dbengineversion
             boolean dbEngineVersionExists = combination.getParameters().removeIf(param ->
-                    param.getName().equals("5.7") && param.getType().equals("DBEngineVersion"));
+                    param.getName().equals(dbEngineVersionPropVal) && param.getType().equals(dbEngineVersionPropKey));
             Assert.assertTrue(dbEngineVersionExists, "DBEngineVersion property of database1 has not got added as a "
                     + "InfrastructureParameter. The infrastructure combination: " + combination);
 
             //check jdk
             boolean jdkExists = combination.getParameters().removeIf(param ->
-                    param.getName().equals(jdkValueSet.getValues().iterator().next().getName()) &&
-                            param.getType().equals(DefaultInfrastructureTypes.JDK));
+                    param.getName().equals(jdkPropVal) &&
+                            param.getType().equals(jdkPropKey));
             Assert.assertTrue(jdkExists, "JDK does not exist in the combination: " + combination);
 
             Assert.assertEquals(combination.getParameters().size(), 0);
@@ -140,11 +132,25 @@ public class InfrastructureCombinationsProviderTest {
     private Set<InfrastructureParameter> createInfrastructureParameterSet(String type, int count) throws IOException {
         Set<InfrastructureParameter> params = new TreeSet<>();
         String propertiesStr = "";
+        Properties properties;
+        StringWriter propWriter;
         if (type.equals(DefaultInfrastructureTypes.DATABASE)) {
-            Properties properties = new Properties();
-            properties.setProperty("DBEngine", "mysql");
-            properties.setProperty("DBEngineVersion", "5.7");
-            StringWriter propWriter = new StringWriter();
+            properties = new Properties();
+            properties.setProperty(dbEnginePropKey, dbEnginePropVal);
+            properties.setProperty(dbEngineVersionPropKey, dbEngineVersionPropVal);
+            propWriter = new StringWriter();
+            properties.store(propWriter, "");
+            propertiesStr = propWriter.toString();
+        } else if (type.equals(DefaultInfrastructureTypes.OPERATING_SYSTEM)) {
+            properties = new Properties();
+            properties.setProperty(osPropKey, osPropVal);
+            propWriter = new StringWriter();
+            properties.store(propWriter, "");
+            propertiesStr = propWriter.toString();
+        } else if (type.equals(DefaultInfrastructureTypes.JDK)) {
+            properties = new Properties();
+            properties.setProperty(jdkPropKey, jdkPropVal);
+            propWriter = new StringWriter();
             properties.store(propWriter, "");
             propertiesStr = propWriter.toString();
         }

--- a/dao/src/main/java/org/wso2/testgrid/dao/dto/TestCaseFailureResultDTO.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/dto/TestCaseFailureResultDTO.java
@@ -18,6 +18,14 @@
 
 package org.wso2.testgrid.dao.dto;
 
+import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
+import org.wso2.testgrid.common.util.TestGridUtil;
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.InfrastructureParameterUOW;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Defines a model object of test case failure results.
  *
@@ -57,5 +65,19 @@ public class TestCaseFailureResultDTO {
 
     public void setInfraParameters(String infraParameters) {
         this.infraParameters = infraParameters;
+    }
+
+    /**
+     * Transforms infrastructure parameters to display values.
+     *
+     * @throws TestGridDAOException if retrieving infra value sets from database fails
+     */
+    public void transformInfraParameters() throws TestGridDAOException {
+        InfrastructureParameterUOW infrastructureParameterUOW = new InfrastructureParameterUOW();
+        final Set<InfrastructureValueSet> valueSets = infrastructureParameterUOW.getValueSet();
+
+        setInfraParameters("{" + TestGridUtil.transformInfraParameters(valueSets, infraParameters).stream()
+                .map(infra -> "\"" + infra.getType() + "\":\"" + infra.getName() + "\"")
+                .collect(Collectors.joining(",")) + "}");
     }
 }

--- a/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
+++ b/dao/src/main/java/org/wso2/testgrid/dao/uow/TestPlanUOW.java
@@ -215,7 +215,11 @@ public class TestPlanUOW {
      * @return a List of TestCaseFailureResultDTO which represent test cases failure for given test plan ids.
      */
     public List<TestCaseFailureResultDTO> getTestFailureSummary(List<String> tpIds) throws TestGridDAOException {
-        return testPlanRepository.getTestFailureSummaryByTPId(tpIds);
+        List<TestCaseFailureResultDTO> testFailures = testPlanRepository.getTestFailureSummaryByTPId(tpIds);
+        for (TestCaseFailureResultDTO testFailure : testFailures) {
+            testFailure.transformInfraParameters();
+        }
+        return testFailures;
     }
 
     /**

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/GraphDataProvider.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/GraphDataProvider.java
@@ -106,12 +106,9 @@ public class GraphDataProvider {
             String testName = testFailure.getName();
             JsonElement jelem = gson.fromJson(testFailure.getInfraParameters(), JsonElement.class);
             JsonObject jobj = jelem.getAsJsonObject();
-            String osVersion = jobj.get("OSVersion") != null ? jobj.get("OSVersion").getAsString() : "";
-            infraCombination.setOs(StringUtil.concatStrings(jobj.get(OPERATING_SYSTEM).getAsString(), " - ",
-                    osVersion));
+            infraCombination.setOs(StringUtil.concatStrings(jobj.get(OPERATING_SYSTEM).getAsString()));
             infraCombination.setJdk(jobj.get(JDK).getAsString());
-            infraCombination.setDbEngine(StringUtil.concatStrings(jobj.get(DATABASE_ENGINE).getAsString(), " - ",
-                    jobj.get(DATABASE_ENGINE_VERSION).getAsString()));
+            infraCombination.setDbEngine(StringUtil.concatStrings(jobj.get(DATABASE_ENGINE).getAsString()));
             if (testFailureSummaryMap.containsKey(testName)) {
                 testFailureSummaryMap.get(testName).getInfraCombinations().add(infraCombination);
             } else {

--- a/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporter.java
+++ b/reporting/src/main/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporter.java
@@ -118,15 +118,15 @@ public class InfrastructureSummaryReporter {
         }
 
         if (allSuccessInfrasFound) {
+            final Set<InfrastructureValueSet> infraValueSet = infrastructureParameterUOW.getValueSet();
             List<TestPlan> testPlansWithoutAllSuccessInfra = testPlans.stream()
                     .filter(tp -> infraBuildStatus.getSuccessInfra().stream()
                             .noneMatch(sip -> {
                                 final Map<String, String> infraParamsStr = TestGridUtil
-                                        .parseInfraParametersString(tp.getInfraParameters());
-                                final InfrastructureParameter oneSubInfraParam = sip
-                                        .getProcessedSubInfrastructureParameters().get(0);
-                                final String s = infraParamsStr.get(oneSubInfraParam.getType());
-                                return s != null && s.equals(oneSubInfraParam.getName());
+                                        .getInfraParamsOfTestPlan(infraValueSet, tp).stream().collect(Collectors.toMap(
+                                                InfrastructureParameter::getType, InfrastructureParameter::getName));
+                                final String s = infraParamsStr.get(sip.getType());
+                                return s.equals(sip.getName());
                             }))
                     .collect(Collectors.toList());
             if (testPlansWithoutAllSuccessInfra.isEmpty()) {

--- a/reporting/src/main/resources/templates/summarized_email_report.mustache
+++ b/reporting/src/main/resources/templates/summarized_email_report.mustache
@@ -145,7 +145,7 @@
                         <table>
                             <tr>
                                 <td style="font-family: arial; font-size: 16px; line-height: 24px; text-align: center;">
-                                    <span class ="mainTitle">{{productName}} integration test Results!</span><br/>
+                                    <span class ="mainTitle">{{productName}} test Results!</span><br/>
                                 </td>
                             </tr>
                         </table>

--- a/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
+++ b/reporting/src/test/java/org/wso2/testgrid/reporting/summary/InfrastructureSummaryReporterTest.java
@@ -70,7 +70,26 @@ public class InfrastructureSummaryReporterTest extends BaseClass {
             Assert.assertEquals(failedInfra.getName(), "CentOS",
                     "Could not detect the actual reason for test failures.");
 
+            // Verify failed infras of each test case
+            Assert.assertEquals(summaryTable.get("CentOS-PaginationCountTestCase")
+                    .getFailedInfra().size(), 1);
+            Assert.assertEquals(summaryTable.get("CentOS-PaginationCountTestCase")
+                    .getFailedInfra().get(0).get(0).getName(), "CentOS");
+
+            Assert.assertEquals(summaryTable.get("Oracle-APINameWithDifferentCaseTestCase").getFailedInfra().size(), 1);
+            Assert.assertEquals(summaryTable.get("Oracle-APINameWithDifferentCaseTestCase")
+                    .getFailedInfra().get(0).get(0).getName(), "Oracle");
+
+            Assert.assertEquals(summaryTable.get("Success-ESBJAVA3380TestCase").getFailedInfra().size(), 0);
+            Assert.assertEquals(summaryTable.get("CentOS-OPEN_JDK8-APIInvocationStatPublisherTestCase")
+                    .getFailedInfra().size(), 2);
+            for (List<InfrastructureParameter> infraParam : summaryTable.get("CentOS-PaginationCountTestCase")
+                    .getFailedInfra()) {
+                Assert.assertTrue(infraParam.get(0).getName().contains("CentOS")
+                        || infraParam.get(0).getName().contains("OPEN_JDK8"));
+            }
         }
+
     }
 
     @AfterMethod

--- a/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
@@ -19,6 +19,8 @@
 package org.wso2.testgrid.web.api;
 
 import org.wso2.testgrid.common.DeploymentPatternTestFailureStat;
+import org.wso2.testgrid.common.infrastructure.InfrastructureValueSet;
+import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.web.bean.DeploymentPattern;
 import org.wso2.testgrid.web.bean.Product;
 import org.wso2.testgrid.web.bean.TestCase;
@@ -29,6 +31,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Util class which holds utility methods required for TestGrid APIs.
@@ -127,13 +131,18 @@ class APIUtil {
      * @param requireTestScenarios boolean flag to indicate whether to include test-scenario info
      * @return {@link TestPlan} instance  with necessary information
      */
-    static TestPlan getTestPlanBean(org.wso2.testgrid.common.TestPlan testPlan, boolean requireTestScenarios) {
+    static TestPlan getTestPlanBean(Set<InfrastructureValueSet> infraValueSet,
+                                    org.wso2.testgrid.common.TestPlan testPlan, boolean requireTestScenarios) {
         TestPlan testPlanBean = new TestPlan();
         if (testPlan != null) {
             testPlanBean.setId(testPlan.getId());
             testPlanBean.setDeploymentPattern(testPlan.getDeploymentPattern().getName());
             testPlanBean.setDeploymentPatternId(testPlan.getDeploymentPattern().getId());
-            testPlanBean.setInfraParams(testPlan.getInfraParameters());
+            String infraParams = "{" + TestGridUtil.getInfraParamsOfTestPlan(infraValueSet, testPlan).stream()
+                    .map(infra -> "\"" + infra.getType() + "\":\"" + infra.getName() + "\"")
+                    .collect(Collectors.joining(",")) + "}";
+
+            testPlanBean.setInfraParams(infraParams);
             testPlanBean.setStatus(testPlan.getStatus().toString());
             testPlanBean.setCreatedTimestamp(testPlan.getCreatedTimestamp());
             testPlanBean.setModifiedTimestamp(testPlan.getModifiedTimestamp());
@@ -152,12 +161,13 @@ class APIUtil {
      * @param requireTestScenarios boolean flag to indicate whether to include test-scenario info
      * @return List of {@link TestPlan} instances with necessary information
      */
-    static List<TestPlan> getTestPlanBeans(List<org.wso2.testgrid.common.TestPlan> testPlans,
+    static List<TestPlan> getTestPlanBeans(Set<InfrastructureValueSet> infraValueSet,
+                                           List<org.wso2.testgrid.common.TestPlan> testPlans,
                                            boolean requireTestScenarios) {
         List<TestPlan> plans = new ArrayList<>();
 
         for (org.wso2.testgrid.common.TestPlan testPlan : testPlans) {
-            plans.add(getTestPlanBean(testPlan, requireTestScenarios));
+            plans.add(getTestPlanBean(infraValueSet, testPlan, requireTestScenarios));
         }
         return plans;
     }


### PR DESCRIPTION
**Purpose**

Contains changes required to supporting different aliases used for infrastructure parameters.

**Goals**

<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

**Approach**

Makes use of the properties attached to infrastructure parameters. Each row is considered an individual infrastructure parameter which can have multiple properties to facilitate different input parameters required by infra scripts. All inputs for infra scripts are generated using only the `PROPERTIES` column in the `infrastructure_parameter` table and the `NAME` column is used as a label for displaying in email report and dashboard.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes