### PR TITLE
Convert stack name to lower case

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -67,6 +67,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -562,7 +563,8 @@ public class GenerateTestPlanCommand implements Command {
      */
     private void setUniqueNamesFor(List<Script> scripts) {
         for (Script script : scripts) {
-            script.setName(script.getName() + '-' + StringUtil.generateRandomString(RANDOMIZED_STR_LENGTH));
+            script.setName(script.getName() + '-' + StringUtil.generateRandomString(RANDOMIZED_STR_LENGTH)
+                    .toLowerCase(Locale.ENGLISH));
         }
     }
 


### PR DESCRIPTION
**Purpose**

Converts the unique name of stack to be in lowercase to support Elasticsearch indexing.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes