### PR TITLE
Fix dashboard job name caching issue

### DIFF
--- a/web/src/main/java/org/wso2/testgrid/web/sso/SSOContextEventListener.java
+++ b/web/src/main/java/org/wso2/testgrid/web/sso/SSOContextEventListener.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.sso.agent.SSOAgentConstants;
 import org.wso2.carbon.identity.sso.agent.SSOAgentException;
 import org.wso2.carbon.identity.sso.agent.bean.SSOAgentConfig;
 import org.wso2.carbon.identity.sso.agent.saml.SSOAgentX509Credential;
+import org.wso2.testgrid.common.config.ConfigurationContext;
 import org.wso2.testgrid.common.exception.TestGridException;
 import org.wso2.testgrid.web.api.SSOService;
 
@@ -45,6 +46,10 @@ public class SSOContextEventListener implements ServletContextListener {
      * {@link org.wso2.testgrid.web.utils.Constants#JKS_FILE_NAME} JKS file.
      */
     public void contextInitialized(ServletContextEvent servletContextEvent) {
+        String isSsoEnabled = ConfigurationContext.getProperty(ConfigurationContext.ConfigurationProperties.ENABLE_SSO);
+        if (!Boolean.valueOf(isSsoEnabled)) {
+            return;
+        }
         SSOConfigurationReader ssoConfigurationReader = new SSOConfigurationReader();
         try {
             SSOAgentX509Credential credential = ssoConfigurationReader.getIdPX509Credential();

--- a/web/src/main/react-dashboard/src/App.css
+++ b/web/src/main/react-dashboard/src/App.css
@@ -14,8 +14,17 @@
   color: white;
 }
 
-.App-title {
+.title {
   font-size: 1.5em;
+  color: inherit;
+  text-decoration:none;
+  cursor: inherit;
+}
+
+a.title:hover, a.title:active {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 
 .App-intro {

--- a/web/src/main/react-dashboard/src/App.js
+++ b/web/src/main/react-dashboard/src/App.js
@@ -83,7 +83,7 @@ class App extends Component {
               left: '0px',
               backgroundColor: '#EEEEEE'
             }}>
-              <AppBar title=" WSO2 TestGrid " style={{
+              <AppBar title=" WSO2 TestGrid " className="App-title" style={{
                 backgroundColor: '#424242', position: 'fixed'
               }}
                       iconElementLeft={<IconButton onClick={this.handleClose}>{this.state.open ? <NavigationBack/> :
@@ -97,7 +97,7 @@ class App extends Component {
                   <Route exact path={'/login'} component={Login}/>
                   <Route exact path={'/'} component={ProductContainer}/>
                   <Route exact path={'/:productName'} component={DeploymentContainer}/>
-                  <Route exact path={'/:productName/:deploymentPatternName/:testPlanId/infra'}
+                  <Route exact path={'/:productName/:deploymentPatternName/test-plans/:testPlanId/history'}
                          component={InfrastructureContainer}/>
                   <Route exact path={'/scenarios/infrastructure/:infraid'} component={ScenarioContainer}/>
                   <Route exact path={'/testcases/scenario/:scenarioid'} component={TestCaseContainer}/>

--- a/web/src/main/react-dashboard/src/App.js
+++ b/web/src/main/react-dashboard/src/App.js
@@ -26,15 +26,12 @@ import TestCaseContainer from './containers/TestCaseContainer.js';
 import DeploymentContainer from './containers/deploymentContainer.js';
 import testRunContainer from './containers/testRunContainer.js';
 import Login from './components/Login.js'
-import {
-  Route,
-  Switch
-} from 'react-router-dom';
+import {Route, Switch} from 'react-router-dom';
 import AppBar from 'material-ui/AppBar';
 import {createStore} from 'redux';
 import {Provider} from 'react-redux';
 import testGrid from './reducers/testGrid.js';
-import {persistStore, persistCombineReducers} from 'redux-persist';
+import {persistCombineReducers, persistStore} from 'redux-persist';
 import {PersistGate} from 'redux-persist/es/integration/react';
 import storage from 'redux-persist/lib/storage/session';
 import Drawer from 'material-ui/Drawer';
@@ -43,6 +40,7 @@ import IconButton from 'material-ui/IconButton';
 import NavigationBack from 'material-ui/svg-icons/navigation/chevron-left';
 import NevigationExpand from 'material-ui/svg-icons/navigation/menu';
 import Paper from 'material-ui/Paper';
+import {TESTGRID_CONTEXT} from "./constants";
 
 const config = {
   key: 'root',
@@ -83,14 +81,19 @@ class App extends Component {
               left: '0px',
               backgroundColor: '#EEEEEE'
             }}>
-              <AppBar title=" WSO2 TestGrid " className="App-title" style={{
-                backgroundColor: '#424242', position: 'fixed'
-              }}
-                      iconElementLeft={<IconButton onClick={this.handleClose}>{this.state.open ? <NavigationBack/> :
-                        <NevigationExpand/>}</IconButton>}> </AppBar>
+              <AppBar
+                title={
+                  <a href={TESTGRID_CONTEXT + '/'} className="title">WSO2 TestGrid</a>
+                }
+                style={{backgroundColor: '#424242', position: 'fixed'}}
+                iconElementLeft={
+                  <IconButton onClick={this.handleClose}>
+                    {this.state.open ? <NavigationBack/> : <NevigationExpand/>}
+                  </IconButton>
+                }/>
               <Drawer open={this.state.open} containerStyle={{'top': '64px', backgroundColor: '#BDBDBD'}} width={200}>
-                <MenuItem><a href="/blue/organizations/jenkins/wso2is5.4.0LTS/activity"> TestGrid
-                  AdminPortal</a></MenuItem>
+                <MenuItem><a href="/admin/blue/organizations/jenkins/pipelines?search=wum">
+                  TestGrid Admin Portal</a></MenuItem>
               </Drawer>
               <Paper style={paperStyle} zDepth={2}>
                 <Switch>

--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -25,6 +25,7 @@ import FlatButton from 'material-ui/FlatButton';
 import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_API_CONTEXT, TESTGRID_CONTEXT} from '../constants.js';
 import {Alert, Input, Table} from 'reactstrap';
 import Moment from "moment/moment";
+import {HTTP_NOT_FOUND} from "../constants";
 
 class DeploymentPatternView extends Component {
 
@@ -33,15 +34,21 @@ class DeploymentPatternView extends Component {
     this.state = {
       hits: [],
       hitsClone: [],
-      product: null
+      product: null,
+      productExists: true
     };
+    this.handleError = this.handleError.bind(this);
   }
 
   handleError(response) {
+    if (response.status === HTTP_NOT_FOUND) {
+      this.setState({productExists: false});
+    }
+
     if (response.status.toString() === HTTP_UNAUTHORIZED) {
       window.location.replace(LOGIN_URI);
     } else if (!response.ok) {
-      throw Error(response.statusText)
+      throw Error(response.status + " " + response.statusText)
     }
     return response;
   }
@@ -99,7 +106,7 @@ class DeploymentPatternView extends Component {
         return response.json()
       })
       .then(data => this.setState({hits: data, hitsClone: data, product: currentProduct}))
-      .catch(error => console.error(error));
+      .catch(error => console.error("error while fetching product details: " + error));
   }
 
   navigateToRoute(route, deployment, testPlan) {
@@ -182,7 +189,7 @@ class DeploymentPatternView extends Component {
           }
         })()}
 
-        {this.state && !this.state.product && (() => {
+        {this.state && this.state.productExists === false && (() => {
           return <Alert color="dark">
             <p/>
             <h5>

--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -22,8 +22,8 @@ import SingleRecord from './SingleRecord.js';
 import {add_current_deployment, add_current_infra} from '../actions/testGridActions.js';
 import ReactTooltip from 'react-tooltip'
 import FlatButton from 'material-ui/FlatButton';
-import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT, TESTGRID_API_CONTEXT} from '../constants.js';
-import {Table, Input, Alert} from 'reactstrap';
+import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_API_CONTEXT, TESTGRID_CONTEXT} from '../constants.js';
+import {Alert, Input, Table} from 'reactstrap';
 import Moment from "moment/moment";
 
 class DeploymentPatternView extends Component {
@@ -61,9 +61,10 @@ class DeploymentPatternView extends Component {
   };
 
   componentDidMount() {
-    let currentProduct = this.props.active.reducer.currentProduct;
-    if (!currentProduct) {
-      let url = TESTGRID_API_CONTEXT + '/api/products/product-status/' + window.location.href.split("/").pop();
+    let currentProduct = this.state.product;
+    let productName = this.props.match.params.productName;
+    if (!currentProduct || productName !== currentProduct.productName) {
+      let url = TESTGRID_API_CONTEXT + '/api/products/product-status/' + productName;
       fetch(url, {
         method: "GET",
         credentials: 'same-origin',
@@ -180,186 +181,208 @@ class DeploymentPatternView extends Component {
               </Alert>;
           }
         })()}
-        <div>
-          <Input placeholder="Search Infra..." innerRef={Input => this.search = Input} onChange={this.handleInputChange}/>
-        </div>
-        <Table responsive bordered className='deployment-pattern-view' fixedHeader={false} size="sm">
-          <thead displaySelectAll={false} adjustForCheckbox={false}>
-          <tr style={{borderBottom: '0'}}>
-            <th rowSpan='2' className="text-center">Deployment Pattern</th>
-            <th className="text-center">Infra Combination</th>
-            <th rowSpan='2' className="text-center">Last Build</th>
-            <th rowSpan='2' className="text-center">Last Failure</th>
-          </tr>
-          <tr class='infra-param-header'>
-            <td>
-              <p className="text-center">OS</p>
-              <p className="text-center">Database</p>
-              <p className="text-center">JDK</p>
-            </td>
-          </tr>
-          </thead>
-          <tbody displayRowCheckbox={false}>
-          {this.state && this.state.product && Object.keys(groupByDeployment).map((key) => {
-            return (
-              groupByDeployment[key].map((value, index) => {
-                var infraParameters = JSON.parse(value.lastBuild.infraParams);
-                if (index === 0) {
+
+        {this.state && !this.state.product && (() => {
+          return <Alert color="dark">
+            <p/>
+            <h5>
+              <i className="fa fa-exclamation-circle" aria-hidden="true" data-tip="404 not found!"> </i>
+              <ReactTooltip/>
+              {" Job '" + this.props.match.params.productName + "' not found."}
+            </h5>
+            <br/>
+            <br/>
+            <br/>
+          </Alert>;
+        })()}
+
+        {this.state && this.state.product && (() => {
+          return (
+            <div>
+              <div>
+                <Input placeholder="Search Infra..." innerRef={Input => this.search = Input}
+                       onChange={this.handleInputChange}/>
+              </div>
+              <Table responsive bordered className='deployment-pattern-view' fixedHeader={false} size="sm">
+                <thead displaySelectAll={false} adjustForCheckbox={false}>
+                <tr style={{borderBottom: '0'}}>
+                  <th rowSpan='2' className="text-center">Deployment Pattern</th>
+                  <th className="text-center">Infra Combination</th>
+                  <th rowSpan='2' className="text-center">Last Build</th>
+                  <th rowSpan='2' className="text-center">Last Failure</th>
+                </tr>
+                <tr class='infra-param-header'>
+                  <td>
+                    <p className="text-center">OS</p>
+                    <p className="text-center">Database</p>
+                    <p className="text-center">JDK</p>
+                  </td>
+                </tr>
+                </thead>
+                <tbody displayRowCheckbox={false}>
+                {this.state && this.state.product && Object.keys(groupByDeployment).map((key) => {
                   return (
-                    <tr>
-                      <td class='deployment-pattern-name'
-                          rowSpan={groupByDeployment[key].length}>{key}</td>
-                      <td style={{whiteSpace: 'normal', wordWrap: 'break-word'}}>
-                        <FlatButton class='view-history' data-tip="View History"
-                                    onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
-                                      this.state.product.productName + "/" + key + "/" +
-                                      value.lastBuild.id +
-                                      "/infra", {deploymentPatternName: key}, {
-                                      testPlanId: value.lastBuild.id,
-                                      infraParameters: value.lastBuild.infraParams,
-                                      testPlanStatus: value.lastBuild.status
-                                    })}>
-                          <p class='infra-param'>
-                            {infraParameters.OS} {infraParameters.OSVersion}
-                          </p>
-                          <p class='infra-param'>
-                            {infraParameters.DBEngine} {infraParameters.DBEngineVersion}
-                          </p>
-                          <p class='infra-param'>
-                            {infraParameters.JDK}
-                          </p>
-                        </FlatButton>
-                        <ReactTooltip/>
-                      </td>
-                      <td>
-                        <FlatButton style={{height: 'inherit', width: '100%', maxWidth: '150px'}}
-                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
-                            this.state.product.productName + "/" + key + "/test-plans/" +
-                            value.lastBuild.id, {
-                            deploymentPatternName: key
-                          }, {
-                            testPlanId: value.lastBuild.id,
-                            infraParameters: value.lastBuild.infraParams,
-                            testPlanStatus: value.lastBuild.status
-                          })}>
-                          <SingleRecord value={value.lastBuild.status}
-                                        time={value.lastBuild.modifiedTimestamp}/>
-                        </FlatButton>
-                      </td>
-                      <td style={{fontSize: '16px'}}>
-                        {(() => {
-                          if (value.lastFailed.modifiedTimestamp) {
-                            return (
-                              <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT +
-                                "/" + this.state.product.productName + "/" + key +
-                                "/test-plans/" + value.lastFailed.id,
-                                {deploymentPatternName: key}, {
-                                  testPlanId: value.lastFailed.id,
-                                  infraParameters: value.lastFailed.infraParams,
-                                  testPlanStatus: value.lastFailed.status
-                                })}
-                                 style={{cursor: 'pointer'}}>{Moment(value.lastFailed.modifiedTimestamp).fromNow()}</i>
-                            );
-                          } else {
-                            return (
-                              <FlatButton
-                                style={{fontSize: '16px'}}>No failed builds yet!
+                    groupByDeployment[key].map((value, index) => {
+                      var infraParameters = JSON.parse(value.lastBuild.infraParams);
+                      if (index === 0) {
+                        return (
+                          <tr>
+                            <td class='deployment-pattern-name'
+                                rowSpan={groupByDeployment[key].length}>{key}</td>
+                            <td style={{whiteSpace: 'normal', wordWrap: 'break-word'}}>
+                              <FlatButton class='view-history' data-tip="View History"
+                                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
+                                            this.state.product.productName + "/" + key + "/test-plans/" +
+                                            value.lastBuild.id +
+                                            "/history", {deploymentPatternName: key}, {
+                                            testPlanId: value.lastBuild.id,
+                                            infraParameters: value.lastBuild.infraParams,
+                                            testPlanStatus: value.lastBuild.status
+                                          })}>
+                                <p class='infra-param'>
+                                  {infraParameters.OS} {infraParameters.OSVersion}
+                                </p>
+                                <p class='infra-param'>
+                                  {infraParameters.DBEngine} {infraParameters.DBEngineVersion}
+                                </p>
+                                <p class='infra-param'>
+                                  {infraParameters.JDK}
+                                </p>
                               </FlatButton>
-                            )
-                          }
-                        })()}
-                      </td>
-                      {/* Note: Commented until the backend coordination is configured.
-                        <td>
-                        <Button outline color="info" size="sm" onClick={() => {
-                          window.location =
-                            '/admin/job/' + this.state.product.productName + '/build'
-                        }}>
-                          <i className="fa fa-play-circle" aria-hidden="true"> </i>
-                        </Button>
-                        <ReactTooltip/></td>*/}
-                    </tr>
-                  )
-                } else {
-                  return (
-                    <tr>
-                      <td style={{whiteSpace: 'normal', wordWrap: 'break-word'}}>
-                        <FlatButton class='view-history' data-tip="View History"
-                                    onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
-                                      this.state.product.productName + "/" + key + "/" +
-                                      value.lastBuild.id + "/infra",
+                              <ReactTooltip/>
+                            </td>
+                            <td>
+                              <FlatButton style={{height: 'inherit', width: '100%', maxWidth: '150px'}}
+                                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
+                                            this.state.product.productName + "/" + key + "/test-plans/" +
+                                            value.lastBuild.id, {
+                                            deploymentPatternName: key
+                                          }, {
+                                            testPlanId: value.lastBuild.id,
+                                            infraParameters: value.lastBuild.infraParams,
+                                            testPlanStatus: value.lastBuild.status
+                                          })}>
+                                <SingleRecord value={value.lastBuild.status}
+                                              time={value.lastBuild.modifiedTimestamp}/>
+                              </FlatButton>
+                            </td>
+                            <td style={{fontSize: '16px'}}>
+                              {(() => {
+                                if (value.lastFailed.modifiedTimestamp) {
+                                  return (
+                                    <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT +
+                                      "/" + this.state.product.productName + "/" + key +
+                                      "/test-plans/" + value.lastFailed.id,
                                       {deploymentPatternName: key}, {
-                                        testPlanId: value.lastBuild.id,
-                                        infraParameters: value.lastBuild.infraParams,
-                                        testPlanStatus: value.lastBuild.status
-                                      })}>
-                          <p class='infra-param'>
-                            {infraParameters.OS} {infraParameters.OSVersion}
-                          </p>
-                          <p class='infra-param'>
-                            {infraParameters.DBEngine} {infraParameters.DBEngineVersion}
-                          </p>
-                          <p class='infra-param'>
-                            {infraParameters.JDK}
-                          </p>
-                        </FlatButton>
-                        <ReactTooltip/>
-                      </td>
-                      <td>
-                        <FlatButton style={{height: 'inherit', width: '100%', maxWidth: '150px'}}
-                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
-                            this.state.product.productName + "/" + key + "/test-plans/" +
-                            value.lastFailed.id, {
-                            deploymentPatternName: key
-                          }, {
-                            testPlanId: value.lastBuild.id,
-                            infraParameters: value.lastBuild.infraParams,
-                            testPlanStatus: value.lastBuild.status
-                          })}>
-                          <SingleRecord value={value.lastBuild.status}
-                                        time={value.lastBuild.modifiedTimestamp}/>
-                        </FlatButton>
-                      </td>
-                      <td style={{fontSize: '16px'}}>
-                        {(() => {
-                          if (value.lastFailed.modifiedTimestamp) {
-                            return (
-                              <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT +
-                                "/" + this.state.product.productName + "/" + key +
-                                "/test-plans/" + value.lastFailed.id,
-                                {deploymentPatternName: key}, {
-                                  testPlanId: value.lastFailed.id,
-                                  infraParameters: value.lastFailed.infraParams,
-                                  testPlanStatus: value.lastFailed.status
-                                })}
-                                 style={{cursor: 'pointer'}}>{Moment(value.lastFailed.modifiedTimestamp).fromNow()}</i>
-                            );
-                          } else {
-                            return (
-                              <FlatButton style={{fontSize: '16px'}}>
-                                No failed builds yet!
+                                        testPlanId: value.lastFailed.id,
+                                        infraParameters: value.lastFailed.infraParams,
+                                        testPlanStatus: value.lastFailed.status
+                                      })}
+                                       style={{cursor: 'pointer'}}>{Moment(value.lastFailed.modifiedTimestamp).fromNow()}</i>
+                                  );
+                                } else {
+                                  return (
+                                    <FlatButton
+                                      style={{fontSize: '16px'}}>No failed builds yet!
+                                    </FlatButton>
+                                  )
+                                }
+                              })()}
+                            </td>
+                              {/* Note: Commented until the backend coordination is configured.
+                          <td>
+                          <Button outline color="info" size="sm" onClick={() => {
+                            window.location =
+                              '/admin/job/' + this.state.product.productName + '/build'
+                          }}>
+                            <i className="fa fa-play-circle" aria-hidden="true"> </i>
+                          </Button>
+                          <ReactTooltip/></td>*/}
+                          </tr>
+                        )
+                      } else {
+                        return (
+                          <tr>
+                            <td style={{whiteSpace: 'normal', wordWrap: 'break-word'}}>
+                              <FlatButton class='view-history' data-tip="View History"
+                                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
+                                            this.state.product.productName + "/" + key + "/test-plans/" +
+                                            value.lastBuild.id + "/history",
+                                            {deploymentPatternName: key}, {
+                                              testPlanId: value.lastBuild.id,
+                                              infraParameters: value.lastBuild.infraParams,
+                                              testPlanStatus: value.lastBuild.status
+                                            })}>
+                                <p class='infra-param'>
+                                  {infraParameters.OS} {infraParameters.OSVersion}
+                                </p>
+                                <p class='infra-param'>
+                                  {infraParameters.DBEngine} {infraParameters.DBEngineVersion}
+                                </p>
+                                <p class='infra-param'>
+                                  {infraParameters.JDK}
+                                </p>
                               </FlatButton>
-                            )
-                          }
-                        })()}
-                      </td>
-                      {/* Note: Commented until the backend coordination is configured.
-                        <td>
-                        <Button outline color="info" size="sm" onClick={() => {
-                          window.location =
-                            '/admin/job/' + this.state.product.productName + '/build'
-                        }}>
-                          <i className="fa fa-play-circle" aria-hidden="true"> </i>
-                        </Button>
-                      </td> */}
-                    </tr>
+                              <ReactTooltip/>
+                            </td>
+                            <td>
+                              <FlatButton style={{height: 'inherit', width: '100%', maxWidth: '150px'}}
+                                          onClick={() => this.navigateToRoute(TESTGRID_CONTEXT + "/" +
+                                            this.state.product.productName + "/" + key + "/test-plans/" +
+                                            value.lastFailed.id, {
+                                            deploymentPatternName: key
+                                          }, {
+                                            testPlanId: value.lastBuild.id,
+                                            infraParameters: value.lastBuild.infraParams,
+                                            testPlanStatus: value.lastBuild.status
+                                          })}>
+                                <SingleRecord value={value.lastBuild.status}
+                                              time={value.lastBuild.modifiedTimestamp}/>
+                              </FlatButton>
+                            </td>
+                            <td style={{fontSize: '16px'}}>
+                              {(() => {
+                                if (value.lastFailed.modifiedTimestamp) {
+                                  return (
+                                    <i onClick={() => this.navigateToRoute(TESTGRID_CONTEXT +
+                                      "/" + this.state.product.productName + "/" + key +
+                                      "/test-plans/" + value.lastFailed.id,
+                                      {deploymentPatternName: key}, {
+                                        testPlanId: value.lastFailed.id,
+                                        infraParameters: value.lastFailed.infraParams,
+                                        testPlanStatus: value.lastFailed.status
+                                      })}
+                                       style={{cursor: 'pointer'}}>{Moment(value.lastFailed.modifiedTimestamp).fromNow()}</i>
+                                  );
+                                } else {
+                                  return (
+                                    <FlatButton style={{fontSize: '16px'}}>
+                                      No failed builds yet!
+                                    </FlatButton>
+                                  )
+                                }
+                              })()}
+                            </td>
+                            {/* Note: Commented until the backend coordination is configured.
+                          <td>
+                          <Button outline color="info" size="sm" onClick={() => {
+                            window.location =
+                              '/admin/job/' + this.state.product.productName + '/build'
+                          }}>
+                            <i className="fa fa-play-circle" aria-hidden="true"> </i>
+                          </Button>
+                        </td> */}
+                          </tr>
+                        )
+                      }
+                    })
                   )
-                }
-              })
-            )
-          })}
-          </tbody>
-        </Table>
+                })}
+                </tbody>
+              </Table>
+            </div>
+          )
+        })()}
       </div>
     );
   }

--- a/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
+++ b/web/src/main/react-dashboard/src/components/DeploymentPatternView.js
@@ -22,7 +22,7 @@ import SingleRecord from './SingleRecord.js';
 import {add_current_deployment, add_current_infra} from '../actions/testGridActions.js';
 import ReactTooltip from 'react-tooltip'
 import FlatButton from 'material-ui/FlatButton';
-import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT} from '../constants.js';
+import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT, TESTGRID_API_CONTEXT} from '../constants.js';
 import {Table, Input, Alert} from 'reactstrap';
 import Moment from "moment/moment";
 
@@ -63,7 +63,7 @@ class DeploymentPatternView extends Component {
   componentDidMount() {
     let currentProduct = this.props.active.reducer.currentProduct;
     if (!currentProduct) {
-      let url = TESTGRID_CONTEXT + '/api/products/product-status/' + window.location.href.split("/").pop();
+      let url = TESTGRID_API_CONTEXT + '/api/products/product-status/' + window.location.href.split("/").pop();
       fetch(url, {
         method: "GET",
         credentials: 'same-origin',
@@ -86,7 +86,7 @@ class DeploymentPatternView extends Component {
   }
 
   getDeploymentDetails(currentProduct) {
-    let url = TESTGRID_CONTEXT + '/api/test-plans/product/' + currentProduct.productId;
+    let url = TESTGRID_API_CONTEXT + '/api/test-plans/product/' + currentProduct.productId;
     fetch(url, {
       method: "GET",
       credentials: 'same-origin',

--- a/web/src/main/react-dashboard/src/components/InfraCombinationView.js
+++ b/web/src/main/react-dashboard/src/components/InfraCombinationView.js
@@ -23,8 +23,8 @@ import {add_current_infra, add_current_deployment} from '../actions/testGridActi
 import FlatButton from 'material-ui/FlatButton';
 import Divider from 'material-ui/Divider';
 import Moment from 'moment';
-import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT, DID_NOT_RUN, INCOMPLETE}
-  from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT, TESTGRID_API_CONTEXT,
+  DID_NOT_RUN, INCOMPLETE} from '../constants.js';
 import {Card, CardText, CardTitle, Col, Row, Table} from 'reactstrap';
 import ReactTooltip from 'react-tooltip'
 
@@ -70,7 +70,7 @@ class InfraCombinationView extends Component {
 
   componentDidMount() {
     let currentUrl = window.location.href.split("/");
-    let url = TESTGRID_CONTEXT + "/api/test-plans/history/" + currentUrl[currentUrl.length - 2];
+    let url = TESTGRID_API_CONTEXT + "/api/test-plans/history/" + currentUrl[currentUrl.length - 2];
     let currentInfra;
     fetch(url, {
       method: "GET",

--- a/web/src/main/react-dashboard/src/components/InfraCombinationView.js
+++ b/web/src/main/react-dashboard/src/components/InfraCombinationView.js
@@ -69,8 +69,7 @@ class InfraCombinationView extends Component {
   }
 
   componentDidMount() {
-    let currentUrl = window.location.href.split("/");
-    let url = TESTGRID_API_CONTEXT + "/api/test-plans/history/" + currentUrl[currentUrl.length - 2];
+    let url = TESTGRID_API_CONTEXT + "/api/test-plans/history/" + this.props.match.params.testPlanId;
     let currentInfra;
     fetch(url, {
       method: "GET",
@@ -84,7 +83,6 @@ class InfraCombinationView extends Component {
         return response.json()
       })
       .then(data => {
-        let currentUrl = window.location.href.split("/");
         if (this.props.active.reducer.currentInfra && this.props.active.reducer.currentInfra.testPlanId === data[0].id) {
           currentInfra = this.props.active.reducer.currentInfra;
         } else {
@@ -94,8 +92,8 @@ class InfraCombinationView extends Component {
           currentInfra.testPlanStatus = data[0].status;
           this.props.active.reducer.currentInfra = currentInfra;
         }
-        currentInfra.relatedProduct = currentUrl[currentUrl.length - 4];
-        currentInfra.relatedDeplymentPattern = currentUrl[currentUrl.length - 3];
+        currentInfra.relatedProduct = this.props.match.params.productName;
+        currentInfra.relatedDeplymentPattern = this.props.match.params.deploymentPatternName;
         this.setState({hits: data, currentInfra: currentInfra});
       })
       .catch(error => console.error(error));

--- a/web/src/main/react-dashboard/src/components/ProductStatusView.js
+++ b/web/src/main/react-dashboard/src/components/ProductStatusView.js
@@ -21,7 +21,8 @@ import '../App.css';
 import SingleRecord from './SingleRecord.js';
 import {add_current_product} from '../actions/testGridActions.js';
 import Moment from 'moment'
-import {HTTP_OK, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT} from '../constants.js';
+import {HTTP_OK, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, LOGIN_URI,
+  TESTGRID_CONTEXT, TESTGRID_API_CONTEXT} from '../constants.js';
 import {Button, Table, Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 
 class ProductStatusView extends Component {
@@ -55,7 +56,7 @@ class ProductStatusView extends Component {
   }
 
   componentDidMount() {
-    var url = TESTGRID_CONTEXT + '/api/products/product-status';
+    var url = TESTGRID_API_CONTEXT + '/api/products/product-status';
     fetch(url, {
       method: "GET",
       credentials: 'same-origin',
@@ -77,7 +78,7 @@ class ProductStatusView extends Component {
   }
 
   downloadReport(productName) {
-    let url = TESTGRID_CONTEXT + '/api/products/reports?product-name=' + productName;
+    let url = TESTGRID_API_CONTEXT + '/api/products/reports?product-name=' + productName;
     fetch(url, {
       method: "HEAD",
       credentials: 'same-origin',

--- a/web/src/main/react-dashboard/src/components/ScenarioView.js
+++ b/web/src/main/react-dashboard/src/components/ScenarioView.js
@@ -21,7 +21,7 @@ import '../App.css';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
 import {add_current_scenario} from '../actions/testGridActions.js';
-import {TESTGRID_CONTEXT, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
+import {TESTGRID_CONTEXT, TESTGRID_API_CONTEXT, HTTP_UNAUTHORIZED, LOGIN_URI} from '../constants.js';
 import {Table} from 'reactstrap';
 
 class ScenarioView extends Component {
@@ -49,7 +49,7 @@ class ScenarioView extends Component {
   }
 
   componentDidMount() {
-    var url = TESTGRID_CONTEXT + "/api/test-plans/" +
+    var url = TESTGRID_API_CONTEXT + "/api/test-plans/" +
       this.props.active.reducer.currentInfra.infrastructureId + "?require-test-scenario-info=true";
 
     fetch(url, {

--- a/web/src/main/react-dashboard/src/components/TestCaseView.js
+++ b/web/src/main/react-dashboard/src/components/TestCaseView.js
@@ -20,7 +20,7 @@ import React, {Component} from 'react';
 import '../App.css';
 import Subheader from 'material-ui/Subheader';
 import SingleRecord from './SingleRecord.js';
-import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT} from '../constants.js';
+import {HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_API_CONTEXT} from '../constants.js';
 import {Table} from 'reactstrap';
 
 class TestCaseView extends Component {
@@ -43,7 +43,7 @@ class TestCaseView extends Component {
   }
 
   componentDidMount() {
-    var url = TESTGRID_CONTEXT + '/api/test-scenarios/' + this.props.active.reducer.currentScenario.scenarioId;
+    var url = TESTGRID_API_CONTEXT + '/api/test-scenarios/' + this.props.active.reducer.currentScenario.scenarioId;
 
     fetch(url, {
       method: "GET",

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -24,8 +24,8 @@ import Divider from 'material-ui/Divider';
 import LinearProgress from 'material-ui/LinearProgress';
 import FlatButton from 'material-ui/FlatButton';
 import Snackbar from 'material-ui/Snackbar';
-import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, LOGIN_URI, TESTGRID_CONTEXT, DID_NOT_RUN, INCOMPLETE}
-  from '../constants.js';
+import {FAIL, SUCCESS, ERROR, PENDING, RUNNING, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, LOGIN_URI,
+  TESTGRID_API_CONTEXT, DID_NOT_RUN, INCOMPLETE} from '../constants.js';
 import {Button, Table, Card, CardText, CardTitle, Col, Row} from 'reactstrap';
 import InfraCombinationView from "./InfraCombinationView";
 import ReactTooltip from 'react-tooltip'
@@ -68,7 +68,7 @@ class TestRunView extends Component {
       this.setState({currentInfra: currentInfra});
       this.getGrafanaUrl(currentInfra.testPlanId);
     } else {
-      let url = TESTGRID_CONTEXT + "/api/test-plans/" + currentUrl.pop();
+      let url = TESTGRID_API_CONTEXT + "/api/test-plans/" + currentUrl.pop();
       fetch(url, {
         method: "GET",
         credentials: 'same-origin',
@@ -94,8 +94,8 @@ class TestRunView extends Component {
   }
 
   getReportData(currentInfra) {
-    const testScenarioSummaryUrl = TESTGRID_CONTEXT + '/api/test-plans/test-summary/' + currentInfra.testPlanId;
-    const logTruncatedContentUrl = TESTGRID_CONTEXT + '/api/test-plans/log/' + currentInfra.testPlanId
+    const testScenarioSummaryUrl = TESTGRID_API_CONTEXT + '/api/test-plans/test-summary/' + currentInfra.testPlanId;
+    const logTruncatedContentUrl = TESTGRID_API_CONTEXT + '/api/test-plans/log/' + currentInfra.testPlanId
       + "?truncate=" + true;
 
     fetch(testScenarioSummaryUrl, {
@@ -164,7 +164,7 @@ class TestRunView extends Component {
   }
 
   downloadScenarioResult(scenarioId) {
-    let url = TESTGRID_CONTEXT + '/api/test-plans/result/' + this.state.currentInfra.testPlanId + "/" + scenarioId;
+    let url = TESTGRID_API_CONTEXT + '/api/test-plans/result/' + this.state.currentInfra.testPlanId + "/" + scenarioId;
     fetch(url, {
       method: "GET",
       credentials: 'same-origin',
@@ -185,7 +185,7 @@ class TestRunView extends Component {
   }
 
   downloadTestOutputs(scenarioId) {
-    let url = TESTGRID_CONTEXT + '/api/test-plans/result/' + this.state.currentInfra.testPlanId;
+    let url = TESTGRID_API_CONTEXT + '/api/test-plans/result/' + this.state.currentInfra.testPlanId;
     fetch(url, {
       method: "GET",
       credentials: 'same-origin',
@@ -206,7 +206,7 @@ class TestRunView extends Component {
   }
 
   checkIfTestRunLogExists() {
-    const path = TESTGRID_CONTEXT + '/api/test-plans/log/' + window.location.href.split("/").pop() +
+    const path = TESTGRID_API_CONTEXT + '/api/test-plans/log/' + window.location.href.split("/").pop() +
       "?truncate=" + true;
     fetch(path, {
       method: "HEAD",
@@ -222,7 +222,7 @@ class TestRunView extends Component {
   }
 
   async getGrafanaUrl(testid){
-    const grafanaUrl = TESTGRID_CONTEXT + '/api/test-plans/perf-url/' + testid;
+    const grafanaUrl = TESTGRID_API_CONTEXT + '/api/test-plans/perf-url/' + testid;
     const fetchResult = fetch(grafanaUrl, {
                             method: "GET",
                             credentials: 'same-origin',
@@ -241,7 +241,7 @@ class TestRunView extends Component {
     var pageURL = window.location.href;
     const PERFDASH_URL = this.state.grafanaUrl
     const divider = (<Divider inset={false} style={{borderBottomWidth: 1}}/>);
-    const logUrl = TESTGRID_CONTEXT + '/api/test-plans/log/' + pageURL.split("/").pop() + "?truncate=";
+    const logUrl = TESTGRID_API_CONTEXT + '/api/test-plans/log/' + pageURL.split("/").pop() + "?truncate=";
     const logAllContentUrl = logUrl + false;
     const turncatedRunLogUrl = logUrl + true;
 

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -314,7 +314,8 @@ class TestRunView extends Component {
                       .then(response => {
                         if (response.status !== HTTP_OK) {
                           this.toggle("Error on downloading log file...");
-                          document.getElementById('logConsole').style.display = "none";
+                          if (document.getElementById('logConsole') !== null)
+                            document.getElementById('logConsole').style.display = "none"
                         } else {
                           window.open(logAllContentUrl, '_blank', false);
                         }

--- a/web/src/main/react-dashboard/src/constants.js
+++ b/web/src/main/react-dashboard/src/constants.js
@@ -10,3 +10,4 @@ export const HTTP_OK = 200;
 export const HTTP_NOT_FOUND = 404;
 export const LOGIN_URI = "/login";
 export const TESTGRID_CONTEXT = "";
+export const TESTGRID_API_CONTEXT = "";


### PR DESCRIPTION
**Purpose**
This PR fixes dashboard job name caching issue.

In addition, it also,
- Introduces TESTGRID_API_CONTEXT to support pointing to different API endpoint
- Provide a link to go back to dashboard home page
- Improve local dashboard testing support

**Goals**
Better functionality of the dashboard

**Approach**

Previously, we extracted the product name, dep pattern name etc. from the url via `window.location.href.split('/')`. This is error-prone.

This improves the existing logic by using the react-router-dom's url match support. The url parameters added to router can be accessed via `this.props.match.params-{param-name}`.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
