### PR TITLE
Invoke cfn-signal for RHEL based instances.

### DIFF
--- a/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/wso2-intg-test-cfn.yaml
@@ -326,6 +326,9 @@ Resources:
           if [[ ${OS} == "CentOS" ]]; then
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
           fi
+          if [[ ${OS} == "RHEL" ]]; then
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2UnixInstance --region ${AWS::Region}
+          fi
       Tags:
         - Key: Name
           Value: !Join


### PR DESCRIPTION
**Purpose**

Invoke the `cfn-signal` for RHEL based instances in TG so that the CFN stack creation completes successfully. 
