### PR TITLE
Update Rocky AMI

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -209,7 +209,7 @@ Mappings:
     SUSE:
       img: ami-009fab158dcff70e0
     Rocky:
-      img: ami-0bdb0ee5983bfb6aa
+      img: ami-0252bb755ffc8d535
 #Conditions
 Conditions:
  IsWindows: !Equals [ !Ref OperatingSystem, "Windows" ]


### PR DESCRIPTION
## Purpose  
The current Rocky AMI has only a 10GB volume attached, which causes the 4.5.0 build to fail intermittently.

## Goal  
Update the Rocky AMI to use a 50GB EBS volume.

## Approach  
Use the existing AMI and modify its EBS volume size to 50GB.

