### PR TITLE
Burn user limits to the AMI

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -270,9 +270,8 @@ Resources:
           set -o xtrace
 
           # Set file limits
-          sysctl -w fs.file-max=1529796
+          sysctl -w fs.file-max=2097152
           sysctl fs.file-nr
-          ulimit -n 65535
           ulimit -Hn
           ulimit -Sn
 


### PR DESCRIPTION
**Purpose**
User limits were not set properly using the CloudFormation script as it needed to logout and login in order to apply the following. 

```
ulimit -n 65535
```

Therefore burned it to the AMI.

**Goals**
Fix the following error
```
INFO [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - Caused by: java.io.FileNotFoundException: /opt/testgrid/workspace/product-is/modules/integration/tests-integration/tests-backend/target/carbontmp1582014362976/wso2is-5.10.0-beta3-SNAPSHOT/repository/conf/bps.xml (Too many open files)
```

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Related PRs**
#1300 

**Test environment**
AWS
 
**Learning**
https://doc.nuxeo.com/nxdoc/java.net.SocketException-too-many-open-files/