### PR TITLE
Append scenrioConfig name to test file path

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -260,7 +260,8 @@ public class TestPlanExecutor {
                 TestExecutor testExecutor = TestExecutorFactory.getTestExecutor(
                         TestEngine.valueOf(scenarioConfig.getTestType()));
 
-                Path scenarioDir = Paths.get(testPlan.getScenarioTestsRepository(), scenarioConfig.getFile());
+                Path scenarioDir = Paths.get(testPlan.getScenarioTestsRepository(), scenarioConfig.getName(),
+                        scenarioConfig.getFile());
                 if (scenarioDir !=  null) {
                     Path parent = scenarioDir.getParent();
                     Path file = scenarioDir.getFileName();


### PR DESCRIPTION
**Purpose**
Add scenrioConfig name before the  test file path to support multiple scenarioConfigs


**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
