### PR TITLE
Add jdk25 support and install oracle tools

### DIFF
--- a/jobs/intg-test-resources/master-branch-releases/wso2-master-is-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/master-branch-releases/wso2-master-is-intg-test-cfn.yaml
@@ -158,9 +158,11 @@ Parameters:
       - ADOPT_OPEN_JDK11
       - ADOPT_OPEN_JDK17
       - ADOPT_OPEN_JDK21
+      - ADOPT_OPEN_JDK25
       - ADOPT_OPEN_JDK11_ARM
       - ADOPT_OPEN_JDK17_ARM
       - ADOPT_OPEN_JDK21_ARM
+      - ADOPT_OPEN_JDK25_ARM
       - TEMURIN_OPEN_JDK8
   MavenVersion:
     Type: String
@@ -377,6 +379,13 @@ Resources:
                   apt install -y mysql-client
                   echo "Installing MariaDB database client"
                   apt install -y mariadb-client
+                  echo "Installing Oracle sqlplus64 tool"
+                  curl -fSL https://yum.oracle.com/repo/OracleLinux/OL8/oracle/instantclient/x86_64/getPackage/oracle-instantclient19.30-basic-19.30.0.0.0-1.el8.x86_64.rpm -o /tmp/oracle-instantclient-basic.rpm
+                  curl -fSL https://yum.oracle.com/repo/OracleLinux/OL8/oracle/instantclient/x86_64/getPackage/oracle-instantclient19.30-sqlplus-19.30.0.0.0-1.el8.x86_64.rpm -o /tmp/oracle-instantclient-sqlplus.rpm
+                  apt-get install -y alien libaio1t64
+                  ln -sf /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+                  alien --install --scripts /tmp/oracle-instantclient-basic.rpm
+                  alien --install --scripts /tmp/oracle-instantclient-sqlplus.rpm
                   echo "Installing MSSQL database client"
                   curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
                   curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
@@ -395,6 +404,7 @@ Resources:
                 wget https://packages.microsoft.com/config/rhel/9/mssql-server-2022.repo -O /etc/yum.repos.d/mssql-server-2022.repo
                 wget https://packages.microsoft.com/config/rhel/9/prod.repo -O /etc/yum.repos.d/msprod.repo
                 ACCEPT_EULA=Y yum install -y mssql-tools unixODBC-devel
+                yum -y install sqlplus64
                 yum -y install mysql
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
@@ -430,6 +440,7 @@ Resources:
                   wget https://packages.microsoft.com/config/rhel/9/prod.repo -O /etc/yum.repos.d/msprod.repo
                 fi
                 ACCEPT_EULA=Y yum install -y mssql-tools unixODBC-devel
+                yum -y install sqlplus64
                 yum -y install mysql
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
                 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
@@ -450,6 +461,7 @@ Resources:
               if [[ ${OperatingSystem} == "SUSE" ]]; then
                 zypper install -y zip unzip
                 zypper install -y python-pip
+                zypper install -y sqlplus64
               fi
               if [[ ${OperatingSystem} == "RHEL9" ]] || [[ ${OperatingSystem} == "Rocky" ]]; then
                 pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz


### PR DESCRIPTION
## **Purpose**

This pull request updates the CloudFormation template `wso2-master-is-intg-test-cfn.yaml` to enhance integration test infrastructure by adding support for newer JDK versions and improving database client tooling. The main improvements are the addition of AdoptOpenJDK 25 options and the installation of the Oracle `sqlplus64` client across supported operating systems.

**Platform support enhancements:**

* Added `ADOPT_OPEN_JDK25` and `ADOPT_OPEN_JDK25_ARM` to the list of supported JDK options, allowing integration tests to run against the latest Java version.

**Database tooling improvements:**

* Added installation steps for the Oracle `sqlplus64` client on Ubuntu-based systems using Oracle Instant Client RPMs and the `alien` package converter.
* Added installation of `sqlplus64` via `yum` for RHEL9 and Rocky Linux environments. [[1]](diffhunk://#diff-ea2df6adf27b3bcfad057ac5a9a668c5b8a16053d6ec61c9b6fb4200109e23b2R407) [[2]](diffhunk://#diff-ea2df6adf27b3bcfad057ac5a9a668c5b8a16053d6ec61c9b6fb4200109e23b2R443)
* Added installation of `sqlplus64` via `zypper` for SUSE environments.
