### PR TITLE
Set default JDK to OPEN_JDK11

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -132,7 +132,7 @@ Parameters:
     Description: Enter target OS version.
   JDK:
     Type: String
-    Default: ORACLE_JDK8
+    Default: OPEN_JDK11
     Description: Enter target JDK version.
     AllowedValues:
       - OPEN_JDK8


### PR DESCRIPTION
**Purpose**
Set default JDK to OPEN_JDK11

**Goals**
Set default JDK to OPEN_JDK11

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
AWS

