### PR TITLE
Remove no apt-get error in aws CLI setup

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/providers/AWSProvider.java
@@ -604,8 +604,8 @@ public class AWSProvider implements InfrastructureProvider {
                             "update-rc.d testgrid-agent defaults\n" +
                             "service testgrid-agent start\n";
                     //Note: Following command addresses both APT and YUM installers.
-                    String awsCLISetup = "YUM_CMD=$(which yum)\n" +
-                            "APT_GET_CMD=$(which apt-get)\n" +
+                    String awsCLISetup = "YUM_CMD=$(which yum) || echo 'yum is not available'\n" +
+                            "APT_GET_CMD=$(which apt-get) || echo 'apt-get is not available'\n" +
                             "if [[ ! -z $YUM_CMD ]]; then\n" +
                             "sudo yum -y install awscli\n" +
                             "elif [[ ! -z $APT_GET_CMD ]]; then\n" +


### PR DESCRIPTION
**Purpose**
AWS CLI setup script is not executing after no apt-get error. So adding echo command to avoid it.