### PR TITLE
Update RHEL version to 9.6

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -214,7 +214,7 @@ Mappings:
     RHEL8:
       img: ami-077a8c9eeb949d9d6
     RHEL9:
-      img: ami-0ad1e6ec3e415de1f
+      img: ami-07aa0998b75b559e0
     SUSE:
       img: ami-009fab158dcff70e0
     Rocky:


### PR DESCRIPTION
**Purpose**
Minor version bump from RHEL 9.5 to 9.6

**Approach**
- Run the following commands on top of `TestGrid-RHEL-9.3-APIM-2025-04-9`
```bash
sudo dnf clean all
sudo dnf update -y
```

- Create new ami: `TestGrid-RHEL-9.6-APIM-2025-09-10`