### PR TITLE
Add Dockerfile used to create run-test-plan container

### DIFF
--- a/jenkins/run-testplan-docker/Dockerfile
+++ b/jenkins/run-testplan-docker/Dockerfile
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# This file contains the dockerfile to create the image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
+MAINTAINER WSO2 Docker Maintainers "testgrid_team@wso2"
+RUN apt-get update && \
+    apt-get install -y netcat python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# activate user ubuntu
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1000 ubuntu
+
+# install awscli
+RUN pip3 install awscli --upgrade --no-cache-dir
+
+# install mvn,git,ssh
+RUN apt-get update && \
+    apt-get install -y maven && \
+    apt-get install -y git && \
+    apt-get install -y ssh
+
+# add github to known hosts
+RUN mkdir -p /home/ubuntu/.ssh && \
+    ssh-keyscan github.com >> /home/ubuntu/.ssh/known_hosts
+
+USER ubuntu
+WORKDIR /home/ubuntu
+ENV JAVA_HOME=/opt/java/openjdk
+
+ENTRYPOINT ["/bin/bash"]

--- a/jenkins/run-testplan-docker/README.md
+++ b/jenkins/run-testplan-docker/README.md
@@ -1,0 +1,27 @@
+
+How to update run-testplan docker image
+===================== 
+The image used to create the docker container for run-testplan block is stored as an ECR in TestGrid AWS account. That is being pulled into each jenkins-slave when executing builds. The following steps describe how to modif y the docker image.
+
+1. Install AWS CLI and Docker in your machine.
+2. Clone repository to your local machine.
+3. Do required modifications in the Dockerfile.
+4. Authenticate ECR registry to Docker CLI from the following command.
+
+		$(aws ecr get-login --no-include-email)
+
+5. Go to the Dockerfile directory and build Docker image using following command.
+
+		docker build -t tg-run-testplan .
+
+6. After build completes, tag the build
+
+		docker tag tg-run-testplan:latest <TestGridDockerRegistryURI>/tg-run-testplan:latest
+	
+	Contact TestGrid team to find <TestGridDockerRegistryURI>
+
+7. Push the image using following command
+
+		docker push <TestGridDockerRegistryURI>/tg-run-testplan:latest
+
+8. The latest image will be automatically picked up by all the slaves who will be spawned after updating the image in ECR.


### PR DESCRIPTION
**Purpose**
Add Dockerfile used to create run-test-plan container

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
