### PR TITLE
Add APIM 4.2.0 and JDK17

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -175,7 +175,7 @@ Mappings:
     Ubuntu:
       img: ami-025def472c84238d3
     CentOS:
-      img: ami-00fd5f05ab29a62bc
+      img: ami-0b3041ea1584670e4
     RHEL:
       img: ami-05b6fba4481489641
     SUSE:

--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -128,7 +128,9 @@ Parameters:
       - ADOPT_OPEN_JDK8
       - CORRETTO_JDK8
       - CORRETTO_JDK11
+      - CORRETTO_JDK17
       - ADOPT_OPEN_JDK11
+      - ADOPT_OPEN_JDK17
       - TEMURIN_OPEN_JDK8
   MavenVersion:
     Type: String


### PR DESCRIPTION
## Purpose

1. Adding CentOS AMI with APIM 4.2.0
2. Adding JDK 17 support