### PR TITLE
Change the default instace type

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -76,7 +76,7 @@ Parameters:
   WSO2InstanceType:
     Description: 'EC2 instance type of the WSO2 EI Node [t2.micro is the free tier]'
     Type: String
-    Default: m3.xlarge
+    Default: c3.xlarge
     AllowedValues:
       - t2.nano
       - t1.micro
@@ -91,6 +91,7 @@ Parameters:
       - m3.xlarge
       - m3.2xlarge
       - m4.large
+      - c3.xlarge
     ConstraintDescription: must be a valid EC2 instance type
   WUMUsername:
     Type: String

--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -76,7 +76,7 @@ Parameters:
   WSO2InstanceType:
     Description: 'EC2 instance type of the WSO2 EI Node [t2.micro is the free tier]'
     Type: String
-    Default: c3.xlarge
+    Default: m3.2xlarge
     AllowedValues:
       - t2.nano
       - t1.micro
@@ -91,7 +91,6 @@ Parameters:
       - m3.xlarge
       - m3.2xlarge
       - m4.large
-      - c3.xlarge
     ConstraintDescription: must be a valid EC2 instance type
   WUMUsername:
     Type: String
@@ -325,7 +324,7 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId: !Ref AMI
-        InstanceType: 'm3.2xlarge'
+        InstanceType: !Ref WSO2InstanceType
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
         "BlockDeviceMappings" : [


### PR DESCRIPTION
1. To execute Integration test, it required at least  instance type 'm3.2xlarge' performance level. There for change the instance default type to m3.2xlarge. 

2. Refer the windows instance type also to the default value. 