### PR TITLE
Replace python-pip with python3-pip package

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -321,7 +321,7 @@ Resources:
                   sleep 120
                   dpkg --configure -a
                   apt install -y zip
-                  apt install -y python-pip
+                  apt install -y python3-pip
                   apt install -y jq
               fi
               if [[ ${OperatingSystem} == "CentOS" ]] || [[ ${OperatingSystem} == "RHEL8" ]] || [[ ${OperatingSystem} == "RHEL9" ]] || [[ ${OperatingSystem} == "Rocky" ]]; then


### PR DESCRIPTION
**Purpose**

This PR replaces the currently used python-pip package to python3-pip package since python-pip package is removed from Ubuntu 24.04.