### PR TITLE
Add new JDKs to AMI build

### DIFF
--- a/packer/resource-ami/init.sh
+++ b/packer/resource-ami/init.sh
@@ -16,7 +16,7 @@
 
 ubuntu_os_version="18.04"
 ubuntu_ssh_username="ubuntu"
-ubuntu_source_ami_filter_name="ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+ubuntu_source_ami_filter_name="ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
 ubuntu_source_ami_filter_owner="099720109477"
 
 centos_os_version="7"


### PR DESCRIPTION
**Purpose**

1. Newest JDKs are added to the AMI build script.
2. Fix error in using Ubuntu 16.04 base AMI as Ubuntu 18.04

**Goals**
Support new JDKs. Fix AMI mismatch issue.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
Ubuntu 18.04
AWS