### PR TITLE
Add if condition to cfn-signal for Unix instance

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -313,7 +313,13 @@ Resources:
 
           cat /dev/null > ~/.bash_history && history -c
           ${CustomUserData}
-          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
+          echo ${OS}
+          if [[ ${OS} == "Ubuntu" ]]; then
+            /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
+          fi
+          if [[ ${OS} == "CentOS" ]]; then
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
+          fi
       Tags:
         - Key: Name
           Value: !Join


### PR DESCRIPTION
**Purpose**
Add if condition to cfn-signal for Unix instance in order to run integration tests for both Ubuntu and centOS

**Goals**
Add if condition to cfn-signal for Unix instance

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
CentOS 7.5
Ubuntu 18.04
AWS
