### PR TITLE
Add --nogpgcheck option to MySQL client installation

### DIFF
--- a/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
+++ b/jobs/intg-test-resources/update2-releases/wso2-u2-intg-test-cfn.yaml
@@ -390,7 +390,7 @@ Resources:
                 ACCEPT_EULA=Y yum install -y mssql-tools unixODBC-devel
                 if [[ ${OperatingSystem} == "RHEL10" ]]; then
                   dnf install https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm -y
-                  yum -y install mysql-community-client
+                  yum -y install mysql-community-client --nogpgcheck
                 else
                   yum -y install mysql
                 fi


### PR DESCRIPTION
This pull request makes a minor update to the installation command for `mysql-community-client` in the `wso2-u2-intg-test-cfn.yaml` configuration file. The change ensures that the package is installed without checking GPG signatures, which can help prevent installation failures due to missing or misconfigured GPG keys.

* Added the `--nogpgcheck` flag to the `yum install mysql-community-client` command for RHEL10 systems to bypass GPG signature verification.