### PR TITLE
Create CloudFormaion stacks in user provided region

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -257,7 +257,7 @@ public class AWSProvider implements InfrastructureProvider {
             awsResourceManager.notifyStackCreation(testPlan, script, describeStackEventsResult.getStackEvents());
 
             //Set log download url to test plan.
-            deriveLogDashboardUrl(testPlan, stackName);
+            deriveLogDashboardUrl(testPlan, stackName, region);
 
             Properties outputProps = getCloudformationOutputs(cloudFormation, stack);
             logEC2SshAccessDetails(stackName, inputs);
@@ -289,10 +289,15 @@ public class AWSProvider implements InfrastructureProvider {
      *
      * @param testPlan test-plan to get log url for
      * @param stackName name of the stack created for the test-plan
+     * @param region aws region where the stack was created
      */
-    private void deriveLogDashboardUrl(TestPlan testPlan, String stackName) {
+    private void deriveLogDashboardUrl(TestPlan testPlan, String stackName, String region) {
         // Filter the EC2 instance corresponding to the stack
-        AmazonEC2 amazonEC2 = AmazonEC2ClientBuilder.defaultClient();
+        Path configFilePath = TestGridUtil.getConfigFilePath();
+        AmazonEC2 amazonEC2 = AmazonEC2ClientBuilder.standard()
+                .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
+                .withRegion(region)
+                .build();
         DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest();
         describeInstancesRequest.withFilters(
                 new Filter("tag:" + STACK_NAME_TAG_KEY).withValues(stackName));

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -101,6 +101,7 @@ public class AWSProvider implements InfrastructureProvider {
     private static final Logger logger = LoggerFactory.getLogger(AWSProvider.class);
     private static final String AWS_REGION_PARAMETER = "region";
     private static final String CUSTOM_USER_DATA = "CustomUserData";
+    private static final String DEFAULT_REGION = "us-east-1";
     private CloudFormationScriptPreprocessor cfScriptPreprocessor;
     private AWSResourceManager awsResourceManager;
     private static final int TIMEOUT = 60;
@@ -180,6 +181,15 @@ public class AWSProvider implements InfrastructureProvider {
             TestGridInfrastructureException {
         Path configFilePath = TestGridUtil.getConfigFilePath();
         String region = inputs.getProperty(AWS_REGION_PARAMETER);
+        logger.info("Region is available as an input parameter, Setting " +
+                "the region as : " + region);
+
+        if (region == null || region.isEmpty()) {
+            region = DEFAULT_REGION;
+            logger.info("Region is not provided as an input parameter, Setting " +
+                    "the region as : " + DEFAULT_REGION);
+        }
+        script.getInputParameters().setProperty(AWS_REGION_PARAMETER, region);
         AmazonCloudFormation cloudFormation = AmazonCloudFormationClientBuilder.standard()
                 .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
                 .withRegion(region)
@@ -201,6 +211,7 @@ public class AWSProvider implements InfrastructureProvider {
 
             stackRequest.setTemplateBody(file);
 
+            /* TODO update when resourceManager is introduced
             region = awsResourceManager.requestAvailableRegion(testPlan, script);
             //Set region to test plan
             inputs.setProperty(AWS_REGION_PARAMETER, region);
@@ -210,7 +221,7 @@ public class AWSProvider implements InfrastructureProvider {
                     .withCredentials(new PropertiesFileCredentialsProvider(configFilePath.toString()))
                     .withRegion(region)
                     .build();
-
+            */
             String tgEnvironment = ConfigurationContext.getProperty(ConfigurationContext.
                     ConfigurationProperties.TESTGRID_ENVIRONMENT);
             final List<Parameter> populatedExpectedParameters = getParameters(expectedParameters, inputs,

--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -574,8 +574,10 @@ public class AWSProvider implements InfrastructureProvider {
                         ConfigurationProperties.DEPLOYMENT_TINKERER_USERNAME);
                 String deploymentTinkererPassword = ConfigurationContext.getProperty(ConfigurationContext.
                         ConfigurationProperties.DEPLOYMENT_TINKERER_PASSWORD);
-                String awsRegion = ConfigurationContext.getProperty(ConfigurationContext.
-                        ConfigurationProperties.AWS_REGION_NAME);
+                String awsRegion = infraInputs.getProperty(AWS_REGION_PARAMETER);
+                if (awsRegion == null || awsRegion.isEmpty()) {
+                    awsRegion = DEFAULT_REGION;
+                }
                 String windowsScript;
                 String customScript;
                 String scriptInputs = StringUtil.concatStrings(testPlanId, " ",

--- a/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
+++ b/infrastructure/src/test/java/org/wso2/testgrid/infrastructure/AWSProviderTest.java
@@ -226,7 +226,16 @@ public class AWSProviderTest extends PowerMockTestCase {
 
         AmazonEC2 amazonEC2Mock = Mockito.mock(AmazonEC2.class);
         PowerMockito.mockStatic(AmazonEC2ClientBuilder.class);
-        PowerMockito.when(AmazonEC2ClientBuilder.defaultClient()).thenReturn(amazonEC2Mock);
+
+        AmazonEC2ClientBuilder ec2ClientBuilderMock = PowerMockito
+                .mock(AmazonEC2ClientBuilder.class);
+        PowerMockito.when(ec2ClientBuilderMock.withCredentials(Mockito.any(PropertiesFileCredentialsProvider.class)))
+                .thenReturn(ec2ClientBuilderMock);
+        PowerMockito.when(ec2ClientBuilderMock.withRegion(Mockito.anyString()))
+                .thenReturn(ec2ClientBuilderMock);
+        PowerMockito.when(ec2ClientBuilderMock.build()).thenReturn(amazonEC2Mock);
+
+        PowerMockito.when(AmazonEC2ClientBuilder.standard()).thenReturn(ec2ClientBuilderMock);
         DescribeInstancesResult describeInstancesResult = Mockito.mock(DescribeInstancesResult.class);
         PowerMockito.when(amazonEC2Mock.describeInstances(Mockito.any())).thenReturn(describeInstancesResult);
         PowerMockito.when(describeInstancesResult.getReservations()).thenReturn(getMockReservations());


### PR DESCRIPTION
**Purpose**

After this change users can specify the AWS region the stack should run. 
The region should be specified as an input parameter to the script in testgrid yaml.
Ex:
```
scripts:
     inputParameters:
        region: "us-east-2"

```

if a region is not specified the default region will be used (us-east-1)