### PR TITLE
Update AMI

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -205,7 +205,7 @@ Mappings:
     RHEL8:
       img: ami-077a8c9eeb949d9d6
     RHEL9:
-      img: ami-0a82122aa7eac8136
+      img: ami-0ad1e6ec3e415de1f
     SUSE:
       img: ami-009fab158dcff70e0
     Rocky:


### PR DESCRIPTION
This pull request includes a small change to the `jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml` file. The change updates the Amazon Machine Image (AMI) ID for RHEL9.

* Updated the AMI ID for RHEL9 from `ami-0a82122aa7eac8136` to `ami-0ad1e6ec3e415de1f`.\
* Install Git
* Update packages