### PR TITLE
Change helm version

### DIFF
--- a/deployment/src/main/resources/kubernetes_helmDeploy.sh
+++ b/deployment/src/main/resources/kubernetes_helmDeploy.sh
@@ -247,8 +247,8 @@ function install_helm(){
   #if helm is not installed in the cluster, helm and tiller will be installed.
   if ! type 'helm'
   then
-    wget https://get.helm.sh/helm-v3.0.0-alpha.1-linux-amd64.tar.gz
-    tar -zxvf helm-v3.0.0-alpha.1-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz
+    tar -zxvf helm-v2.14.3-linux-amd64.tar.gz
     mkdir ~/.local/bin/
     PATH=~/.local/bin/:$PATH
     mv linux-amd64/helm ~/.local/bin/helm


### PR DESCRIPTION
**Purpose**
Resolves #1244 

**Goals**
Changing the Helm Version.

According to [this](https://github.com/helm/helm/issues/5628#issuecomment-485493497), helm 3 introduced a change where it gets the namespace from the local kube config for deployment. The solution given in the above-mentioned ticket cannot be used infra combination running in parallel. 

**Approach**
Helm v2.14.3 will be installed after this change instead of Helm v3. 
