### PR TITLE
Bump Oracle 19 DB Engine Version

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -198,7 +198,7 @@ Mappings:
     SQLServer-SE-16.00:
       DBEngine: "sqlserver-se_16.00"
     Oracle-SE2-19.0:
-      DBEngine: "oracle-se2_19.0.0.0.ru-2019-10.rur-2019-10.r1"
+      DBEngine: "oracle-se2_19.0.0.0.ru-2025-04.rur-2025-04.r1"
     Oracle-SE2-21.0:
       DBEngine: "oracle-se2-cdb_21.0.0.0.ru-2024-01.rur-2024-01.r1"
   OperatingSystemAMI:


### PR DESCRIPTION
**Purpose**
The existing oracle 19 DB engine version (oracle-se2_19.0.0.0.ru-2019-10.rur-2019-10.r1) seems to be discontinued by aws. Hence, bumping the oracle 19 DB engine version to oracle-se2_19.0.0.0.ru-2025-04.rur-2025-04.r1
