### PR TITLE
Add commands to install postgres15 client in centos

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -311,6 +311,10 @@ Resources:
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
                 source ~/.bashrc
+                yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+                yum -y update
+                yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+                yum -y install postgresql15
               fi
               if [[ ${OperatingSystem} == "SUSE" ]]; then
                 zypper install -y zip unzip


### PR DESCRIPTION
**Purpose**

This PR adds the commands to install postgres15 client in CentOS in order to test PostgreSQL 15.3 in the testgrid.