### PR TITLE
Set both sysctl and ulimit values

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -263,6 +263,8 @@ Resources:
 
           # Set file limits
           sysctl -w fs.file-max=1000000
+          sysctl fs.file-nr
+          ulimit -n 65535
           ulimit -Hn
           ulimit -Sn
 


### PR DESCRIPTION
**Purpose**

Identity Server Tests are getting the following error.
```
[ADOPT_OPEN_JDK8_MySQL-5.7_CentOS-7.5] [m[32m[10:22:16,340] INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - Caused by: java.io.FileNotFoundException: /opt/testgrid/workspace/product-is/modules/integration/tests-integration/tests-backend/target/carbontmp1575366870802/wso2is-5.7.0/repository/conf/bps.xml (Too many open files)
```

**Goals**
Fix the error by changing file descriptor limit to 65535

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
Ubuntu 18.04

**Related PRs**
https://github.com/wso2/testgrid/pull/1271
https://github.com/wso2/testgrid/pull/1272
https://github.com/wso2/testgrid/pull/1273

**Learning**
http://man7.org/linux/man-pages/man3/ulimit.3.html