### PR TITLE
Add port 10173 to IS sec-group

### DIFF
--- a/jobs/intg-test-resources/ballerina-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/ballerina-intg-test-cfn.yaml
@@ -186,6 +186,10 @@ Resources:
           FromPort: 8086
           ToPort: 8086
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 10173
+          ToPort: 10173
+          CidrIp: 0.0.0.0/0
     Metadata:
       'AWS::CloudFormation::Designer':
         id: abbdb5e8-f28b-4bc6-8b63-da9595b59c4a

--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -206,6 +206,10 @@ Resources:
           FromPort: 8086
           ToPort: 8086
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 10173
+          ToPort: 10173
+          CidrIp: 0.0.0.0/0
     Metadata:
       'AWS::CloudFormation::Designer':
         id: abbdb5e8-f28b-4bc6-8b63-da9595b59c4a
@@ -357,7 +361,6 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId: !Ref AMI
-        
         InstanceType: !Ref WSO2InstanceType
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -461,7 +464,7 @@ Outputs:
   DBUsername:
     Value: !Ref DBUsername
   DBPassword:
-    Value: !Ref DBPassword    
+    Value: !Ref DBPassword
 Metadata:
   'AWS::CloudFormation::Designer':
     abbdb5e8-f28b-4bc6-8b63-da9595b59c4a:


### PR DESCRIPTION
**Purpose**
Add port configs for port 10173 to Identity Server Security group used for Integration tests

**Goals**
Open port 10173

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes