### PR TITLE
Set default JDK to ORACLE_JDK8

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -132,7 +132,7 @@ Parameters:
     Description: Enter target OS version.
   JDK:
     Type: String
-    Default: OPEN_JDK11
+    Default: ORACLE_JDK8
     Description: Enter target JDK version.
     AllowedValues:
       - OPEN_JDK8
@@ -270,7 +270,6 @@ Resources:
           ulimit -Sn
 
           setup_java_env() {
-            JDK=ORACLE_JDK8
             source /etc/environment
 
             echo JDK_PARAM=${JDK} >> /opt/testgrid/java.txt


### PR DESCRIPTION
**Purpose**
Set default JDK to ORACLE_JDK8

**Goals**
Set default JDK to ORACLE_JDK8

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Related PRs**

**Test environment**
Ubuntu18.04
AWS
