### PR TITLE
Access Blueocean console from testplan view in webapp

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestPlan.java
@@ -133,6 +133,9 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
     private String workspace = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
             "sample-").toString();
 
+    @Column (name = "build_url")
+    private String buildURL;
+
     /**
      * Returns the status of the infrastructure.
      *
@@ -523,6 +526,14 @@ public class TestPlan extends AbstractUUIDEntity implements Serializable, Clonea
 
     public void setEmailToList(String emailToList) {
         this.emailToList = emailToList;
+    }
+
+    public void setBuildURL(String buildURL) {
+        this.buildURL = buildURL;
+    }
+
+    public String getBuildURL() {
+        return buildURL;
     }
 
     /**

--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -74,6 +74,11 @@ public class RunTestPlanCommand implements Command {
             required = true)
     private String workspace = "";
 
+    @Option(name = "--url",
+            usage = "Jenkins URL",
+            aliases = {"-u"})
+    private String buildURL;
+
     private ProductUOW productUOW;
     private DeploymentPatternUOW deploymentPatternUOW;
     private TestPlanUOW testPlanUOW;
@@ -110,6 +115,9 @@ public class RunTestPlanCommand implements Command {
             // Generate test plan from config
             TestPlan testPlan = FileUtil.readYamlFile(testPlanYAMLFilePath.get(), TestPlan.class);
             testPlan.setWorkspace(workspace); // In future, the workspace will be kept in 'Context' and referred.
+            if (buildURL != null && !buildURL.isEmpty()) {
+                testPlan.setBuildURL(buildURL);
+            }
 
             resolvePaths(testPlan);
             InfrastructureConfig infrastructureConfig = testPlan.getInfrastructureConfig();

--- a/dao/src/main/resources/META-INF/persistence.xml
+++ b/dao/src/main/resources/META-INF/persistence.xml
@@ -38,7 +38,7 @@
             <property name="eclipselink.logging.logger"
                       value="org.wso2.testgrid.logging.Slf4jSessionLogger"/>
             <property name="eclipselink.logging.level" value="CONFIG"/>
-            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/pom.xml
+++ b/pom.xml
@@ -623,7 +623,7 @@
         <javax.mail.version>1.5.0-b01</javax.mail.version>
         <!-- DAO dependencies -->
         <javax.persistence.version>2.2.0</javax.persistence.version>
-        <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
+        <org.eclipse.persistence.version>2.4.0</org.eclipse.persistence.version>
         <jersey.server.version>2.22.2</jersey.server.version>
         <!-- Web app dependencies -->
         <javax.websocket.version>1.1</javax.websocket.version>

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -74,7 +74,7 @@ class TestRunView extends Component {
     currentInfra.testPlanStatus = this.props.currentInfra.testPlanStatus;
     this.getReportData(currentInfra);
     this.getGrafanaUrl(currentInfra.testPlanId);
-    this.getWSO2Logs(currentInfra.testPlanId);
+    this.getURLs(currentInfra.testPlanId);
     this.setState({currentInfra: currentInfra});
   }
 
@@ -105,7 +105,7 @@ class TestRunView extends Component {
           this.getReportData(currentInfra);
           this.setState({currentInfra: currentInfra});
           this.getGrafanaUrl(currentInfra.testPlanId);
-          this.getWSO2Logs(currentInfra.testPlanId);
+          this.getURLs(currentInfra.testPlanId);
         });
     }
 
@@ -255,7 +255,7 @@ class TestRunView extends Component {
 
   }
 
-  getWSO2Logs(testPlanId) {
+  getURLs(testPlanId) {
           let url = TESTGRID_API_CONTEXT + "/api/test-plans/" + testPlanId;
                 fetch(url, {
                   method: "GET",
@@ -268,7 +268,9 @@ class TestRunView extends Component {
                   .then(response => {
                     return response.json();
                   })
-                  .then(data => this.setState({deploymentLogsUrl: data.logUrl}))
+                  .then(data => {this.setState({deploymentLogsUrl: data.logUrl})
+                            this.setState({buildURL: data.buildURL})        
+                  })
           .catch(error => console.error(error));
   }
 
@@ -361,6 +363,16 @@ class TestRunView extends Component {
                       })
                   )}
           ><i className="fa fa-download" aria-hidden="true"> </i> Download Test-Run log</Button>
+
+          <Button id ="tdd" size="sm" style={{marginLeft: "10px"}}
+          onClick={() => {
+            if(this.state.buildURL == null || this.state.buildURL == undefined ){
+              this.toggle("Error when accessing TestGrid console");
+            }else{
+              window.open(this.state.buildURL, '_blank', false);
+            }
+          }}
+            ><i className="fa fa-id-card-o" aria-hidden="true"> </i> TestGrid console </Button>
 
           <Button id ="tdd" size="sm" style={{marginLeft: "10px"}} onClick={this.downloadTestOutputs.bind(this)}>
             <i className="fa fa-download" aria-hidden="true"> </i> Download results and logs</Button>

--- a/web/src/main/react-dashboard/src/components/TestRunView.js
+++ b/web/src/main/react-dashboard/src/components/TestRunView.js
@@ -366,7 +366,7 @@ class TestRunView extends Component {
 
           <Button id ="tdd" size="sm" style={{marginLeft: "10px"}}
           onClick={() => {
-            if(this.state.buildURL == null || this.state.buildURL == undefined ){
+            if(this.state.buildURL === null || this.state.buildURL === undefined ){
               this.toggle("Error when accessing TestGrid console");
             }else{
               window.open(this.state.buildURL, '_blank', false);


### PR DESCRIPTION
**Purpose**

provide a blue ocean link to the user in the test plan view

**Approach**
link is provided as an input parameter to the RunTestPlan command and then it is saved in the database.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

### IMPORTANT!!

- from this PR the create-or-extend-tables property is added to the persistant xml. JPA will modify the existing table in runtime and add new columns. so there is **no need of a manual database migration script.**

- Since this PR introduces Database level changes any jobs running during the PR merge will not revcieve these changes and will break during execution. Hence its **important that no builds are running until the deployments are updated.**