### PR TITLE
Filter jobs by a regex in build-failure-escalation email

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/GenerateEscalationEmailCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/GenerateEscalationEmailCommand.java
@@ -49,10 +49,10 @@ public class GenerateEscalationEmailCommand implements Command {
     private List<String> excludeList = new ArrayList<>();
 
     @Option(name = "--product-include-pattern",
-            usage = "Product names that matches the pattern will be included",
+            usage = "Product names that matches the regex pattern will be included",
             aliases = {"-i"}
     )
-    String productIncludePattern; //TODO : Need to implement this
+    private String productIncludePattern;
 
     private static final Logger logger = LoggerFactory.getLogger(GenerateEscalationEmailCommand.class);
 
@@ -61,7 +61,8 @@ public class GenerateEscalationEmailCommand implements Command {
 
         try {
             EscalationEmailGenerator generator = new EscalationEmailGenerator();
-            final Optional<Path> escalationReportPath = generator.generateEscalationEmail(excludeList, workspace);
+            final Optional<Path> escalationReportPath = generator.
+                    generateEscalationEmail(excludeList, productIncludePattern, workspace);
             escalationReportPath.ifPresent(p -> logger.info("Written the escalation email " +
                                                             "report body contents to: " + p));
         } catch (ReportingException e) {


### PR DESCRIPTION
**Purpose**
Option to filter-out jobs use by developer for testing purpose when considering the build-failure-escalation email.
This PR provides option to filter jobs from a regex pattern when selecting the jobs to consider for the build-failure escalation.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes