### PR TITLE
Change user limits in the Integration test EC2 instance

### DIFF
--- a/packer/resource-ami/config.sh
+++ b/packer/resource-ami/config.sh
@@ -487,6 +487,18 @@ function showInstallations() {
     echo
 }
 
+#=== FUNCTION ==================================================================
+# NAME: setUserLimits
+# DESCRIPTION: Set hard and soft limits for all users.
+#===============================================================================
+function setUserLimits() {
+	echo "Set hardlimit for all users"
+	echo "*		hard	nofile		65535" >> /etc/security/limits.conf
+	echo "Set softlimit for all users"
+	echo "*		soft	nofile		65535" >> /etc/security/limits.conf
+	echo "session		required		pam_limits.so" >> /etc/pam.d/su
+}
+
 case "$AMI_OS" in
     Ubuntu)
 	showMessage "Starting Ubuntu configuration steps.."
@@ -538,4 +550,6 @@ showMessage "10. Adding environment variables"
 addEnvVariables
 showMessage "11.Showing installations"
 showInstallations
+showMessage "12. Set user limits"
+setUserLimits
 sudo rm -f -r *


### PR DESCRIPTION
**Purpose**
User limits were not set properly using the CloudFormation script as it needed to logout and login in order to apply the following. 

```
ulimit -n 65535
```

Therefore should be burned to the AMI.

**Goals**
Fix the following error
```
INFO [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - Caused by: java.io.FileNotFoundException: /opt/testgrid/workspace/product-is/modules/integration/tests-integration/tests-backend/target/carbontmp1582014362976/wso2is-5.10.0-beta3-SNAPSHOT/repository/conf/bps.xml (Too many open files)
```

**Security checks**
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Related PRs**
#1300 
#1301 

**Test environment**
AWS
 
**Learning**
https://doc.nuxeo.com/nxdoc/java.net.SocketException-too-many-open-files/