### PR TITLE
Increase the open file limit

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -270,7 +270,7 @@ Resources:
           set -o xtrace
 
           # Set file limits
-          sysctl -w fs.file-max=1000000
+          sysctl -w fs.file-max=1529796
           sysctl fs.file-nr
           ulimit -n 65535
           ulimit -Hn


### PR DESCRIPTION
**Purpose**
Identity server Integration tests are getting the following error.

```
 org.apache.axis2.AxisFault: Too many open files
```

**Goals**
Fix the above error by increasing the file limit.

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
AWS
