### PR TITLE
Avoid considering maven-reserved directories as scenarios

### DIFF
--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -92,4 +92,6 @@ public class TestGridConstants {
 
 
     public static final String NOT_CONFIGURED_STR = "/not-configured/";
+
+    public static final String MAVEN_RELATED_DIR = "target";
 }

--- a/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/testgrid/core/TestPlanExecutor.java
@@ -432,7 +432,12 @@ public class TestPlanExecutor {
 
         if (directories != null) {
             for (File scenario : directories) {
-                appendScenario(testPlan, scenario.getName(), scenarioConfig);
+                if (scenario.getName().equals(TestGridConstants.MAVEN_RELATED_DIR)) {
+                    logger.warn("Avoid considering a directory with maven-reserved name (" +
+                            scenario.getName() + ") as a scenario directory.");
+                } else {
+                    appendScenario(testPlan, scenario.getName(), scenarioConfig);
+                }
             }
         } else {
             //testPlan.setStatus(Status.FAIL);


### PR DESCRIPTION
**Purpose**
Avoid considering maven-reserved directories as scenarios

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes