### PR TITLE
Add script to install DB clients for Ubuntu

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -317,13 +317,26 @@ Resources:
 
               if [[ ${OperatingSystem} == "Ubuntu" ]]; then
                   export DEBIAN_FRONTEND=noninteractive
-                  apt-get update
+                  apt update
                   sleep 120
                   dpkg --configure -a
                   apt install -y zip
                   apt install -y python3-pip
                   apt install -y jq
                   apt install -y python3-venv
+                  echo "Installing PostgreSQL database client"
+                  apt install -y postgresql-client
+                  echo "Installing MySQL database client"
+                  apt install -y mysql-client
+                  echo "Installing MariaDB database client"
+                  apt install -y mariadb-client
+                  echo "Installing MSSQL database client"
+                  curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+                  curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+                  apt update
+                  apt install -y mssql-tools18 unixodbc-dev
+                  echo 'export PATH="/opt/mssql-tools18/bin:$PATH"' >> /etc/environment
+                  source /etc/environment
               fi
               if [[ ${OperatingSystem} == "CentOS" ]] || [[ ${OperatingSystem} == "RHEL8" ]] || [[ ${OperatingSystem} == "RHEL9" ]] || [[ ${OperatingSystem} == "Rocky" ]]; then
                 yum install -y epel-release zip unzip


### PR DESCRIPTION
**Purpose**

This PR adds the script to install the following DB clients for the Ubuntu instance.
- MySQL
- PostgreSQL
- MariaDB
- MSSQL
