### PR TITLE
Enable viewing WSO2 logs for each test plan 

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -92,22 +92,4 @@ public class TestGridConstants {
 
 
     public static final String NOT_CONFIGURED_STR = "/not-configured/";
-
-    // Ctx for dashboard with place holders to be replaced for each test plan
-    public static  final String KIBANA_DASHBOARD_STR = "/app/kibana#/dashboard/171ab700-f6f4-11e8-9563-f7edf14e1790?" +
-            "_g=(refreshInterval:('$$hashKey':'object:374',display:Off,pause:!f,section:0,value:0)," +
-            "time:(from:now%2FM,mode:quick,to:now))&_a=(description:'',filters:!(('$state':(store:appState)," +
-            "meta:(alias:'All%20logs',disabled:!f,index:e0c3bc10-f6f3-11e8-9563-f7edf14e1790,key:_index,negate:!f," +
-            "params:(query:'#_STACK_NAME_#*',type:phrase),type:phrase,value:'#_STACK_NAME_#*'),query:(match:(_index:" +
-            "(query:'#_STACK_NAME_#*',type:phrase)))),#_NODE_FILTERS_#),fullScreenMode:!t,options:(darkTheme:!t," +
-            "hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:30,i:'1',w:48,x:0,y:0)," +
-            "id:f7db4b70-f6f3-11e8-9563-f7edf14e1790,panelIndex:'1',sort:!('@timestamp',desc),type:search," +
-            "version:'6.3.1')),query:(language:lucene,query:''),timeRestore:!t,title:All-TPs,viewMode:view)";
-
-    // Filter string with place holders to be replaced for each instance in a stack
-    public static final String KIBANA_FILTER_STR = "('$state':(store:appState),meta:(alias:#_LABEL_#,disabled:!t," +
-            "index:e0c3bc10-f6f3-11e8-9563-f7edf14e1790,key:_index,negate:!f," +
-            "params:(query:#_STACK_NAME_#-#_INSTANCE_ID_#,type:phrase),type:phrase," +
-            "value:#_STACK_NAME_#-#_INSTANCE_ID_#),query:(match:(_index:(query:#_STACK_NAME_#-#_INSTANCE_ID_#," +
-            "type:phrase))))";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -92,4 +92,22 @@ public class TestGridConstants {
 
 
     public static final String NOT_CONFIGURED_STR = "/not-configured/";
+
+    // Ctx for dashboard with place holders to be replaced for each test plan
+    public static  final String KIBANA_DASHBOARD_STR = "/app/kibana#/dashboard/171ab700-f6f4-11e8-9563-f7edf14e1790?" +
+            "_g=(refreshInterval:('$$hashKey':'object:374',display:Off,pause:!f,section:0,value:0)," +
+            "time:(from:now%2FM,mode:quick,to:now))&_a=(description:'',filters:!(('$state':(store:appState)," +
+            "meta:(alias:'All%20logs',disabled:!f,index:e0c3bc10-f6f3-11e8-9563-f7edf14e1790,key:_index,negate:!f," +
+            "params:(query:'#_STACK_NAME_#*',type:phrase),type:phrase,value:'#_STACK_NAME_#*'),query:(match:(_index:" +
+            "(query:'#_STACK_NAME_#*',type:phrase)))),#_NODE_FILTERS_#),fullScreenMode:!t,options:(darkTheme:!t," +
+            "hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(),gridData:(h:30,i:'1',w:48,x:0,y:0)," +
+            "id:f7db4b70-f6f3-11e8-9563-f7edf14e1790,panelIndex:'1',sort:!('@timestamp',desc),type:search," +
+            "version:'6.3.1')),query:(language:lucene,query:''),timeRestore:!t,title:All-TPs,viewMode:view)";
+
+    // Filter string with place holders to be replaced for each instance in a stack
+    public static final String KIBANA_FILTER_STR = "('$state':(store:appState),meta:(alias:#_LABEL_#,disabled:!t," +
+            "index:e0c3bc10-f6f3-11e8-9563-f7edf14e1790,key:_index,negate:!f," +
+            "params:(query:#_STACK_NAME_#-#_INSTANCE_ID_#,type:phrase),type:phrase," +
+            "value:#_STACK_NAME_#-#_INSTANCE_ID_#),query:(match:(_index:(query:#_STACK_NAME_#-#_INSTANCE_ID_#," +
+            "type:phrase))))";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -76,6 +76,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     @Column(name = "test_run_number")
     private int testRunNumber;
 
+    @Column(name = "log_url")
+    private String logUrl;
+
     @ManyToOne(optional = false, cascade = CascadeType.ALL, targetEntity = DeploymentPattern.class,
                fetch = FetchType.LAZY)
     @PrimaryKeyJoinColumn(name = "DEPLOYMENTPATTERN_id", referencedColumnName = ID_COLUMN)
@@ -416,6 +419,24 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
      */
     public void setKeyFileLocation(String keyFileLocation) {
         this.keyFileLocation = keyFileLocation;
+    }
+
+    /**
+     * Returns the URL to view WSO2 server logs.
+     *
+     * @return Log location URL
+     */
+    public String getLogUrl() {
+        return logUrl;
+    }
+
+    /**
+     * Returns the URL to view WSO2 server logs.
+     *
+     * @param logUrl Log location URL
+     */
+    public void setLogUrl(String logUrl) {
+        this.logUrl = logUrl;
     }
 
     @Override

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -219,8 +219,19 @@ public class ConfigurationContext {
          * Interval (in hours) to run finalize run testplan
          */
         FINALIZE_RUN_TESTPLAN_INTERVAL("FINALIZE_RUN_TESTPLAN_INTERVAL"),
+
         /**
          * Kibana dashboard endpoint to view WSO2 logs
+         */
+        KIBANA_DASHBOARD_STR("KIBANA_DASHBOARD_STR"),
+
+        /**
+         * Kibana dashboard ctx with placeholders
+         */
+        KIBANA_FILTER_STR("KIBANA_FILTER_STR"),
+
+        /**
+         * Kibana dashboard filter with placeholders
          */
         KIBANA_ENDPOINT_URL("KIBANA_ENDPOINT_URL");
 

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -218,7 +218,11 @@ public class ConfigurationContext {
         /**
          * Interval (in hours) to run finalize run testplan
          */
-        FINALIZE_RUN_TESTPLAN_INTERVAL("FINALIZE_RUN_TESTPLAN_INTERVAL");
+        FINALIZE_RUN_TESTPLAN_INTERVAL("FINALIZE_RUN_TESTPLAN_INTERVAL"),
+        /**
+         * Kibana dashboard endpoint to view WSO2 logs
+         */
+        KIBANA_ENDPOINT_URL("KIBANA_ENDPOINT_URL");
 
 
         private String propertyName;

--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateTestPlanCommand.java
@@ -234,9 +234,6 @@ public class GenerateTestPlanCommand implements Command {
              * Test plans of test scenarios should be persisted. This is persisted after building the
              * yaml to avoid adding unnecessary lines to the test-plan file.
              */
-            for (ScenarioConfig scenarioConfig : testPlan.getScenarioConfigs()) {
-                scenarioConfig.setTestPlan(persistedTestPlan);
-            }
             testPlanUOW.persistTestPlan(persistedTestPlan);
 
             if (printTestPlanPaths) {

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -34,9 +34,20 @@ import com.amazonaws.services.cloudformation.model.TemplateParameter;
 import com.amazonaws.services.cloudformation.model.ValidateTemplateRequest;
 import com.amazonaws.services.cloudformation.model.ValidateTemplateResult;
 import com.amazonaws.services.cloudformation.waiters.AmazonCloudFormationWaiters;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterParameters;
 import com.amazonaws.waiters.WaiterUnrecoverableException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +68,7 @@ import org.wso2.testgrid.common.util.LambdaExceptionUtils;
 import org.wso2.testgrid.common.util.StringUtil;
 import org.wso2.testgrid.common.util.TestGridUtil;
 import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.infrastructure.CloudFormationScriptPreprocessor;
 import org.wso2.testgrid.infrastructure.providers.aws.AMIMapper;
 import org.wso2.testgrid.infrastructure.providers.aws.AWSResourceManager;
@@ -72,12 +84,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * This class provides the infrastructure from amazon web services (AWS).
@@ -96,6 +111,8 @@ public class AWSProvider implements InfrastructureProvider {
     private static final TimeUnit TIMEOUT_UNIT = TimeUnit.MINUTES;
     private static final int POLL_INTERVAL = 1;
     private static final TimeUnit POLL_UNIT = TimeUnit.MINUTES;
+    private static final String STACK_NAME_TAG_KEY = "aws:cloudformation:stack-name";
+    private static final String INSTANCE_NAME_TAG_KEY = "Name";
 
     @Override
     public String getProviderName() {
@@ -227,6 +244,9 @@ public class AWSProvider implements InfrastructureProvider {
             //Notify AWSResourceManager about stack creation completion
             awsResourceManager.notifyStackCreation(testPlan, script, describeStackEventsResult.getStackEvents());
 
+            //Set log download url to test plan.
+            deriveLogDashboardUrl(testPlan, stackName);
+
             DescribeStacksRequest describeStacksRequest = new DescribeStacksRequest();
             describeStacksRequest.setStackName(stack.getStackId());
             DescribeStacksResult describeStacksResult = cloudFormation
@@ -267,6 +287,81 @@ public class AWSProvider implements InfrastructureProvider {
                     StringUtil.concatStrings("Error occurred while waiting for stack ", stackName), e);
         } catch (TestGridDAOException e) {
             throw new TestGridInfrastructureException("Error occurred while retrieving resource requirements", e);
+        }
+    }
+
+    /**
+     * Constructs the URL to Kibana dashboard to view logs.
+     *
+     * Makes use of the static dashboard having logs of all test plans. Filters to view logs
+     * of each EC2 instance are derived using placeholders. The default view shows all logs. The shortened URL of the
+     * dashboard is retrieved through Kibana ShortenURL API to have a compact url.
+     *
+     * @param testPlan test-plan to get log url for
+     * @param stackName name of the stack created for the test-plan
+     */
+    private void deriveLogDashboardUrl(TestPlan testPlan, String stackName) {
+        String kibanaEndpoint = ConfigurationContext.getProperty(ConfigurationProperties.KIBANA_ENDPOINT_URL);
+        String dashboardCtxFormat = TestGridConstants.KIBANA_DASHBOARD_STR;
+        String instanceLogFilterFormat = TestGridConstants.KIBANA_FILTER_STR;
+        String instanceLogFilter;
+        String instanceName;
+        StringJoiner filtersStr = new StringJoiner(",");
+
+        // Filter the EC2 instance corresponding to the stack
+        AmazonEC2 amazonEC2 = AmazonEC2ClientBuilder.defaultClient();
+        List<Reservation> reservations = amazonEC2.describeInstances().getReservations()
+                .stream().filter(r -> r.getInstances().get(0).getTags().contains(
+                        new Tag(STACK_NAME_TAG_KEY, stackName))).collect(Collectors.toList());
+        Map<String, String> instancesMap = new HashMap<>();
+
+        /* Create a map with instance ids and names to create the log filter. InstanceId is used to filter the index
+           pattern and name is used to set a label for the filter */
+        for (Reservation reservation : reservations) {
+            instanceName = reservation.getInstances().get(0).getTags().stream().filter(
+                    t -> t.getKey().equalsIgnoreCase(INSTANCE_NAME_TAG_KEY))
+                    .collect(Collectors.toList()).get(0).getValue();
+            instancesMap.put(reservation.getInstances().get(0).getInstanceId(), instanceName);
+        }
+
+        // Construct filters for each node
+        for (Map.Entry<String, String> entry : instancesMap.entrySet()) {
+            instanceLogFilter = instanceLogFilterFormat.replaceAll("#_INSTANCE_ID_#", entry.getKey())
+                    .replaceAll("#_LABEL_#", entry.getValue());
+            filtersStr.add(instanceLogFilter);
+        }
+
+        // Construct the dashboard ctx
+        String logDownloadCtx = dashboardCtxFormat.replace("#_NODE_FILTERS_#", filtersStr.toString())
+                .replaceAll("#_STACK_NAME_#", stackName);
+        String logUrl = null;
+
+        // Get the short url to dashboard by calling the Kibana REST API
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            HttpPost request = new HttpPost(kibanaEndpoint + "/shorten");
+            StringEntity entity = new StringEntity("{\"url\" : \"" + logDownloadCtx + "\"}");
+            request.addHeader("Content-Type", "application/json;charset=utf-8");
+            request.addHeader("kbn-xsrf", "true");
+            request.setEntity(entity);
+            CloseableHttpResponse  httpResponse = httpClient.execute(request);
+            if (httpResponse.getStatusLine().getStatusCode() == 200) {
+                String shortUrlId = EntityUtils.toString(httpResponse.getEntity());
+                logUrl = kibanaEndpoint + "/goto/" + shortUrlId;
+            } else {
+                logger.warn("Request to Kibana to retrieve shortened URL for dashboard returned status code:" +
+                        httpResponse.getStatusLine().getStatusCode() + "\n. View logs at: " +
+                        kibanaEndpoint + logDownloadCtx);
+            }
+        } catch (IOException e) {
+            logger.error("Error occurred while trying to retrieve the short URL for Kibana dashboard.", e.getMessage());
+        }
+        testPlan.setLogUrl(logUrl);
+        TestPlanUOW testPlanUOW = new TestPlanUOW();
+        try {
+            testPlanUOW.persistTestPlan(testPlan);
+        } catch (TestGridDAOException e) {
+            logger.error("Error occurred while persisting log URL to test plan."
+                    + testPlan.toString() + e.getMessage());
         }
     }
 

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -63,6 +63,7 @@ import org.wso2.testgrid.common.config.InfrastructureConfig;
 import org.wso2.testgrid.common.config.ScenarioConfig;
 import org.wso2.testgrid.common.config.Script;
 import org.wso2.testgrid.common.infrastructure.AWSResourceLimit;
+import org.wso2.testgrid.dao.uow.TestPlanUOW;
 import org.wso2.testgrid.infrastructure.providers.AWSProvider;
 import org.wso2.testgrid.infrastructure.providers.aws.AMIMapper;
 import org.wso2.testgrid.infrastructure.providers.aws.AWSResourceManager;
@@ -227,10 +228,17 @@ public class AWSProviderTest extends PowerMockTestCase {
         PowerMockito.mockStatic(AmazonEC2ClientBuilder.class);
         PowerMockito.when(AmazonEC2ClientBuilder.defaultClient()).thenReturn(amazonEC2Mock);
         DescribeInstancesResult describeInstancesResult = Mockito.mock(DescribeInstancesResult.class);
-        PowerMockito.when(amazonEC2Mock.describeInstances()).thenReturn(describeInstancesResult);
+        PowerMockito.when(amazonEC2Mock.describeInstances(Mockito.any())).thenReturn(describeInstancesResult);
         PowerMockito.when(describeInstancesResult.getReservations()).thenReturn(getMockReservations());
         PowerMockito.when(ConfigurationContext.getProperty(
                 ConfigurationContext.ConfigurationProperties.KIBANA_ENDPOINT_URL)).thenReturn("http://localhost:5601");
+        PowerMockito.when(ConfigurationContext.getProperty(
+                ConfigurationContext.ConfigurationProperties.KIBANA_DASHBOARD_STR)).thenReturn("dummyDashboardStr");
+        PowerMockito.when(ConfigurationContext.getProperty(
+                ConfigurationContext.ConfigurationProperties.KIBANA_FILTER_STR)).thenReturn("dummyFilterStr");
+        TestPlanUOW testPlanUOWMock = Mockito.mock(TestPlanUOW.class);
+        PowerMockito.whenNew(TestPlanUOW.class).withNoArguments().thenReturn(testPlanUOWMock);
+        PowerMockito.when(testPlanUOWMock.persistTestPlan(Mockito.any(TestPlan.class))).thenReturn(testPlan);
 
         StackCreationWaiter validatorMock = Mockito.mock(StackCreationWaiter.class);
         PowerMockito.whenNew(StackCreationWaiter.class).withAnyArguments().thenReturn(validatorMock);

--- a/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
+++ b/web/src/main/java/org/wso2/testgrid/web/api/APIUtil.java
@@ -143,6 +143,7 @@ class APIUtil {
                     .collect(Collectors.joining(",")) + "}";
 
             testPlanBean.setInfraParams(infraParams);
+            testPlanBean.setLogUrl(testPlan.getLogUrl());
             testPlanBean.setStatus(testPlan.getStatus().toString());
             testPlanBean.setCreatedTimestamp(testPlan.getCreatedTimestamp());
             testPlanBean.setModifiedTimestamp(testPlan.getModifiedTimestamp());

--- a/web/src/main/java/org/wso2/testgrid/web/bean/TestPlan.java
+++ b/web/src/main/java/org/wso2/testgrid/web/bean/TestPlan.java
@@ -30,6 +30,7 @@ public class TestPlan {
     private String deploymentPattern;
     private String status;
     private String infraParams;
+    private String logUrl;
     private List<TestScenario> testScenarios;
     private Timestamp createdTimestamp;
     private Timestamp modifiedTimestamp;
@@ -122,6 +123,24 @@ public class TestPlan {
      */
     public void setInfraParams(String infraParams) {
         this.infraParams = infraParams;
+    }
+
+    /**
+     * Returns the URL to view WSO2 server logs.
+     *
+     * @return Log location URL
+     */
+    public String getLogUrl() {
+        return logUrl;
+    }
+
+    /**
+     * Returns the URL to view WSO2 server logs.
+     *
+     * @param logUrl Log location URL
+     */
+    public void setLogUrl(String logUrl) {
+        this.logUrl = logUrl;
     }
 
     /**

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -252,14 +252,14 @@ class TestRunView extends Component {
                   .then(response => {
                     return response.json();
                   })
-                  .then(data => this.setState({wso2LogsUrl: data.logUrl}))
+                  .then(data => this.setState({deploymentLogsUrl: data.logUrl}))
           .catch(error => console.error(error));
   }
 
   render() {
     var pageURL = window.location.href;
     const PERFDASH_URL = this.state.grafanaUrl
-    const WSO2_LOGS_URL = this.state.wso2LogsUrl
+    const DEPL_LOGS_URL = this.state.deploymentLogsUrl
     const divider = (<Divider inset={false} style={{borderBottomWidth: 1}}/>);
     const logUrl = TESTGRID_API_CONTEXT + '/api/test-plans/log/' + pageURL.split("/").pop() + "?truncate=";
     const logAllContentUrl = logUrl + false;
@@ -604,9 +604,9 @@ class TestRunView extends Component {
             <Collapsible trigger="WSO2 Server logs" lazyRender={true} triggerWhenOpen="WSO2 Server logs >>" >
                          {(() => {
                             return <div>
-                            <p style={{float: 'right'}}><a href={WSO2_LOGS_URL} target="_blank">View Kibana Dashboard</a></p>
+                            <p style={{float: 'right'}}><a href={DEPL_LOGS_URL} target="_blank">View Kibana Dashboard</a></p>
                               <br/>
-                              <iframe src= {WSO2_LOGS_URL} height="1500" width="100%" title="wso2serverlogs"></iframe>
+                              <iframe src= {DEPL_LOGS_URL} height="900" width="100%" title="wso2serverlogs"></iframe>
                               <br/>
                               </div>
                          })()}

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -51,7 +51,8 @@ class TestRunView extends Component {
       showLogDownloadErrorDialog: false,
       currentInfra: null,
       TruncatedRunLogUrlStatus:null,
-      grafanaUrl: ""
+      grafanaUrl: "",
+      wso2LogsUrl: ""
     };
   }
 
@@ -67,6 +68,7 @@ class TestRunView extends Component {
       this.getReportData(currentInfra);
       this.setState({currentInfra: currentInfra});
       this.getGrafanaUrl(currentInfra.testPlanId);
+      this.getWSO2Logs(currentInfra.testPlanId);
     } else {
       let url = TESTGRID_API_CONTEXT + "/api/test-plans/" + currentUrl.pop();
       fetch(url, {
@@ -87,6 +89,7 @@ class TestRunView extends Component {
         this.getReportData(currentInfra);
         this.setState({currentInfra: currentInfra});
         this.getGrafanaUrl(currentInfra.testPlanId);
+        this.getWSO2Logs(currentInfra.testPlanId);
       });
     }
 
@@ -236,10 +239,27 @@ class TestRunView extends Component {
 
   }
 
+  getWSO2Logs(testPlanId) {
+          let url = TESTGRID_API_CONTEXT + "/api/test-plans/" + testPlanId;
+                fetch(url, {
+                  method: "GET",
+                  credentials: 'same-origin',
+                  headers: {
+                    'Accept': 'application/json'
+                  }
+                })
+                  .then(this.handleError)
+                  .then(response => {
+                    return response.json();
+                  })
+                  .then(data => this.setState({wso2LogsUrl: data.logUrl}))
+          .catch(error => console.error(error));
+  }
 
   render() {
     var pageURL = window.location.href;
     const PERFDASH_URL = this.state.grafanaUrl
+    const WSO2_LOGS_URL = this.state.wso2LogsUrl
     const divider = (<Divider inset={false} style={{borderBottomWidth: 1}}/>);
     const logUrl = TESTGRID_API_CONTEXT + '/api/test-plans/log/' + pageURL.split("/").pop() + "?truncate=";
     const logAllContentUrl = logUrl + false;
@@ -581,6 +601,16 @@ class TestRunView extends Component {
                 }
               })()}
             </Collapsible>
+            <Collapsible trigger="WSO2 Server logs" lazyRender={true} triggerWhenOpen="WSO2 Server logs >>" >
+                         {(() => {
+                            return <div>
+                            <p style={{float: 'right'}}><a href={WSO2_LOGS_URL} target="_blank">View Kibana Dashboard</a></p>
+                              <br/>
+                              <iframe src= {WSO2_LOGS_URL} height="1500" width="100%" title="wso2serverlogs"></iframe>
+                              <br/>
+                              </div>
+                         })()}
+                        </Collapsible>
             <Collapsible trigger="Performance Data" lazyRender={true} triggerWhenOpen="Performance Data>>" >
              {(() => {
                 return <div>


### PR DESCRIPTION
**Purpose**

Show logs of each test plan in the TestGrid dashboard.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Changes required**
Add new column logUrl to test_plan table 
ALTER TABLE `testgriddb`.`test_plan` ADD COLUMN `log_url` VARCHAR(255) NULL DEFAULT NULL AFTER `DEPLOYMENTPATTERN_id`;

Add following to properties to config.properties
KIBANA_ENDPOINT_URL
KIBANA_DASHBOARD_STR
KIBANA_FILTER_STR