### PR TITLE
Modify finalize-run-testplan command

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/FinalizeRunTestplan.java
@@ -20,6 +20,7 @@ package org.wso2.testgrid.core.command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.Product;
 import org.wso2.testgrid.common.Status;
 import org.wso2.testgrid.common.TestGridConstants;
 import org.wso2.testgrid.common.TestPlan;
@@ -58,8 +59,7 @@ public class FinalizeRunTestplan implements Command {
 
     @Option(name = "--product",
             usage = "Product Name",
-            aliases = { "-p" },
-            required = true)
+            aliases = { "-p" })
     private String productName = "";
 
     @Option(name = "--file",
@@ -83,9 +83,31 @@ public class FinalizeRunTestplan implements Command {
 
     @Override
     public void execute() throws CommandExecutionException {
+        if (productName == null || productName.isEmpty()) {
+            try {
+                ProductUOW productUOW = new ProductUOW();
+                List<Product> products = productUOW.getProducts();
 
+                for (Product product: products) {
+                    logger.info("Finalizing test-plans of product " + product.getName());
+                    executePerProduct(product.getName());
+                }
+            } catch (TestGridDAOException e) {
+                logger.error("Error while fetching product-list from database.", e);
+            }
+        } else {
+            executePerProduct(productName);
+        }
+    }
+
+    /**
+     * Execute finalizing logic for the give product.
+     *
+     * @param product product-name
+     */
+    private void executePerProduct(String product) {
         LogFilePathLookup.setLogFilePath(
-                TestGridUtil.deriveTestGridLogFilePath(productName, TestGridConstants.TESTGRID_LOG_FILE_NAME));
+                TestGridUtil.deriveTestGridLogFilePath(product, TestGridConstants.TESTGRID_LOG_FILE_NAME));
         logger.info("Finalizing test plan status...");
         try {
             if (Paths.get(testPlanYamlFilePath).toFile().exists()) {
@@ -135,19 +157,19 @@ public class FinalizeRunTestplan implements Command {
                 //Set statuses of scenarios
                 for (TestScenario testScenario : testPlan.getTestScenarios()) {
                     switch (testScenario.getStatus()) {
-                    case PENDING:
-                        testScenario.setStatus(Status.DID_NOT_RUN);
-                        break;
-                    case RUNNING:
-                        testScenario.setStatus(Status.ERROR);
-                        break;
-                    case SUCCESS:
-                        break;
-                    case FAIL:
-                        isExistsFailedScenarios = true;
-                        break;
-                    default:
-                        break;
+                        case PENDING:
+                            testScenario.setStatus(Status.DID_NOT_RUN);
+                            break;
+                        case RUNNING:
+                            testScenario.setStatus(Status.ERROR);
+                            break;
+                        case SUCCESS:
+                            break;
+                        case FAIL:
+                            isExistsFailedScenarios = true;
+                            break;
+                        default:
+                            break;
                     }
                 }
                 testPlan = TestGridUtil.updateFinalTestPlanPhase(testPlan);


### PR DESCRIPTION
**Purpose**
Modify finalize-run-testplan command to run when the `product` input is not given.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
