### PR TITLE
Persisting Input Parameters through JsonPropFile Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ hs_err_pid*
 # target
 *target*
 
+#local-dev-files
+deployment-local/testgrid/testgrid-home/testgrid-dist/
+deployment-local/tomcat/
+
 # webapp dependencies
 node_modules/
 build/

--- a/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/testgrid/common/TestGridConstants.java
@@ -105,9 +105,11 @@ public class TestGridConstants {
     public static final String KUBERNETES_INFRA_SCRIPT = "kubernetes_infra.sh";
     public static final String KUBERNETES_DEPLOY_SCRIPT = "kubernetes_deploy.sh";
     public static final String KUBERNETES_DESTROY_SCRIPT = "kubernetes_destroy.sh";
+    public static final String K8S_HELM_EDITOR = "kubedeployment_editor.groovy";
     public static final String HELM_INFRA_SCRIPT = "kubernetes_helmInfra.sh";
     public static final String HELM_DEPLOY_SCRIPT = "kubernetes_helmDeploy.sh";
     public static final String HELM_DESTROY_SCRIPT = "kubernetes_helmDestroy.sh";
+    public static final String SIDECAR_DEPLOYMENT_ZIP = "testgrid-sidecar.zip";
 
 
     public static final String EXACT_ALGO = "exact";
@@ -115,4 +117,6 @@ public class TestGridConstants {
     public static final String ALL_ALGO = "all";
 
     public static final String DEFAULT_SCHEDULE = "manual";
+
+    public static final String HELM_PRODUCT_PROPFILE = "helm_dep.props";
 }

--- a/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
+++ b/common/src/main/java/org/wso2/testgrid/common/config/ConfigurationContext.java
@@ -159,6 +159,12 @@ public class ConfigurationContext {
          */
         TESTGRID_ENVIRONMENT("TESTGRID_ENVIRONMENT"),
 
+        //TODO: Better implementation for local testgrid's /etc/host support
+        /**
+         * Running environment of the application
+         */
+        TESTGRID_PASS("TESTGRID_PASS"),
+
         /**
          * Host-name of TestGrid deployment.
          */
@@ -265,9 +271,29 @@ public class ConfigurationContext {
         REPEATABLE_ALL_LOGS_FILTER_STRING("REPEATABLE_ALL_LOGS_FILTER_STRING"),
 
         /**
-         * Repeateble json string section of all logs
+         * Repeateble json string section of all logs for helm deployments
          */
-        REPEATABLE_ALL_LOGS_JSON("REPEATABLE_ALL_LOGS_JSON");
+        REPEATABLE_ALL_LOGS_JSON("REPEATABLE_ALL_LOGS_JSON"),
+
+        /**
+         * Repeatable string section of all logs for K8S deployments
+         */
+        REPEATABLE_ALL_LOGS_FILTER_STRING_K8S("REPEATABLE_ALL_LOGS_FILTER_STRING_K8S"),
+
+        /**
+         * Repeateble json string section of all logs for K8S deployments
+         */
+        REPEATABLE_ALL_LOGS_JSON_K8S("REPEATABLE_ALL_LOGS_JSON_K8S"),
+
+        /**
+         * Kibana dashboard ctx with placeholders for K8S deployments
+         */
+        KIBANA_FILTER_STR_K8S("KIBANA_FILTER_STR_K8S"),
+
+        /*
+           Elastic Search Endpoint
+         */
+        ES_ENDPOINT_URL("ES_ENDPOINT_URL");
 
         private String propertyName;
 

--- a/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
+++ b/common/src/main/java/org/wso2/testgrid/common/util/DataBucketsHelper.java
@@ -54,7 +54,12 @@ public class DataBucketsHelper {
     public static final String INFRA_OUT_FILE = "infrastructure.properties";
     public static final String DEPL_OUT_FILE = "deployment.properties";
     public static final String TEST_OUT_FILE = "tests.properties";
+    public static final String INFRA_OUT_JSONFILE = "infrastructures.json";
+    public static final String DEPL_OUT_JSONFILE = "deployments.json";
+    public static final String TEST_OUT_JSONFILE = "tests.json";
     public static final String TESTPLAN_PROPERTIES_FILE = "testplan-props.properties";
+    public static final String TESTPLAN_PROPERTIES_JSONFILE = "testplan-props.json";
+    public static final String PARAMS_JSONFILE = "params.json";
     private static final Logger logger = LoggerFactory.getLogger(DataBucketsHelper.class);
     private static boolean init = false;
 

--- a/core/src/main/java/org/wso2/testgrid/core/util/JsonPropFileUtil.java
+++ b/core/src/main/java/org/wso2/testgrid/core/util/JsonPropFileUtil.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.testgrid.core.util;
+
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.testgrid.common.config.Script;
+import org.wso2.testgrid.core.exception.TestPlanExecutorException;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+
+/**
+ * This class is used for managing the .properties file and .json files used by TestGrid
+ */
+public class JsonPropFileUtil {
+
+    final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Observes the properties file and updates any necessary values to the json file as a general input
+     *  NOTE :: OVERRIDES ANY PROPERTY OF THE SAME NAME
+     *
+     * @param propFilePath path to .properties file
+     * @param jsonFilePath path tp .json file
+     */
+    public void refillJSONfromPropFile(Path propFilePath , Path jsonFilePath) {
+
+        try (InputStream propInputStream = new FileInputStream(propFilePath.toString())) {
+
+            Properties existingProps = new Properties();
+            existingProps.load(propInputStream);
+
+            File jsonFile = new File(jsonFilePath.toString());
+            if (jsonFile.exists()) {
+                try (InputStream jsonInputStream = new FileInputStream(jsonFilePath.toString())) {
+
+                    JSONTokener jsonTokener = new JSONTokener(jsonInputStream);
+                    JSONObject inputJson = new JSONObject(jsonTokener);
+
+                    Iterator it = existingProps.entrySet().iterator();
+
+                    while (it.hasNext()) {
+                        Map.Entry existingPair = (Map.Entry) it.next();
+                        if (existingPair.getValue() != null) {
+                            if (inputJson.has("general")) {
+                                inputJson.getJSONObject("general").put((String) existingPair.getKey(),
+                                        existingPair.getValue());
+                            } else {
+                                JSONObject generalProps = new JSONObject(existingProps);
+                                inputJson.put("general", generalProps);
+                            }
+                        }
+                    }
+                    try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                        inputJson.write(jsonWriter);
+                        jsonWriter.write("\n");
+                    } catch (IOException e) {
+                        logger.error(" Error while persisting input params to " + jsonFilePath);
+                    }
+                } catch (IOException ex) {
+                    logger.info("ERROR " + ex.getMessage());
+                }
+            } else {
+                HashMap<String, Object> newJsonFileInputs = new HashMap<String, Object>();
+                newJsonFileInputs.put("general", existingProps);
+
+                JSONObject newJsonFile = new JSONObject(newJsonFileInputs);
+                try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                    newJsonFile.write(jsonWriter);
+                    jsonWriter.write("\n");
+                } catch (IOException exc) {
+                    logger.error("Error while persisting infra input params to " + jsonFilePath);
+                }
+            }
+
+        } catch (FileNotFoundException e) {
+            logger.info(propFilePath + " Not created yet ignoring read property file step");
+        } catch (IOException e) {
+            logger.error("Error while persisting infra input params to " + propFilePath);
+        }
+
+    }
+
+    /**
+     * Persist additional inputs required other than the outputs from previous steps (i.e. infra/deployment).
+     * The additional inputs are specified in the testgrid.yaml.
+     *
+     * NOTE :: Used in DeployPhase
+     *
+     * NOTE :: JSON File structure
+     * { general: {
+     *      gen_prop1:val1 , gen_prop2:val2
+     *   },
+     *   currentscript: {
+     *      prop4:val4
+     *   },
+     *   script1: {prop3:val3},
+     *   script2: {prop4:val4}
+     *  }
+     *
+     * @param properties properties to be added
+     * @param propFilePath path of the property file
+     * @param jsonFilePath path to the JSON file
+     * @param scriptName  OPTIONAL Name of script file if not provided property added as a general variable
+     * @throws TestPlanExecutorException if writing to the property file fails
+     */
+    public void persistAdditionalInputs(Map properties, Path propFilePath , Path jsonFilePath,
+                                         Optional<String> scriptName) throws TestPlanExecutorException {
+
+        if (!scriptName.isPresent()) {
+            // If value is not specified from a script add the value as a general value to the json file
+            File jsonFile = new File(jsonFilePath.toString());
+            if (jsonFile.exists()) {
+                try {
+
+                    // If the JSON file exists read existing values and append to the file
+                    InputStream jsonInputStream = new FileInputStream(jsonFilePath.toString());
+                    JSONTokener jsonTokener = new JSONTokener(jsonInputStream);
+                    JSONObject inputJson = new JSONObject(jsonTokener);
+                    Iterator it = properties.entrySet().iterator();
+
+                    // Add new value to a flatlist level of the script
+                    while (it.hasNext()) {
+                        Map.Entry existingPair = (Map.Entry) it.next();
+                        if (inputJson.has("general")) {
+                            inputJson.getJSONObject("general").put((String) existingPair.getKey(),
+                                    existingPair.getValue());
+                        } else {
+                            JSONObject generalProps = new JSONObject(properties);
+                            inputJson.put("general", generalProps);
+                        }
+                    }
+                    // Append to json file
+                    try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                        inputJson.write(jsonWriter);
+                        jsonWriter.write("\n");
+                    } catch (IOException e) {
+                        logger.error("Error while persisting Additional input params to " + jsonFilePath, e);
+                    }
+
+                } catch (IOException e) {
+                    logger.error("ERROR :" + e.getMessage());
+                }
+            } else {
+                logger.info(jsonFilePath + "created");
+                HashMap<String, Object> newJsonFileInputs = new HashMap<String, Object>();
+                newJsonFileInputs.put("general", properties);
+                JSONObject newJsonFile = new JSONObject(newJsonFileInputs);
+                try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                    newJsonFile.write(jsonWriter);
+                    jsonWriter.write("\n");
+                } catch (IOException ex) {
+                    logger.error("Error while persisting Additional input params to " + jsonFilePath, ex);
+                }
+            }
+
+        } else {
+            /*
+             If input params are specified from a script save currently executing script under currentscript
+             and save the same info under script name for future use.
+             */
+            File jsonFile = new File(jsonFilePath.toString());
+            if (jsonFile.exists()) {
+                try {
+                    InputStream jsonInputStream = new FileInputStream(jsonFilePath.toString());
+                    JSONTokener jsonTokener = new JSONTokener(jsonInputStream);
+                    JSONObject inputJson = new JSONObject(jsonTokener);
+                    JSONObject generalProps = null;
+                    // Contains both general and script params
+                    JSONObject scriptParamsJson = new JSONObject();
+                    JSONObject scriptParamsOnly = new JSONObject(properties);
+
+                    if (inputJson.has("general")) {
+                        generalProps = inputJson.getJSONObject("general");
+                    }
+
+                    Iterator it = properties.entrySet().iterator();
+                    while (it.hasNext()) {
+                        Map.Entry pair = (Map.Entry) it.next();
+                        scriptParamsJson.put((String) pair.getKey(), pair.getValue());
+                    }
+
+                    if (generalProps != null) {
+                        Iterator<String> genit = generalProps.keys();
+                        while (genit.hasNext()) {
+                            String key = genit.next();
+                            scriptParamsJson.put(key, generalProps.get(key));
+                        }
+                    }
+
+                    String scriptNameString = scriptName.get();
+                    inputJson.put(scriptNameString, scriptParamsOnly);
+                    inputJson.put("currentscript", scriptParamsJson);
+
+                    try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                        inputJson.write(jsonWriter);
+                        jsonWriter.write("\n");
+                    } catch (IOException e) {
+                        logger.error("Error while persisting Additional input params to " + jsonFilePath, e);
+                    }
+
+                } catch (IOException e) {
+                    logger.error("ERROR :" + e.getMessage());
+                }
+            } else {
+
+                logger.info(jsonFilePath + "created");
+                JSONObject scriptParamsJson = new JSONObject(properties);
+                JSONObject inputJson = new JSONObject();
+                String scriptNameString = scriptName.get();
+                inputJson.put(scriptNameString, scriptParamsJson);
+                inputJson.put("currentscript", scriptParamsJson);
+
+                try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(jsonFilePath.toString()))) {
+                    inputJson.write(jsonWriter);
+                    jsonWriter.write("\n");
+                } catch (IOException ex) {
+                    logger.error("Error while persisting Additional input params to " + jsonFilePath, ex);
+                }
+            }
+        }
+        // append new properties to .properties file
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(
+                new FileOutputStream(propFilePath.toString(), true), StandardCharsets.UTF_8))) {
+            Iterator it = properties.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry pair = (Map.Entry) it.next();
+                printWriter.println(pair.getKey() + "=" + pair.getValue());
+            }
+        } catch (IOException e) {
+            throw new TestPlanExecutorException("Error occurred while writing deployment outputs.", e);
+        }
+    }
+
+    /**
+     *
+     *  Optional method removes a scripts params from prop file after execution
+     *  @Param script - Script File
+     *  @Param propFilePath - Path Variable to properties File
+     */
+
+    public void removeScriptParams(Script script, Path propFilePath) {
+
+
+        try (InputStream propInputStream = new FileInputStream(propFilePath.toString());) {
+            Properties existingProps = new Properties();
+            existingProps.load(propInputStream);
+
+            Map<String, Object> inputParams = script.getInputParameters();
+
+            Iterator it = inputParams.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry pair = (Map.Entry) it.next();
+                if (existingProps.containsKey(pair.getKey()) && existingProps.get(pair.getKey()) != pair.getValue()) {
+                    existingProps.remove(pair.getKey());
+                    logger.info("removing property " + pair.getKey());
+                }
+            }
+
+            try (PrintWriter printWriter = new PrintWriter(
+                    new OutputStreamWriter(Files.newOutputStream(propFilePath), StandardCharsets.UTF_8))) {
+                Iterator itr = existingProps.entrySet().iterator();
+                while (itr.hasNext()) {
+                    Map.Entry pair = (Map.Entry) itr.next();
+                    printWriter.println(pair.getKey() + "=" + pair.getValue());
+                }
+            } catch (IOException e) {
+                logger.error("Error removing existing Properties from " + propFilePath, e);
+            }
+
+        } catch (FileNotFoundException e) {
+            logger.info(propFilePath + " Not created yet ignoring read property file step");
+        } catch (IOException e) {
+            logger.info(propFilePath + " Failed to read file");
+        }
+    }
+
+
+
+    /**
+     * This method adds any newly created variables by a certain phase into its output section of the params.json file
+     *
+     * Stores this information under <phase_name>-out
+     *
+     * @param outputPropFile location of the properties file relevant to the current phase
+     * @param phase          Currently executing phase
+     * @param outputJsonPath Location to the user see-able params.json file
+     */
+    public void jsonAddNewPropsToParams(Path outputPropFile, String phase, Path outputJsonPath) {
+        try (InputStream outputPropStream = new FileInputStream(outputPropFile.toString())) {
+            Properties existingProps = new Properties();
+            existingProps.load(outputPropStream);
+            File outputjsonFile = new File(outputJsonPath.toString());
+
+            if (outputjsonFile.exists()) {
+                try (InputStream outputJsonStream = new FileInputStream(outputJsonPath.toString())) {
+
+                    JSONTokener outputTokener = new JSONTokener(outputJsonStream);
+                    JSONObject insertOutputJsonVal = new JSONObject(outputTokener);
+
+                    insertOutputJsonVal.put(phase + "-out", existingProps);
+
+                    if (insertOutputJsonVal.length() != 0) {
+                        try (BufferedWriter jsonWriter = Files
+                                .newBufferedWriter(Paths.get(outputJsonPath.toString()))) {
+                            insertOutputJsonVal.write(jsonWriter);
+                            jsonWriter.write("\n");
+                        } catch (IOException ex) {
+                            logger.error("Error while persisting params to " + outputJsonPath, ex);
+                        }
+                    }
+
+                } catch (IOException e) {
+                    logger.error(outputJsonPath.toString() + "not found creating");
+                }
+            } else {
+                JSONObject insertOutputJsonVal = new JSONObject();
+
+                insertOutputJsonVal.put(phase + "-out", existingProps);
+
+                if (insertOutputJsonVal.length() != 0) {
+                    try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(outputJsonPath.toString()))) {
+                        insertOutputJsonVal.write(jsonWriter);
+                        jsonWriter.write("\n");
+                    } catch (IOException ex) {
+                        logger.error("Error while persisting params to " + outputJsonPath, ex);
+                    }
+                }
+            }
+
+        } catch (IOException e) {
+            logger.error(outputPropFile.toString() + "not found");
+        }
+    }
+    /**
+     * This method reads the appropriate intermediate json file of a phase and updates the final user see-able
+     * params.json file to show all input params required by the currently executing script of that phase
+     *
+     * It stores this data under <phase_name>-in json parameter
+     *
+     * @param jsonFileLocation location of the intermediate json staging file relevant to the current phase
+     * @param phase          Currently executing phase
+     * @param outputJsonPath Location to the user see-able params.json file\
+     */
+    public void updateParamsJson(Path jsonFileLocation, String phase, Path outputJsonPath) {
+
+        try (InputStream jsonInputStream = new FileInputStream(jsonFileLocation.toString())) {
+
+            JSONTokener jsonTokener = new JSONTokener(jsonInputStream);
+            JSONObject inputJson = new JSONObject(jsonTokener);
+
+            File outputjsonFile = new File(outputJsonPath.toString());
+
+            if (outputjsonFile.exists()) {
+                try (InputStream outputJsonStream = new FileInputStream(outputJsonPath.toString())) {
+
+                    JSONTokener outputTokener = new JSONTokener(outputJsonStream);
+                    JSONObject insertOutputJsonVal = new JSONObject(outputTokener);
+
+                    if (inputJson.has("currentscript")) {
+                        insertOutputJsonVal.put(phase + "-in", inputJson.get("currentscript"));
+                    } else if (inputJson.has("general")) {
+                        insertOutputJsonVal.put(phase + "-in", inputJson.get("general"));
+                    }
+
+                    if (insertOutputJsonVal.length() != 0) {
+                        try (BufferedWriter jsonWriter = Files
+                                .newBufferedWriter(Paths.get(outputJsonPath.toString()))) {
+                            insertOutputJsonVal.write(jsonWriter);
+                            jsonWriter.write("\n");
+                        } catch (IOException ex) {
+                            logger.error("Error while persisting params to " + outputJsonPath, ex);
+                        }
+                    }
+
+                } catch (IOException e) {
+                    logger.error(outputJsonPath.toString() + "not found creating");
+                }
+            } else {
+                JSONObject insertOutputJsonVal = new JSONObject();
+
+                if (inputJson.has("currentscript")) {
+                    insertOutputJsonVal.put(phase + "-in", inputJson.get("currentscript"));
+                } else if (inputJson.has("general")) {
+                    insertOutputJsonVal.put(phase + "-in", inputJson.get("general"));
+                }
+
+                if (insertOutputJsonVal.length() != 0) {
+                    try (BufferedWriter jsonWriter = Files.newBufferedWriter(Paths.get(outputJsonPath.toString()))) {
+                        insertOutputJsonVal.write(jsonWriter);
+                        jsonWriter.write("\n");
+                    } catch (IOException ex) {
+                        logger.error("Error while persisting params to " + outputJsonPath, ex);
+                    }
+                }
+            }
+
+        } catch (IOException e) {
+            logger.error(jsonFileLocation.toString() + "not found");
+        }
+    }
+
+}

--- a/core/src/test/java/org/wso2/testgrid/core/command/PropJsonUtilTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/command/PropJsonUtilTest.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.testgrid.core.command;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import org.wso2.testgrid.automation.TestAutomationException;
+import org.wso2.testgrid.automation.executor.ShellTestExecutor;
+import org.wso2.testgrid.automation.executor.TestExecutorFactory;
+
+import org.wso2.testgrid.common.DeploymentPattern;
+import org.wso2.testgrid.common.InfrastructureProvider;
+import org.wso2.testgrid.common.InfrastructureProvisionResult;
+import org.wso2.testgrid.common.Product;
+import org.wso2.testgrid.common.TestGridConstants;
+import org.wso2.testgrid.common.TestPlan;
+import org.wso2.testgrid.common.TestPlanPhase;
+import org.wso2.testgrid.common.TestPlanStatus;
+import org.wso2.testgrid.common.TestScenario;
+import org.wso2.testgrid.common.config.InfrastructureConfig;
+import org.wso2.testgrid.common.config.Script;
+import org.wso2.testgrid.common.config.TestgridYaml;
+import org.wso2.testgrid.common.infrastructure.DefaultInfrastructureTypes;
+import org.wso2.testgrid.common.infrastructure.InfrastructureCombination;
+import org.wso2.testgrid.common.infrastructure.InfrastructureParameter;
+import org.wso2.testgrid.common.util.DataBucketsHelper;
+import org.wso2.testgrid.common.util.FileUtil;
+import org.wso2.testgrid.common.util.StringUtil;
+import org.wso2.testgrid.common.util.TestGridUtil;
+
+import org.wso2.testgrid.core.ScenarioExecutor;
+import org.wso2.testgrid.core.TestPlanExecutor;
+import org.wso2.testgrid.core.util.JsonPropFileUtil;
+
+import org.wso2.testgrid.dao.TestGridDAOException;
+import org.wso2.testgrid.dao.uow.DeploymentPatternUOW;
+import org.wso2.testgrid.dao.uow.ProductUOW;
+import org.wso2.testgrid.dao.uow.TestCaseUOW;
+import org.wso2.testgrid.dao.uow.TestPlanUOW;
+import org.wso2.testgrid.dao.uow.TestScenarioUOW;
+
+import org.wso2.testgrid.infrastructure.InfrastructureCombinationsProvider;
+import org.wso2.testgrid.infrastructure.InfrastructureProviderFactory;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@PrepareForTest({ StringUtil.class, TestExecutorFactory.class })
+@PowerMockIgnore({ "javax.management.*", "javax.script.*", "org.apache.logging.log4j.*" })
+public class PropJsonUtilTest extends PowerMockTestCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(RunTestPlanCommandTest.class);
+    private static final String TESTGRID_HOME = Paths.get("target", "testgrid-home").toString();
+    private static final String infraParamsString = "{\"operating_system\":\"ubuntu_16.04\"}";
+    private static final String TESTPLAN_ID = "TP_1";
+    private static final String DEFAULT_SCHEDULE = "manual";
+
+    @InjectMocks
+    private RunTestPlanCommand runTestPlanCommand;
+
+    @Mock
+    private InfrastructureCombinationsProvider infrastructureCombinationsProvider;
+
+    @Mock
+    private ProductUOW productUOW;
+    @Mock
+    private DeploymentPatternUOW deploymentPatternUOW;
+    @Mock
+    private TestPlanUOW testPlanUOW;
+    @Mock
+    private TestScenarioUOW testScenarioUOW;
+    @Mock
+    private TestCaseUOW testCaseUOW;
+
+    private Product product;
+    private TestPlan testPlan;
+    private DeploymentPattern deploymentPattern;
+    private TestPlanExecutor testPlanExecutor;
+    private ScenarioExecutor scenarioExecutor;
+    private String actualTestPlanFileLocation;
+    private String workspaceDir;
+
+    @BeforeMethod
+    public void init() throws Exception {
+        final String randomStr = StringUtil.generateRandomString(5);
+        String productName = "wso2-" + randomStr;
+        actualTestPlanFileLocation = Paths.get("target", "testgrid-home", TestGridConstants.TESTGRID_JOB_DIR,
+                productName, TestGridConstants.PRODUCT_TEST_PLANS_DIR, "test-plan-01.yaml").toString();
+        workspaceDir = Paths.get(TestGridUtil.getTestGridHomePath(), TestGridConstants.TESTGRID_JOB_DIR,
+                productName).toString();
+        runTestPlanCommand = new RunTestPlanCommand(productName, actualTestPlanFileLocation, workspaceDir);
+        System.setProperty(TestGridConstants.TESTGRID_HOME_SYSTEM_PROPERTY, TESTGRID_HOME);
+
+        this.product = new Product();
+        product.setName(productName);
+
+        this.deploymentPattern = new DeploymentPattern();
+        deploymentPattern.setName("default-" + randomStr);
+        deploymentPattern.setProduct(product);
+
+        this.testPlan = new TestPlan();
+        testPlan.setId(TESTPLAN_ID);
+        testPlan.setTestRunNumber(1);
+        testPlan.setDeploymentPattern(deploymentPattern);
+        testPlan.setInfraParameters(infraParamsString);
+        testPlan.setPhase(TestPlanPhase.INFRA_PHASE_SUCCEEDED);
+        testPlan.setStatus(TestPlanStatus.RUNNING);
+        testPlan.setDeployerType(TestPlan.DeployerType.SHELL);
+        testPlan.setScenarioTestsRepository(Paths.get(workspaceDir, "/workspace/scenarioTests").toString());
+        testPlan.setInfrastructureRepository(Paths.get(workspaceDir, "/workspace/infrastructure").toString());
+        testPlan.setDeploymentRepository(Paths.get(workspaceDir, "/workspace/deployment").toString());
+        testPlan.setKeyFileLocation(Paths.get(workspaceDir, "/workspace/testkey.pem").toString());
+        testPlan.setWorkspace(workspaceDir);
+
+        when(testScenarioUOW.persistTestScenario(any(TestScenario.class))).thenAnswer(invocation -> invocation
+                .getArguments()[0]);
+
+        scenarioExecutor = new ScenarioExecutor(testScenarioUOW, testCaseUOW);
+        testPlanExecutor = new TestPlanExecutor(scenarioExecutor, testPlanUOW, testScenarioUOW);
+        testPlanExecutor = spy(testPlanExecutor);
+
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(dataProvider = "getJobConfigData")
+    public void testExecute(String jobConfigFile) throws Exception {
+        doMock();
+
+        GenerateTestPlanCommand generateTestPlanCommand = new GenerateTestPlanCommand(product.getName(),
+                jobConfigFile, infrastructureCombinationsProvider, productUOW,
+                deploymentPatternUOW, testPlanUOW);
+        generateTestPlanCommand.execute();
+
+        Path actualTestPlanPath = Paths.get(actualTestPlanFileLocation);
+        assertTrue(Files.exists(actualTestPlanPath));
+        copyWorkspaceArtifacts();
+
+        TestPlan testPlan = FileUtil.readYamlFile(actualTestPlanPath.toString(), TestPlan.class);
+        InfrastructureConfig infrastructureConfig = testPlan.getInfrastructureConfig();
+
+        JsonPropFileUtil jsonpropFileEditor = new JsonPropFileUtil();
+
+        final Properties infraConfigParameters = testPlan.getInfrastructureConfig().getParameters();
+        final Properties infraJobProperties = testPlan.getJobProperties();
+        final String keyFileLocation = testPlan.getKeyFileLocation();
+
+        if (keyFileLocation != null) {
+            infraJobProperties.setProperty(TestGridConstants.KEY_FILE_LOCATION, keyFileLocation);
+        }
+
+        jsonpropFileEditor.persistAdditionalInputs(infraConfigParameters, DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE),
+                DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_JSONFILE), Optional.empty());
+        jsonpropFileEditor.persistAdditionalInputs(infraJobProperties, DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE),
+                DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_JSONFILE), Optional.empty());
+
+        InfrastructureProvisionResult provisionResult = new InfrastructureProvisionResult();
+
+        for (Script script : infrastructureConfig.getFirstProvisioner().getScripts()) {
+            if (!Script.Phase.DESTROY.equals(script.getPhase())) {
+                jsonpropFileEditor.persistAdditionalInputs(script.getInputParameters(),
+                        DataBucketsHelper.getInputLocation(testPlan)
+                                .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE),
+                        DataBucketsHelper.getInputLocation(testPlan)
+                                .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_JSONFILE),
+                        Optional.of(script.getName()));
+                InfrastructureProvider infrastructureProvider = InfrastructureProviderFactory
+                        .getInfrastructureProvider(script);
+                infrastructureProvider.init(testPlan);
+                logger.info("");
+                logger.info("--- executing script: " + script.getName() + ", file: " + script.getFile());
+                InfrastructureProvisionResult aProvisionResult =
+                        infrastructureProvider.provision(testPlan, script);
+                addTo(provisionResult, aProvisionResult);
+
+
+                Properties propertiesfile = readData(DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE));
+                JSONObject propjsonfile = readJsonData(DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_JSONFILE));
+                boolean assertionContainsScriptparams = true;
+                for (String key : script.getInputParameters().keySet()) {
+                    if (propertiesfile.containsKey(key))  {
+                        assertionContainsScriptparams = assertionContainsScriptparams &&
+                                propertiesfile.containsKey(key) &&
+                                (propertiesfile.get(key)).equals(script.getInputParameters().get(key).toString());
+                    } else {
+                        assertionContainsScriptparams  = false;
+                    }
+                    if (propjsonfile.has("currentscript")) {
+                        logger.info("has currentscript");
+                        if (propjsonfile.getJSONObject("currentscript").has(key)) {
+                            assertionContainsScriptparams = assertionContainsScriptparams &&
+                                    propjsonfile.getJSONObject("currentscript").has(key) &&
+                                    (propjsonfile.getJSONObject("currentscript").get(key).toString())
+                                            .equals(script.getInputParameters().get(key).toString());
+                        } else {
+                            assertionContainsScriptparams  = false;
+                        }
+                    } else {
+                        assertionContainsScriptparams  = false;
+                    }
+                    if (propjsonfile.has(script.getName())) {
+                        if (propjsonfile.getJSONObject(script.getName()).has(key)) {
+                            assertionContainsScriptparams = assertionContainsScriptparams &&
+                                    propjsonfile.getJSONObject(script.getName()).has(key) &&
+                                    (propjsonfile.getJSONObject(script.getName()).get(key).toString())
+                                            .equals(script.getInputParameters().get(key).toString());
+
+                        } else {
+                            assertionContainsScriptparams  = false;
+                        }
+                    } else {
+                        assertionContainsScriptparams  = false;
+                    }
+                }
+                assertTrue(assertionContainsScriptparams, "Script Params are present");
+
+                final Properties infraParameters = testPlan.getInfrastructureConfig().getParameters();
+                final Properties jobProperties = testPlan.getJobProperties();
+                Boolean assertionContainsGeneralInfraParams = true;
+
+                for (Object key : infraParameters.keySet()) {
+                    if (propertiesfile.containsKey(key)) {
+                        assertionContainsGeneralInfraParams = assertionContainsGeneralInfraParams &&
+                                propertiesfile.containsKey(key) &&
+                                (propertiesfile.get(key)).equals(infraParameters.get(key).toString());
+                    } else {
+                        assertionContainsGeneralInfraParams = false;
+                    }
+                    if (propjsonfile.has("currentscript")) {
+                        if (propjsonfile.getJSONObject("currentscript").has((String) key)) {
+                            assertionContainsGeneralInfraParams = assertionContainsGeneralInfraParams &&
+                                    propjsonfile.getJSONObject("currentscript").has((String) key) &&
+                                    (propjsonfile.getJSONObject("currentscript").get((String) key)).toString()
+                                            .equals(infraParameters.get(key).toString());
+                        } else {
+                            assertionContainsGeneralInfraParams = false;
+                        }
+                    } else {
+                        assertionContainsGeneralInfraParams = false;
+                    }
+                    if (propjsonfile.has("general")) {
+                        if (propjsonfile.getJSONObject("general").has((String) key)) {
+                            assertionContainsGeneralInfraParams = assertionContainsGeneralInfraParams &&
+                                    propjsonfile.getJSONObject("general").has((String) key) &&
+                                    (propjsonfile.getJSONObject("general").get((String) key)).toString()
+                                            .equals(infraParameters.get(key).toString());
+
+                        } else {
+                            assertionContainsGeneralInfraParams = false;
+                        }
+                    } else {
+                        assertionContainsGeneralInfraParams = false;
+                    }
+                }
+
+                assertTrue(assertionContainsGeneralInfraParams, "General Infra Params are present");
+
+                if (propjsonfile.has("general")) {
+                    assertEquals(propjsonfile.getJSONObject("general").length(),
+                            infraParameters.size() + jobProperties.size(),
+                            "general has wrong amount of values");
+                }
+                if (propjsonfile.has("currentscript")) {
+                    assertEquals(propjsonfile.getJSONObject("currentscript").length(),
+                            infraParameters.size() + jobProperties.size() + script.getInputParameters().size(),
+                            "current script has wrong amount of values");
+                    assertEquals(propertiesfile.size(),
+                            infraParameters.size() + jobProperties.size() + script.getInputParameters().size(),
+                            "prop file has wrong amount of values");
+                }
+                if (propjsonfile.has(script.getName())) {
+                    assertEquals(propjsonfile.getJSONObject(script.getName()).length()
+                            , script.getInputParameters().size(),  "script name has wrong amount of values");
+                }
+
+
+
+                jsonpropFileEditor.removeScriptParams(script, DataBucketsHelper.getInputLocation(testPlan)
+                        .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE));
+                jsonpropFileEditor.refillJSONfromPropFile(DataBucketsHelper.getInputLocation(testPlan)
+                                .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_FILE),
+                        DataBucketsHelper.getInputLocation(testPlan)
+                                .resolve(DataBucketsHelper.TESTPLAN_PROPERTIES_JSONFILE));
+            }
+        }
+
+
+    }
+
+    private void copyWorkspaceArtifacts() throws IOException {
+        String resourceDir = Paths.get("./src", "test", "resources", "workspace").toString();
+        String destinationDir = Paths.get(workspaceDir, "/workspace").toString();
+        FileUtils.copyDirectory(new File(resourceDir), new File(destinationDir));
+        logger.info("Copying necessary artifacts to directory: " + destinationDir);
+        resourceDir = Paths.get("src", "test", "resources", "workspace", "data-bucket").toString();
+        destinationDir = Paths.get(workspaceDir, "/data-bucket").toString();
+        FileUtils.copyDirectory(new File(resourceDir), new File(destinationDir));
+        logger.info("Copying necessary artifacts to directory: " + destinationDir);
+    }
+
+    private void doMock() throws TestGridDAOException, TestAutomationException {
+        spy(StringUtil.class);
+        when(StringUtil.generateRandomString(anyInt())).thenReturn("");
+        PowerMockito.mockStatic(TestExecutorFactory.class);
+        when(TestExecutorFactory.getTestExecutor(any())).thenReturn(new ShellTestExecutor());
+
+        InfrastructureParameter param = new InfrastructureParameter("ubuntu_16.04", DefaultInfrastructureTypes
+                .OPERATING_SYSTEM, "{}", true);
+        InfrastructureCombination comb1 = new InfrastructureCombination(param);
+        when(infrastructureCombinationsProvider.getCombinations(any(TestgridYaml.class), eq(DEFAULT_SCHEDULE)))
+                .thenReturn(Collections.singleton(comb1));
+
+        logger.info("Product : " + product.getName());
+        when(productUOW.persistProduct(anyString())).thenReturn(product);
+        when(productUOW.getProduct(anyString())).thenReturn(Optional.of(product));
+        when(deploymentPatternUOW.getDeploymentPattern(eq(product), anyString()))
+                .thenReturn(Optional.of(deploymentPattern));
+
+        doAnswer(invocation -> new TestScenario()).when(testScenarioUOW).persistTestScenario(any(TestScenario.class));
+        // we need to further improve this
+        when(testScenarioUOW.isFailedTestScenariosExist(anyObject())).thenReturn(false);
+        when(testCaseUOW.isExistsFailedTests(anyObject())).thenReturn(false);
+
+        when(testPlanUOW.persistTestPlan(any(TestPlan.class))).thenReturn(testPlan);
+        when(testPlanUOW.getTestPlanById(TESTPLAN_ID)).thenReturn(Optional.of(testPlan));
+    }
+
+
+
+    @DataProvider
+    public Object[][] getJobConfigData() {
+        return new Object[][] {
+                { "src/test/resources/job-config.yaml" }
+        };
+    }
+
+    private void addTo(InfrastructureProvisionResult provisionResult, InfrastructureProvisionResult aProvisionResult) {
+        provisionResult.getProperties().putAll(aProvisionResult.getProperties());
+        if (!aProvisionResult.isSuccess()) {
+            provisionResult.setSuccess(false);
+        }
+    }
+
+    private Properties readData(Path propFilePath) {
+        InputStream propInputStream = null;
+        Properties existingprops = new Properties();
+        try {
+            propInputStream = new FileInputStream(propFilePath.toString());
+            existingprops.load(propInputStream);
+        } catch (FileNotFoundException e) {
+            logger.info(propFilePath + " Not created yet ignoring read property file step");
+        } catch (IOException e) {
+            logger.error("Error while persisting infra input params to " + propFilePath);
+        } finally {
+            try {
+                if (propInputStream != null) {
+                    propInputStream.close();
+                }
+            } catch (Exception e) {
+                logger.error("Failed to close Stream");
+            }
+        }
+        return existingprops;
+    }
+
+    private JSONObject readJsonData(Path jsonFilePath) {
+        InputStream jsonInputStream = null;
+        JSONObject jsondata = null;
+        try {
+            jsonInputStream = new FileInputStream(jsonFilePath.toString());
+            JSONTokener jsonTokener = new JSONTokener(jsonInputStream);
+            jsondata = new JSONObject(jsonTokener);
+        } catch (IOException ex) {
+            logger.info("Error json file not found");
+        } finally {
+            try {
+                if (jsonInputStream != null) {
+                    jsonInputStream.close();
+                }
+            } catch (Exception e) {
+                logger.error("Failed to close Stream");
+            }
+        }
+        return jsondata;
+    }
+
+}


### PR DESCRIPTION
**Purpose**
This PR intends to isolate the input parameter added to the .properties file from the Phase class and to add a new feature of using JSON files to support hierarchical Input Parameters.

**Documentation**
<!-- List any other related PRs -->

