### PR TITLE
Add CentOS AMI with support for Temurin JDK 8

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -173,7 +173,7 @@ Mappings:
     Ubuntu:
       img: ami-025def472c84238d3
     CentOS:
-      img: ami-0c6e499577dc522ef
+      img: ami-044935fa8f784339d
     RHEL:
       img: ami-05b6fba4481489641
     SUSE:
@@ -322,6 +322,9 @@ Resources:
 
             export JAVA_HOME=/opt/$1
             ln -sf /opt/$1/bin/java /usr/bin/java
+            
+            java -version
+            javac -version
           }
 
           mkdir -p /opt/testgrid/workspace


### PR DESCRIPTION
**Purpose**

> To support Temurin JDKs in Test Grid