### PR TITLE
Exit the testgrid execution once the main thread completes

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/Main.java
+++ b/core/src/main/java/org/wso2/testgrid/core/Main.java
@@ -45,6 +45,7 @@ public class Main {
             logger.info("TestGrid Home\t: " + testGridHome);
 
             commandHandler.execute();
+            System.exit(0);
         } catch (CmdLineException e) {
             logger.error("Error while parsing command line arguments.", e);
         } catch (CommandExecutionException e) {


### PR DESCRIPTION

**Purpose**
Exit the testgrid execution once the main thread completes

Currently, there are other Runnables like tinkerer that keep the JVM from exiting
even though the testgrid run-testplan execution is completed.

